### PR TITLE
Add initiator/target terminology guard in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
 
 jobs:
+  terminology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if git grep -nIwiE 'm[a]ster|s[l]ave'; then
+            echo "Found legacy terminology."
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- verify tracked files contain no whole-word legacy role terms
- add a CI terminology gate that fails on whole-word legacy terms
- keep integration behavior unchanged

## Validation
- .venv/bin/python -m pytest
- git grep -nIwE '(master|slave)'
- grep -RInw --exclude-dir=.git --exclude-dir=.venv -E '(master|slave)' .

Closes #50

@codex review