### PR TITLE
M0: README entity matrix + troubleshooting decision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,53 @@ After setup, options flow exposes:
 - `scan_interval` (seconds, default `60`)
 - `use_subscriptions` (default `true`)
 
+## Backend capability matrix (backend data -> HA entities)
+
+| Backend capability | GraphQL dependency | HA capability | Current fallback/degraded behavior |
+| --- | --- | --- | --- |
+| Device inventory | `devices` query | Bus-device registry nodes + per-device inventory diagnostics (`manufacturer`, `deviceId`, `serialNumber`, `hardwareVersion`, `softwareVersion`, `macAddress`, `address`) | If `serialNumber`/`macAddress` are not queryable, integration retries with base fields and keeps deterministic IDs; if a device has no `address`, bus/virtual device registry creation is skipped for that record. |
+| Service status | `daemonStatus`, `adapterStatus` | Daemon + adapter diagnostics (`status`, `firmwareVersion`, `updatesAvailable`) | No schema fallback for these fields; if status query fails at startup, config entry setup retries/fails until backend is fixed. |
+| Zone semantics | `zones` | `climate` entity per zone with `id`, plus zone heating-demand diagnostics | Missing-field GraphQL errors for `zones`/`dhw` are treated as semantic fallback (`zones=[]`, `dhw=None`), so zone entities are not created. |
+| DHW semantics | `dhw` | One `water_heater` entity (`Domestic Hot Water`) | If `dhw` is `null` (or semantic fallback is active), water-heater entity is absent. The DHW heating-demand diagnostic sensor still exists but remains `unknown`. |
+| Energy totals | `energyTotals` | Six energy sensors (`gas|electric|solar` x `dhw|climate`) | Missing `energyTotals` field falls back to `energyTotals=None`; sensors still exist but expose `unknown` values. |
+| Realtime updates | `zoneUpdate`, `dhwUpdate`, `energyUpdate` subscriptions over `graphql-transport-ws` | Near-real-time state updates for semantic/energy coordinators | If websocket/subscriptions fail, integration logs a warning and continues polling (`scan_interval`) without entity loss. |
+
+## Setup + troubleshooting decision tree
+
+```text
+Start setup (manual or Zeroconf)
+|
++-- Does HA reach <transport>://<host>:<port><path> ?
+|   |
+|   +-- No -> config-flow error `cannot_connect`
+|   |        Action: verify host/port/path/transport, network route, TLS endpoint.
+|   |
+|   +-- Yes
+|       |
+|       +-- Does schema introspection (`__schema`) return valid GraphQL data?
+|       |   |
+|       |   +-- No -> config-flow error `invalid_response`
+|       |   |        Action: verify this is the GraphQL endpoint (not `/snapshot` or other API),
+|       |   |                and introspection is enabled.
+|       |   |
+|       |   +-- Yes
+|       |       |
+|       |       +-- Is `host:port` already configured?
+|       |       |   |
+|       |       |   +-- Yes -> abort `already_configured`
+|       |       |   |        Action: reuse existing entry or remove/re-add it.
+|       |       |   |
+|       |       |   +-- No -> entry setup continues
+|       |       |
+|       |       +-- After setup, do entities/state look wrong?
+|       |           |
+|       |           +-- Missing climate entities -> backend `zones` data missing/empty.
+|       |           +-- Missing DHW water heater -> backend `dhw` is null/missing.
+|       |           +-- Energy sensors are `unknown` -> backend `energyTotals` missing/non-numeric.
+|       |           +-- No realtime changes -> disable `use_subscriptions`; rely on polling and inspect WS support.
+|       |           +-- Unstable device identity -> ensure backend serial/MAC are consistently populated.
+```
+
 ## Development and test workflow
 
 From repo root:
@@ -140,16 +187,37 @@ Exit codes:
 - `0` => all checklist items passed
 - `1` => at least one checklist item failed
 
-## Troubleshooting
+## Smoke profile interpretation guide
 
-- `cannot_connect` during setup: verify host/port/path/transport and that GraphQL is reachable from HA.
-- `invalid_response` during setup: endpoint responded, but not with expected GraphQL schema payload.
-- `already_configured`: the same `host:port` is already configured.
-- Missing entities:
-  - no `zones`/`dhw` in backend schema → climate/DHW entities are absent
-  - no `energyTotals` → energy sensors remain unavailable
-- Realtime updates not visible: disable `use_subscriptions` temporarily to isolate websocket issues and rely on polling.
-- Unstable device identity concerns: ensure backend returns serial/MAC consistently so preferred ID path is used.
+Treat each checklist item as an operational signal:
+
+- `connection`
+  - **PASS:** endpoint is reachable and returns GraphQL `data.__typename`.
+  - **FAIL:** transport/path/connectivity/JSON contract issue.
+- `subscriptions_fallback`
+  - **PASS + `mode=subscriptions_available`:** subscription type detected; realtime path should be available.
+  - **PASS + `mode=polling_fallback`:** still healthy; integration should run in polling-only mode.
+  - If `introspection_error=...` appears, backend blocked subscription introspection; polling fallback is expected.
+- `entity_creation`
+  - **PASS:** backend payload is sufficient for initial entity setup.
+  - **FAIL:** setup-critical data missing (for example no valid devices, status object shape mismatch, query execution failure).
+  - `details` fields map directly to integration behavior:
+    - `devices_query=extended|base` shows whether inventory fallback was needed.
+    - `semantic_mode=full|fallback_missing_fields|fallback_non_object` shows semantic capability level.
+    - `energy_mode=full|fallback_missing_field|fallback_non_object` shows energy capability level.
+    - `diagnostics_sensors` follows current formula: `devices*7 + 6 + zones + 1`.
+    - `energy_sensors` is always `6` (values can still be `unknown` when energy payload is unavailable).
+
+## Compatibility assumptions and limits
+
+- The integration is a **GraphQL consumer only**; it does not consume raw eBUS.
+- Setup assumes GraphQL schema introspection (`__schema`) is available at the configured endpoint.
+- One config entry maps to one endpoint identity key `host:port` (path/transport do not participate in uniqueness).
+- No authentication options are currently exposed in config flow (backend must be reachable from HA as configured).
+- Climate and water-heater entities are read-only in this version (`supported_features = 0`).
+- Subscriptions are best-effort and optional; the current loop does not implement reconnect/backoff recovery.
+- Most entity discovery is startup-time (devices/zones/DHW). Backend topology changes typically require a reload/restart to create new entities.
+- Energy totals assume numeric `today` + numeric list `yearly`; invalid payloads surface as `unknown`.
 
 ## Related repos and docs
 


### PR DESCRIPTION
## Summary
- add backend-data -> entity capability matrix aligned with current coordinator/entity behavior
- add setup + troubleshooting decision tree for config-flow errors and post-setup symptoms
- add smoke profile interpretation guide for checklist fields/modes
- document compatibility assumptions and current limits (GraphQL dependency, fallbacks, startup-time discovery, subscriptions behavior)

## Testing
- ./.venv/bin/python -m pytest

Closes #56