### PR TITLE
M3 smoke: add local gateway GraphQL checklist profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,38 @@ Useful focused runs:
 ```bash
 python -m pytest tests/test_graphql.py
 python -m pytest tests/test_device_ids.py
+python -m pytest tests/test_smoke_profile.py
 ```
 
 Current tests are unit-focused (client/discovery/ID/energy behavior), not full HA runtime integration tests.
+
+## Smoke profile (local gateway GraphQL)
+
+Use this smoke profile when the local gateway is running and reachable from the same host:
+
+```bash
+python -m custom_components.helianthus.smoke_profile \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --path /graphql
+```
+
+Deterministic checklist output always includes:
+
+- `connection` (GraphQL endpoint reachability)
+- `subscriptions_fallback` (subscriptions available vs polling fallback mode)
+- `entity_creation` (device/status/semantic/energy payload viability for entity setup)
+
+Machine-readable output is available with:
+
+```bash
+python -m custom_components.helianthus.smoke_profile --url http://127.0.0.1:8080/graphql --json
+```
+
+Exit codes:
+
+- `0` => all checklist items passed
+- `1` => at least one checklist item failed
 
 ## Troubleshooting
 

--- a/custom_components/helianthus/smoke_profile.py
+++ b/custom_components/helianthus/smoke_profile.py
@@ -1,0 +1,451 @@
+"""Smoke profile checks for local gateway GraphQL operator runs."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+QUERY_CONNECTION = """
+query SmokeConnection {
+  __typename
+}
+"""
+
+QUERY_SUBSCRIPTION_INTROSPECTION = """
+query SmokeSubscriptionIntrospection {
+  __schema {
+    subscriptionType {
+      name
+    }
+  }
+}
+"""
+
+QUERY_DEVICES_EXTENDED = """
+query SmokeDevicesExtended {
+  devices {
+    address
+    manufacturer
+    deviceId
+    serialNumber
+    macAddress
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_DEVICES_BASE = """
+query SmokeDevicesBase {
+  devices {
+    address
+    manufacturer
+    deviceId
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_STATUS = """
+query SmokeStatus {
+  daemonStatus {
+    status
+    firmwareVersion
+    updatesAvailable
+  }
+  adapterStatus {
+    status
+    firmwareVersion
+    updatesAvailable
+  }
+}
+"""
+
+QUERY_SEMANTIC = """
+query SmokeSemantic {
+  zones {
+    id
+    name
+    operatingMode
+    preset
+    currentTempC
+    targetTempC
+    heatingDemand
+  }
+  dhw {
+    operatingMode
+    preset
+    currentTempC
+    targetTempC
+    heatingDemand
+  }
+}
+"""
+
+QUERY_ENERGY = """
+query SmokeEnergy {
+  energyTotals {
+    gas { dhw { today yearly } climate { today yearly } }
+    electric { dhw { today yearly } climate { today yearly } }
+    solar { dhw { today yearly } climate { today yearly } }
+  }
+}
+"""
+
+MISSING_DEVICE_FIELDS = ["serialNumber", "macAddress"]
+INVENTORY_FIELD_COUNT = 7
+STATUS_FIELD_COUNT = 3
+
+GraphQLExecutor = Callable[[str], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class SmokeCheck:
+    """Single deterministic smoke checklist item."""
+
+    name: str
+    ok: bool
+    details: str
+
+
+@dataclass(frozen=True)
+class SmokeRunResult:
+    """Smoke profile execution result."""
+
+    version: str
+    endpoint: str
+    checks: list[SmokeCheck]
+
+    @property
+    def ok(self) -> bool:
+        return all(check.ok for check in self.checks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "endpoint": self.endpoint,
+            "ok": self.ok,
+            "checks": [asdict(check) for check in self.checks],
+        }
+
+    def to_checklist_lines(self) -> list[str]:
+        lines = [f"HELIANTHUS_HA_SMOKE_CHECKLIST {self.version}", f"endpoint={self.endpoint}"]
+        for check in self.checks:
+            state = "PASS" if check.ok else "FAIL"
+            lines.append(f"[{state}] {check.name} :: {check.details}")
+        lines.append(f"OVERALL {'PASS' if self.ok else 'FAIL'}")
+        return lines
+
+
+def build_graphql_url(
+    host: str,
+    port: int,
+    path: str = "/graphql",
+    transport: str = "http",
+) -> str:
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return f"{transport}://{host}:{port}{normalized_path}"
+
+
+def run_smoke_profile(
+    endpoint: str,
+    timeout: float = 10.0,
+    executor: GraphQLExecutor | None = None,
+) -> SmokeRunResult:
+    execute = executor if executor is not None else _http_executor(endpoint, timeout)
+    checks = [
+        _check_connection(execute),
+        _check_subscriptions_fallback(execute),
+        _check_entity_creation(execute),
+    ]
+    return SmokeRunResult(version="v1", endpoint=endpoint, checks=checks)
+
+
+def _http_executor(endpoint: str, timeout: float) -> GraphQLExecutor:
+    def execute(query: str) -> dict[str, Any]:
+        payload = json.dumps({"query": query, "variables": {}}).encode("utf-8")
+        request = Request(
+            endpoint,
+            data=payload,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"http {exc.code}: {body}") from exc
+        except URLError as exc:
+            raise RuntimeError(f"connection error: {exc.reason}") from exc
+        except TimeoutError as exc:
+            raise RuntimeError("connection timeout") from exc
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"invalid json response: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeError("graphql response must be a json object")
+        return parsed
+
+    return execute
+
+
+def _check_connection(execute: GraphQLExecutor) -> SmokeCheck:
+    try:
+        response = execute(QUERY_CONNECTION)
+    except RuntimeError as exc:
+        return SmokeCheck("connection", False, str(exc))
+
+    data, error = _extract_data(response)
+    if error:
+        return SmokeCheck("connection", False, error)
+    typename = None if not isinstance(data, dict) else data.get("__typename")
+    if not typename:
+        return SmokeCheck("connection", False, "missing __typename in response")
+    return SmokeCheck("connection", True, f"typename={typename}")
+
+
+def _check_subscriptions_fallback(execute: GraphQLExecutor) -> SmokeCheck:
+    try:
+        response = execute(QUERY_SUBSCRIPTION_INTROSPECTION)
+    except RuntimeError as exc:
+        return SmokeCheck("subscriptions_fallback", False, str(exc))
+
+    data, error = _extract_data(response)
+    if error:
+        return SmokeCheck("subscriptions_fallback", False, error)
+
+    subscription_name = ""
+    if isinstance(data, dict):
+        schema = data.get("__schema", {})
+        if isinstance(schema, dict):
+            subscription_type = schema.get("subscriptionType")
+            if isinstance(subscription_type, dict):
+                raw_name = subscription_type.get("name")
+                if isinstance(raw_name, str):
+                    subscription_name = raw_name.strip()
+
+    if subscription_name:
+        return SmokeCheck(
+            "subscriptions_fallback",
+            True,
+            f"mode=subscriptions_available subscription_type={subscription_name}",
+        )
+    return SmokeCheck(
+        "subscriptions_fallback",
+        True,
+        "mode=polling_fallback subscription_type=none",
+    )
+
+
+def _check_entity_creation(execute: GraphQLExecutor) -> SmokeCheck:
+    devices, devices_source, error = _fetch_devices(execute)
+    if error:
+        return SmokeCheck("entity_creation", False, error)
+
+    status_data, error = _fetch_status(execute)
+    if error:
+        return SmokeCheck("entity_creation", False, error)
+
+    semantic_data, semantic_mode, error = _fetch_semantic(execute)
+    if error:
+        return SmokeCheck("entity_creation", False, error)
+
+    _, energy_mode, error = _fetch_energy(execute)
+    if error:
+        return SmokeCheck("entity_creation", False, error)
+
+    daemon_status = status_data.get("daemonStatus")
+    adapter_status = status_data.get("adapterStatus")
+    if not isinstance(daemon_status, dict) or not isinstance(adapter_status, dict):
+        return SmokeCheck(
+            "entity_creation",
+            False,
+            "status payload must include daemonStatus and adapterStatus objects",
+        )
+
+    valid_devices = [
+        device
+        for device in devices
+        if isinstance(device, dict) and device.get("address") is not None and device.get("deviceId")
+    ]
+    if len(valid_devices) == 0:
+        return SmokeCheck("entity_creation", False, "no devices discovered for entity creation")
+
+    zones_raw = semantic_data.get("zones", []) if isinstance(semantic_data, dict) else []
+    zones = [zone for zone in zones_raw if isinstance(zone, dict) and zone.get("id")]
+    zone_count = len(zones)
+    dhw_present = bool(isinstance(semantic_data, dict) and semantic_data.get("dhw") is not None)
+
+    diagnostics_count = (
+        len(valid_devices) * INVENTORY_FIELD_COUNT
+        + STATUS_FIELD_COUNT * 2
+        + zone_count
+        + 1
+    )
+    details = (
+        f"devices={len(valid_devices)} diagnostics_sensors={diagnostics_count} "
+        f"climate_entities={zone_count} dhw_entities={1 if dhw_present else 0} "
+        f"energy_sensors=6 devices_query={devices_source} "
+        f"semantic_mode={semantic_mode} energy_mode={energy_mode}"
+    )
+    return SmokeCheck("entity_creation", True, details)
+
+
+def _fetch_devices(execute: GraphQLExecutor) -> tuple[list[dict[str, Any]], str, str | None]:
+    response = execute(QUERY_DEVICES_EXTENDED)
+    data, error, errors = _extract_data_with_errors(response)
+    if error and _is_missing_field_error(errors, MISSING_DEVICE_FIELDS):
+        fallback = execute(QUERY_DEVICES_BASE)
+        data, error = _extract_data(fallback)
+        if error:
+            return [], "", f"devices base query failed: {error}"
+        devices = data.get("devices", []) if isinstance(data, dict) else []
+        if not isinstance(devices, list):
+            return [], "", "devices base query returned non-list payload"
+        return devices, "base", None
+    if error:
+        return [], "", f"devices extended query failed: {error}"
+    devices = data.get("devices", []) if isinstance(data, dict) else []
+    if not isinstance(devices, list):
+        return [], "", "devices extended query returned non-list payload"
+    return devices, "extended", None
+
+
+def _fetch_status(execute: GraphQLExecutor) -> tuple[dict[str, Any], str | None]:
+    response = execute(QUERY_STATUS)
+    data, error = _extract_data(response)
+    if error:
+        return {}, f"status query failed: {error}"
+    if not isinstance(data, dict):
+        return {}, "status query returned non-object payload"
+    return data, None
+
+
+def _fetch_semantic(execute: GraphQLExecutor) -> tuple[dict[str, Any], str, str | None]:
+    response = execute(QUERY_SEMANTIC)
+    data, error, errors = _extract_data_with_errors(response)
+    if error and _is_missing_field_error(errors, ["zones", "dhw"]):
+        return {"zones": [], "dhw": None}, "fallback_missing_fields", None
+    if error:
+        return {}, "", f"semantic query failed: {error}"
+    if not isinstance(data, dict):
+        return {"zones": [], "dhw": None}, "fallback_non_object", None
+    return data, "full", None
+
+
+def _fetch_energy(execute: GraphQLExecutor) -> tuple[dict[str, Any], str, str | None]:
+    response = execute(QUERY_ENERGY)
+    data, error, errors = _extract_data_with_errors(response)
+    if error and _is_missing_field_error(errors, ["energyTotals"]):
+        return {"energyTotals": None}, "fallback_missing_field", None
+    if error:
+        return {}, "", f"energy query failed: {error}"
+    if not isinstance(data, dict):
+        return {"energyTotals": None}, "fallback_non_object", None
+    return data, "full", None
+
+
+def _extract_data(response: dict[str, Any]) -> tuple[dict[str, Any] | Any, str | None]:
+    data, error, _ = _extract_data_with_errors(response)
+    return data, error
+
+
+def _extract_data_with_errors(
+    response: dict[str, Any],
+) -> tuple[dict[str, Any] | Any, str | None, list[Any]]:
+    if not isinstance(response, dict):
+        return {}, "graphql response is not an object", []
+    errors = response.get("errors")
+    if isinstance(errors, list) and errors:
+        return {}, _format_graphql_errors(errors), errors
+    if "data" not in response:
+        return {}, "graphql response missing data", []
+    return response["data"], None, []
+
+
+def _format_graphql_errors(errors: list[Any]) -> str:
+    messages: list[str] = []
+    for item in errors:
+        if isinstance(item, dict):
+            message = str(item.get("message", "")).strip()
+            if message:
+                messages.append(message)
+        elif item:
+            messages.append(str(item).strip())
+    if not messages:
+        return "graphql response contains errors"
+    return "; ".join(messages)
+
+
+def _is_missing_field_error(errors: list[Any], fields: list[str]) -> bool:
+    for item in errors:
+        message = ""
+        if isinstance(item, dict):
+            message = str(item.get("message", ""))
+        else:
+            message = str(item)
+        for field in fields:
+            if f'Cannot query field "{field}"' in message:
+                return True
+    return False
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run HA integration smoke profile against local Helianthus GraphQL endpoint.",
+    )
+    parser.add_argument("--url", default="", help="Full GraphQL URL (overrides host/port/path).")
+    parser.add_argument("--host", default="127.0.0.1", help="Gateway host.")
+    parser.add_argument("--port", type=int, default=8080, help="Gateway port.")
+    parser.add_argument("--path", default="/graphql", help="GraphQL path.")
+    parser.add_argument(
+        "--transport",
+        choices=["http", "https"],
+        default="http",
+        help="HTTP transport scheme.",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0, help="Request timeout in seconds.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output deterministic JSON instead of checklist text.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    endpoint = args.url.strip() if args.url else build_graphql_url(args.host, args.port, args.path, args.transport)
+    endpoint = _normalize_endpoint(endpoint)
+    result = run_smoke_profile(endpoint=endpoint, timeout=args.timeout)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        for line in result.to_checklist_lines():
+            print(line)
+
+    return 0 if result.ok else 1
+
+
+def _normalize_endpoint(url: str) -> str:
+    parts = urlsplit(url)
+    path = parts.path or "/graphql"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    scheme = parts.scheme or "http"
+    return urlunsplit((scheme, parts.netloc, path, "", ""))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_profile.py
+++ b/tests/test_smoke_profile.py
@@ -1,0 +1,147 @@
+"""Tests for smoke profile checklist helpers."""
+
+from __future__ import annotations
+
+from custom_components.helianthus import smoke_profile
+
+
+class FakeExecutor:
+    def __init__(self, responses: dict[str, dict]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, query: str) -> dict:
+        operation = self._operation_name(query)
+        self.calls.append(operation)
+        return self.responses[operation]
+
+    @staticmethod
+    def _operation_name(query: str) -> str:
+        parts = query.split()
+        if "query" in parts:
+            idx = parts.index("query")
+            if idx + 1 < len(parts):
+                return parts[idx + 1]
+        raise AssertionError(f"could not parse operation from query: {query!r}")
+
+
+def test_run_smoke_profile_success_with_subscription_type() -> None:
+    executor = FakeExecutor(
+        {
+            "SmokeConnection": {"data": {"__typename": "Query"}},
+            "SmokeSubscriptionIntrospection": {
+                "data": {"__schema": {"subscriptionType": {"name": "Subscription"}}}
+            },
+            "SmokeDevicesExtended": {
+                "data": {
+                    "devices": [
+                        {
+                            "address": 8,
+                            "manufacturer": "Vaillant",
+                            "deviceId": "BAI00",
+                            "serialNumber": "SER123",
+                            "macAddress": "AA:BB:CC:DD:EE:FF",
+                            "softwareVersion": "0102",
+                            "hardwareVersion": "7603",
+                        }
+                    ]
+                }
+            },
+            "SmokeStatus": {
+                "data": {
+                    "daemonStatus": {"status": "ok"},
+                    "adapterStatus": {"status": "ok"},
+                }
+            },
+            "SmokeSemantic": {
+                "data": {
+                    "zones": [{"id": "z1", "name": "Living"}],
+                    "dhw": {"operatingMode": "auto"},
+                }
+            },
+            "SmokeEnergy": {"data": {"energyTotals": {}}},
+        }
+    )
+
+    result = smoke_profile.run_smoke_profile("http://127.0.0.1:8080/graphql", executor=executor)
+
+    assert result.ok is True
+    assert [check.name for check in result.checks] == [
+        "connection",
+        "subscriptions_fallback",
+        "entity_creation",
+    ]
+    assert "mode=subscriptions_available" in result.checks[1].details
+    assert "diagnostics_sensors=15" in result.checks[2].details
+    assert result.to_checklist_lines()[-1] == "OVERALL PASS"
+
+
+def test_run_smoke_profile_uses_fallback_paths() -> None:
+    executor = FakeExecutor(
+        {
+            "SmokeConnection": {"data": {"__typename": "Query"}},
+            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscriptionType": None}}},
+            "SmokeDevicesExtended": {
+                "errors": [{'message': 'Cannot query field "serialNumber" on type "Device".'}]
+            },
+            "SmokeDevicesBase": {
+                "data": {
+                    "devices": [
+                        {
+                            "address": 21,
+                            "manufacturer": "Vaillant",
+                            "deviceId": "BASV2",
+                            "softwareVersion": "0101",
+                            "hardwareVersion": "7603",
+                        }
+                    ]
+                }
+            },
+            "SmokeStatus": {
+                "data": {
+                    "daemonStatus": {"status": "ok"},
+                    "adapterStatus": {"status": "ok"},
+                }
+            },
+            "SmokeSemantic": {
+                "errors": [{'message': 'Cannot query field "zones" on type "Query".'}]
+            },
+            "SmokeEnergy": {
+                "errors": [{'message': 'Cannot query field "energyTotals" on type "Query".'}]
+            },
+        }
+    )
+
+    result = smoke_profile.run_smoke_profile("http://127.0.0.1:8080/graphql", executor=executor)
+
+    assert result.ok is True
+    assert "mode=polling_fallback" in result.checks[1].details
+    assert "devices_query=base" in result.checks[2].details
+    assert "semantic_mode=fallback_missing_fields" in result.checks[2].details
+    assert "energy_mode=fallback_missing_field" in result.checks[2].details
+    assert "SmokeDevicesBase" in executor.calls
+
+
+def test_run_smoke_profile_fails_when_no_devices() -> None:
+    executor = FakeExecutor(
+        {
+            "SmokeConnection": {"data": {"__typename": "Query"}},
+            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscriptionType": None}}},
+            "SmokeDevicesExtended": {"data": {"devices": []}},
+            "SmokeStatus": {
+                "data": {
+                    "daemonStatus": {"status": "ok"},
+                    "adapterStatus": {"status": "ok"},
+                }
+            },
+            "SmokeSemantic": {"data": {"zones": [], "dhw": None}},
+            "SmokeEnergy": {"data": {"energyTotals": {}}},
+        }
+    )
+
+    result = smoke_profile.run_smoke_profile("http://127.0.0.1:8080/graphql", executor=executor)
+
+    assert result.ok is False
+    assert result.checks[2].name == "entity_creation"
+    assert result.checks[2].ok is False
+    assert "no devices discovered" in result.checks[2].details


### PR DESCRIPTION
## What
Add a focused HA smoke profile for local gateway GraphQL validation with deterministic operator checklist output.

## Why
Issue #52 requires a repeatable local smoke run that confirms connection viability, subscriptions fallback behavior, and entity creation readiness.

## Changes
- add `custom_components/helianthus/smoke_profile.py` smoke runner (CLI + JSON/checklist output)
- add deterministic checks for: `connection`, `subscriptions_fallback`, `entity_creation`
- preserve fallback semantics for missing GraphQL fields used by coordinators
- add `tests/test_smoke_profile.py` coverage for success, fallback, and failure cases
- document smoke run recipe and output modes in `README.md`

## Verification
- `.venv/bin/python -m pytest`

Closes #52