### PR TITLE
Stabilize device tree identifiers

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -37,17 +37,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HelianthusSemanticCoordinator,
         HelianthusStatusCoordinator,
     )
+    from .device_ids import (
+        adapter_identifier,
+        build_device_id,
+        bus_identifier,
+        daemon_identifier,
+        virtual_identifier,
+    )
     from .subscriptions import start_subscriptions
-    from .device_ids import build_device_id, virtual_device_id
 
     device_registry = dr.async_get(hass)
 
-    daemon_identifier = (DOMAIN, "daemon")
-    adapter_identifier = (DOMAIN, f"adapter-{entry.entry_id}")
+    daemon_device_id = daemon_identifier()
+    adapter_device_id = adapter_identifier(entry.entry_id)
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={daemon_identifier},
+        identifiers={daemon_device_id},
         manufacturer="Helianthus",
         model="Helianthus Daemon",
         name="Helianthus Daemon",
@@ -55,11 +61,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={adapter_identifier},
+        identifiers={adapter_device_id},
         manufacturer="Helianthus",
         model="eBUS Adapter",
         name="eBUS Adapter",
-        via_device=daemon_identifier,
+        via_device=daemon_device_id,
     )
 
     host = entry.data.get(CONF_HOST)
@@ -106,26 +112,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             software_version=str(sw_version) if sw_version else None,
         )
 
-        bus_identifier = (DOMAIN, resolved_id)
+        bus_device_id = bus_identifier(resolved_id)
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={bus_identifier},
+            identifiers={bus_device_id},
             manufacturer=manufacturer,
             model=device_id,
             name=f"{manufacturer} {device_id}",
             sw_version=sw_version,
             hw_version=hw_version,
-            via_device=adapter_identifier,
+            via_device=adapter_device_id,
         )
 
-        virtual_identifier = (DOMAIN, virtual_device_id(resolved_id))
+        virtual_device_id = virtual_identifier(resolved_id)
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={virtual_identifier},
+            identifiers={virtual_device_id},
             manufacturer="Helianthus",
             model="Virtual Device",
             name=f"Virtual {device_id}",
-            via_device=bus_identifier,
+            via_device=bus_device_id,
         )
 
     use_subscriptions = entry.options.get(CONF_USE_SUBSCRIPTIONS, DEFAULT_USE_SUBSCRIPTIONS)

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from .const import DOMAIN
+
 
 def _token(value: object | None) -> str:
     if value is None:
@@ -31,3 +33,19 @@ def build_device_id(
 
 def virtual_device_id(base_device_id: str) -> str:
     return f"{base_device_id}-virtual"
+
+
+def daemon_identifier() -> tuple[str, str]:
+    return (DOMAIN, "daemon")
+
+
+def adapter_identifier(config_entry_id: str) -> tuple[str, str]:
+    return (DOMAIN, f"adapter-{_token(config_entry_id)}")
+
+
+def bus_identifier(resolved_id: str) -> tuple[str, str]:
+    return (DOMAIN, _token(resolved_id))
+
+
+def virtual_identifier(base_device_id: str) -> tuple[str, str]:
+    return (DOMAIN, virtual_device_id(_token(base_device_id)))

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -1,0 +1,50 @@
+"""Tests for Helianthus device ID helpers."""
+
+from custom_components.helianthus.device_ids import (
+    adapter_identifier,
+    build_device_id,
+    bus_identifier,
+    daemon_identifier,
+    virtual_identifier,
+)
+
+
+def test_build_device_id_prefers_serial_number() -> None:
+    device_id = build_device_id(
+        model="BAI00",
+        serial_number="SN123",
+        mac_address="AA:BB:CC:DD:EE:FF",
+        address=8,
+        hardware_version="7603",
+        software_version="0806",
+    )
+    assert device_id == "BAI00-SN123"
+
+
+def test_build_device_id_falls_back_to_mac_then_address_versions() -> None:
+    with_mac = build_device_id(
+        model="BASV2",
+        serial_number=None,
+        mac_address="AA:BB:CC:DD:EE:FF",
+        address=0x15,
+        hardware_version="1704",
+        software_version="0507",
+    )
+    assert with_mac == "BASV2-AA:BB:CC:DD:EE:FF-15-1704-0507"
+
+    without_mac = build_device_id(
+        model="VR_71",
+        serial_number=None,
+        mac_address=None,
+        address=0x26,
+        hardware_version="5904",
+        software_version="0100",
+    )
+    assert without_mac == "VR_71-26-5904-0100"
+
+
+def test_identifier_helpers_are_deterministic() -> None:
+    assert daemon_identifier() == ("helianthus", "daemon")
+    assert adapter_identifier("entry-1") == ("helianthus", "adapter-entry-1")
+    assert bus_identifier("BASV2-SN") == ("helianthus", "BASV2-SN")
+    assert virtual_identifier("BASV2-SN") == ("helianthus", "BASV2-SN-virtual")


### PR DESCRIPTION
Fixes #32.

- Centralize daemon/adapter/bus/virtual identifier builders in device_ids helpers
- Use helper-built identifiers in integration setup for deterministic tree wiring
- Add unit tests for ID fallback chain and identifier tuple helpers

Validation:
- python3 -m compileall custom_components tests
- pytest not available in current environment