### PR TITLE
Fix HA device model (stable IDs + cleanup)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,9 +24,9 @@ HA device hierarchy is explicit:
 
 Device IDs must be stable and deterministic.
 
-- Base: `<model>-<serial>`
-- If serial missing: `<model>-<mac>-<addr>-<hw>-<sw>`
-- If mac missing: `<model>-<addr>-<hw>-<sw>`
+- **Physical eBUS devices:** stable key is `<model>-<addr>` (hex address), independent of volatile fields.
+  - Serial numbers, MAC addresses, and software versions are treated as **metadata enrichment**, not identity.
+- **Entry scoping:** all HA device identifiers are prefixed with the config entry id to avoid collisions across multiple Helianthus daemons.
 
 ## GraphQL Model
 

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -63,6 +63,7 @@ def _clean_label(value: object | None) -> str | None:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Helianthus from a config entry."""
     from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
     from homeassistant.helpers.aiohttp_client import async_get_clientsession
     from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
     from .graphql import GraphQLClient, build_graphql_url
@@ -74,16 +75,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     from .device_ids import (
         adapter_identifier,
-        build_device_id,
+        build_bus_device_key,
         bus_identifier,
         daemon_identifier,
-        virtual_identifier,
     )
     from .subscriptions import start_subscriptions
 
     device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
-    daemon_device_id = daemon_identifier()
+    removed_entities = 0
+    for entity_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        entity_registry.async_remove(entity_entry.entity_id)
+        removed_entities += 1
+
+    removed_devices = 0
+    for device_entry in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        if any(identifier[0] == DOMAIN for identifier in device_entry.identifiers):
+            device_registry.async_remove_device(device_entry.id)
+            removed_devices += 1
+
+    if removed_entities or removed_devices:
+        _LOGGER.info(
+            "Helianthus cleanup removed %d entities and %d devices for entry %s",
+            removed_entities,
+            removed_devices,
+            entry.entry_id,
+        )
+
+    daemon_device_id = daemon_identifier(entry.entry_id)
     adapter_device_id = adapter_identifier(entry.entry_id)
 
     device_registry.async_get_or_create(
@@ -135,30 +155,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.info("Reloading Helianthus entry %s: %s", entry.entry_id, reason)
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
-    def resolved_bus_device_id(device: dict) -> str | None:
+    def resolved_bus_device_key(device: dict) -> str | None:
         address = device.get("address")
         device_id = device.get("deviceId", "unknown")
-        serial_number = device.get("serialNumber")
-        mac_address = device.get("macAddress")
-        sw_version = device.get("softwareVersion")
-        hw_version = device.get("hardwareVersion")
         if address is None:
             return None
-        return build_device_id(
-            model=str(device_id),
-            serial_number=str(serial_number) if serial_number else None,
-            mac_address=str(mac_address) if mac_address else None,
-            address=int(address),
-            hardware_version=str(hw_version) if hw_version else None,
-            software_version=str(sw_version) if sw_version else None,
+        return build_bus_device_key(model=str(device_id), address=int(address))
+
+    def is_regulator_device(device: dict) -> bool:
+        device_id = str(device.get("deviceId") or "").upper()
+        display_name = str(device.get("displayName") or "").upper()
+        product_family = str(device.get("productFamily") or "").upper()
+        return bool(
+            device_id.startswith("BASV")
+            or device_id.startswith("VRC")
+            or "SENSOCOMFORT" in display_name
+            or "SENSOCOMFORT" in product_family
         )
 
     known_bus_devices: set[str] = set()
+    regulator_device: tuple[str, str] | None = None
     for device in devices:
         address = device.get("address")
         device_id = device.get("deviceId", "unknown")
         serial_number = device.get("serialNumber")
-        mac_address = device.get("macAddress")
         manufacturer = _clean_label(device.get("manufacturer")) or "Unknown"
         sw_version = device.get("softwareVersion")
         hw_version = device.get("hardwareVersion")
@@ -171,38 +191,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if address is None:
             continue
 
-        resolved_id = resolved_bus_device_id(device)
-        if not resolved_id:
+        bus_device_key = resolved_bus_device_key(device)
+        if not bus_device_key:
             continue
-        known_bus_devices.add(resolved_id)
+        known_bus_devices.add(bus_device_key)
 
         device_name = display_name or f"{manufacturer} {device_id}"
         model_name = product_model or str(device_id)
         if part_number and f"({part_number})" not in model_name:
             model_name = f"{model_name} ({part_number})"
 
-        bus_device_id = bus_identifier(resolved_id)
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={bus_device_id},
-            manufacturer=manufacturer,
-            model=model_name,
-            name=device_name,
-            serial_number=str(serial_number) if serial_number else None,
-            sw_version=_format_hex4_version(str(sw_version)) if sw_version else None,
-            hw_version=hw_version,
-            via_device=adapter_device_id,
-        )
+        bus_device_id = bus_identifier(entry.entry_id, bus_device_key)
+        device_kwargs = {
+            "config_entry_id": entry.entry_id,
+            "identifiers": {bus_device_id},
+            "manufacturer": manufacturer,
+            "model": model_name,
+            "name": device_name,
+            "via_device": adapter_device_id,
+        }
+        if serial_number:
+            device_kwargs["serial_number"] = str(serial_number)
+        if sw_version:
+            device_kwargs["sw_version"] = _format_hex4_version(str(sw_version))
+        if hw_version:
+            device_kwargs["hw_version"] = hw_version
+        device_registry.async_get_or_create(**device_kwargs)
 
-        virtual_device_id = virtual_identifier(resolved_id)
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={virtual_device_id},
-            manufacturer="Helianthus",
-            model="Virtual Device",
-            name=f"Virtual {device_name}",
-            via_device=bus_device_id,
-        )
+        device_id_upper = str(device_id).upper()
+        if device_id_upper.startswith("BASV"):
+            regulator_device = bus_device_id
+        elif regulator_device is None and is_regulator_device(device):
+            regulator_device = bus_device_id
 
     semantic = semantic_coordinator.data or {}
     known_zones: set[str] = {
@@ -218,9 +238,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
         current_ids: set[str] = set()
         for dev in current:
-            resolved = resolved_bus_device_id(dev)
-            if resolved:
-                current_ids.add(resolved)
+            bus_key = resolved_bus_device_key(dev)
+            if bus_key:
+                current_ids.add(bus_key)
         if not current_ids:
             return
         if current_ids.issubset(known_bus_devices):
@@ -257,6 +277,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "energy_coordinator": energy_coordinator,
         "subscription_task": subscription_task,
         "unsub_listeners": unsub_listeners,
+        "daemon_device_id": daemon_device_id,
+        "adapter_device_id": adapter_device_id,
+        "regulator_device_id": regulator_device,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .device_ids import zone_identifier
 
 OPERATING_MODE_MAP = {
     "heating": HVACMode.HEAT,
@@ -27,9 +28,19 @@ OPERATING_MODE_MAP = {
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
+    via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
 
     zones = coordinator.data.get("zones", []) if coordinator.data else []
-    entities = [HelianthusZoneClimate(entry.entry_id, coordinator, zone.get("id"), zone.get("name")) for zone in zones]
+    entities = [
+        HelianthusZoneClimate(
+            entry.entry_id,
+            coordinator,
+            via_device,
+            zone.get("id"),
+            zone.get("name"),
+        )
+        for zone in zones
+    ]
     async_add_entities([entity for entity in entities if entity.zone_id])
 
 
@@ -39,13 +50,21 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = ClimateEntityFeature(0)
 
-    def __init__(self, entry_id: str, coordinator, zone_id: str | None, name: str | None) -> None:
+    def __init__(
+        self,
+        entry_id: str,
+        coordinator,
+        via_device: tuple[str, str] | None,
+        zone_id: str | None,
+        name: str | None,
+    ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
+        self._via_device = via_device
         self._zone_id = zone_id
         self._attr_name = name or f"Zone {zone_id}"
         if zone_id:
-            self._attr_unique_id = f"zone-{zone_id}"
+            self._attr_unique_id = f"{entry_id}-zone-{zone_id}"
 
     @property
     def zone_id(self) -> str | None:
@@ -61,8 +80,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        identifier = (DOMAIN, f"zone-{self._zone_id}")
-        via = (DOMAIN, f"adapter-{self._entry_id}")
+        identifier = zone_identifier(self._entry_id, str(self._zone_id))
+        via = self._via_device
         return DeviceInfo(
             identifiers={identifier},
             manufacturer="Helianthus",

--- a/custom_components/helianthus/config_flow.py
+++ b/custom_components/helianthus/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 try:
     from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 except ImportError:  # pragma: no cover - older HA versions
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
+    ZeroconfServiceInfo = Any  # type: ignore[misc,assignment]
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -11,41 +11,36 @@ def _token(value: object | None) -> str:
     return str(value).strip().replace(" ", "-")
 
 
-def build_device_id(
-    model: str | None,
-    serial_number: str | None,
-    mac_address: str | None,
-    address: int | None,
-    hardware_version: str | None,
-    software_version: str | None,
-) -> str:
+def build_bus_device_key(model: str | None, address: int | None) -> str:
+    """Return a stable identifier key for a physical eBUS device.
+
+    This is intentionally independent of volatile fields (serial number, MAC, software version).
+    """
+
     model_token = _token(model) if model else "unknown"
     address_token = f"{address:02x}" if isinstance(address, int) else _token(address)
-    hw_token = _token(hardware_version)
-    sw_token = _token(software_version)
-
-    if serial_number:
-        return f"{model_token}-{_token(serial_number)}"
-    if mac_address:
-        return f"{model_token}-{_token(mac_address)}-{address_token}-{hw_token}-{sw_token}"
-    return f"{model_token}-{address_token}-{hw_token}-{sw_token}"
+    return f"{model_token}-{address_token}"
 
 
-def virtual_device_id(base_device_id: str) -> str:
-    return f"{base_device_id}-virtual"
-
-
-def daemon_identifier() -> tuple[str, str]:
-    return (DOMAIN, "daemon")
+def daemon_identifier(config_entry_id: str) -> tuple[str, str]:
+    return (DOMAIN, f"daemon-{_token(config_entry_id)}")
 
 
 def adapter_identifier(config_entry_id: str) -> tuple[str, str]:
     return (DOMAIN, f"adapter-{_token(config_entry_id)}")
 
 
-def bus_identifier(resolved_id: str) -> tuple[str, str]:
-    return (DOMAIN, _token(resolved_id))
+def bus_identifier(config_entry_id: str, bus_device_key: str) -> tuple[str, str]:
+    return (DOMAIN, f"{_token(config_entry_id)}-bus-{_token(bus_device_key)}")
 
 
-def virtual_identifier(base_device_id: str) -> tuple[str, str]:
-    return (DOMAIN, virtual_device_id(_token(base_device_id)))
+def zone_identifier(config_entry_id: str, zone_id: str) -> tuple[str, str]:
+    return (DOMAIN, f"{_token(config_entry_id)}-zone-{_token(zone_id)}")
+
+
+def dhw_identifier(config_entry_id: str) -> tuple[str, str]:
+    return (DOMAIN, f"{_token(config_entry_id)}-dhw")
+
+
+def energy_identifier(config_entry_id: str) -> tuple[str, str]:
+    return (DOMAIN, f"{_token(config_entry_id)}-energy")

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import build_device_id
+from .device_ids import (
+    build_bus_device_key,
+    bus_identifier,
+    dhw_identifier,
+    energy_identifier,
+    zone_identifier,
+)
 from .energy import compute_total
 
 
@@ -20,16 +26,6 @@ class InventoryField:
     key: str
     name: str
 
-
-INVENTORY_FIELDS = [
-    InventoryField("manufacturer", "Manufacturer"),
-    InventoryField("deviceId", "Model"),
-    InventoryField("serialNumber", "Serial Number"),
-    InventoryField("hardwareVersion", "Hardware Version"),
-    InventoryField("softwareVersion", "Software Version"),
-    InventoryField("macAddress", "MAC Address"),
-    InventoryField("address", "Address"),
-]
 
 STATUS_FIELDS = [
     InventoryField("status", "Status"),
@@ -44,27 +40,40 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     status_coordinator = data["status_coordinator"]
     semantic_coordinator = data.get("semantic_coordinator")
     energy_coordinator = data.get("energy_coordinator")
+    via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
 
-    sensors: list[HelianthusInventorySensor] = []
+    sensors: list[SensorEntity] = []
     for device in device_coordinator.data or []:
-        sensors.extend(
-            HelianthusInventorySensor(device_coordinator, device, field)
-            for field in INVENTORY_FIELDS
-        )
-
-    daemon_identifier = (DOMAIN, "daemon")
-    adapter_identifier = (DOMAIN, f"adapter-{entry.entry_id}")
+        device_id = device.get("deviceId", "unknown")
+        address = device.get("address")
+        if address is None:
+            continue
+        bus_key = build_bus_device_key(model=str(device_id), address=int(address))
+        bus_id = bus_identifier(entry.entry_id, bus_key)
+        sensors.append(HelianthusBusAddressSensor(device_coordinator, bus_id, int(address)))
 
     status_entries = status_coordinator.data or {}
     daemon_status = status_entries.get("daemon", {})
     adapter_status = status_entries.get("adapter", {})
 
     sensors.extend(
-        HelianthusStatusSensor(status_coordinator, "Daemon", daemon_status, daemon_identifier, field)
+        HelianthusStatusSensor(
+            status_coordinator,
+            "Daemon",
+            daemon_status,
+            data.get("daemon_device_id"),
+            field,
+        )
         for field in STATUS_FIELDS
     )
     sensors.extend(
-        HelianthusStatusSensor(status_coordinator, "Adapter", adapter_status, adapter_identifier, field)
+        HelianthusStatusSensor(
+            status_coordinator,
+            "Adapter",
+            adapter_status,
+            data.get("adapter_device_id"),
+            field,
+        )
         for field in STATUS_FIELDS
     )
 
@@ -76,13 +85,17 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 sensors.append(
                     HelianthusDemandSensor(
                         semantic_coordinator,
-                        f"Zone {zone_id}",
-                        ("zone", zone_id),
+                        entry.entry_id,
+                        via_device,
+                        zone.get("name") or f"Zone {zone_id}",
+                        ("zone", str(zone_id)),
                     )
                 )
         sensors.append(
             HelianthusDemandSensor(
                 semantic_coordinator,
+                entry.entry_id,
+                via_device,
                 "DHW",
                 ("dhw", None),
             )
@@ -91,56 +104,42 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if energy_coordinator and energy_coordinator.data:
         sensors.extend(
             [
-                HelianthusEnergySensor(energy_coordinator, "gas", "dhw"),
-                HelianthusEnergySensor(energy_coordinator, "gas", "climate"),
-                HelianthusEnergySensor(energy_coordinator, "electric", "dhw"),
-                HelianthusEnergySensor(energy_coordinator, "electric", "climate"),
-                HelianthusEnergySensor(energy_coordinator, "solar", "dhw"),
-                HelianthusEnergySensor(energy_coordinator, "solar", "climate"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "gas", "dhw"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "gas", "climate"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "electric", "dhw"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "electric", "climate"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "solar", "dhw"),
+                HelianthusEnergySensor(energy_coordinator, entry.entry_id, via_device, "solar", "climate"),
             ]
         )
 
     async_add_entities(sensors)
 
 
-class HelianthusInventorySensor(CoordinatorEntity, SensorEntity):
-    """Inventory field sensor."""
+class HelianthusBusAddressSensor(CoordinatorEntity, SensorEntity):
+    """eBUS address sensor for a physical bus device."""
 
     entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator, device: dict[str, Any], field: InventoryField) -> None:
+    def __init__(
+        self,
+        coordinator,
+        device_id: tuple[str, str],
+        address: int,
+    ) -> None:
         super().__init__(coordinator)
-        self._device = device
-        self._field = field
-        self._attr_name = f"{device.get('deviceId', 'Device')} {field.name}"
-        self._attr_unique_id = self._build_unique_id()
-
-    def _build_unique_id(self) -> str:
-        device_id = build_device_id(
-            model=self._device.get("deviceId"),
-            serial_number=self._device.get("serialNumber"),
-            mac_address=self._device.get("macAddress"),
-            address=self._device.get("address"),
-            hardware_version=self._device.get("hardwareVersion"),
-            software_version=self._device.get("softwareVersion"),
-        )
-        return f"{device_id}-{self._field.key}"
+        self._device_id = device_id
+        self._address = address
+        self._attr_name = "eBUS Address"
+        self._attr_unique_id = f"{device_id[1]}-ebus-address"
 
     @property
     def device_info(self) -> DeviceInfo:
-        device_id = build_device_id(
-            model=self._device.get("deviceId"),
-            serial_number=self._device.get("serialNumber"),
-            mac_address=self._device.get("macAddress"),
-            address=self._device.get("address"),
-            hardware_version=self._device.get("hardwareVersion"),
-            software_version=self._device.get("softwareVersion"),
-        )
-        return DeviceInfo(identifiers={(DOMAIN, device_id)})
+        return DeviceInfo(identifiers={self._device_id})
 
     @property
     def native_value(self) -> Any:
-        return self._device.get(self._field.key)
+        return f"0x{self._address:02x}"
 
 
 class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
@@ -153,15 +152,15 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         coordinator,
         target_name: str,
         status: dict[str, Any],
-        identifier: tuple[str, str],
+        identifier: tuple[str, str] | None,
         field: InventoryField,
     ) -> None:
         super().__init__(coordinator)
         self._status = status
         self._field = field
-        self._identifier = identifier
+        self._identifier = identifier or (DOMAIN, f"unknown-{target_name.lower()}")
         self._attr_name = f"{target_name} {field.name}"
-        self._attr_unique_id = f"{identifier[1]}-{field.key}"
+        self._attr_unique_id = f"{self._identifier[1]}-{field.key}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -179,19 +178,37 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator, label: str, target: tuple[str, str | None]) -> None:
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        via_device: tuple[str, str] | None,
+        label: str,
+        target: tuple[str, str | None],
+    ) -> None:
         super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._via_device = via_device
         self._target = target
         self._attr_name = f"{label} Heating Demand"
-        self._attr_unique_id = f"{target[0]}-{target[1] or 'dhw'}-heating-demand"
+        self._attr_unique_id = (
+            f"{entry_id}-{target[0]}-{target[1] or 'dhw'}-heating-demand"
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
         if self._target[0] == "zone":
-            identifier = (DOMAIN, f"zone-{self._target[1]}")
+            identifier = zone_identifier(self._entry_id, str(self._target[1]))
+            model = "Virtual Zone"
         else:
-            identifier = (DOMAIN, "dhw")
-        return DeviceInfo(identifiers={identifier})
+            identifier = dhw_identifier(self._entry_id)
+            model = "Virtual DHW"
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer="Helianthus",
+            model=model,
+            via_device=self._via_device,
+        )
 
     @property
     def native_value(self) -> Any:
@@ -214,21 +231,31 @@ class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
     _attr_state_class = SensorStateClass.TOTAL
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 
-    def __init__(self, coordinator, source: str, usage: str) -> None:
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        via_device: tuple[str, str] | None,
+        source: str,
+        usage: str,
+    ) -> None:
         super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._via_device = via_device
         self._source = source
         self._usage = usage
         self._attr_name = f"{source.capitalize()} {usage.upper()} Energy"
-        self._attr_unique_id = f"energy-{source}-{usage}"
+        self._attr_unique_id = f"{entry_id}-energy-{source}-{usage}"
 
     @property
     def device_info(self) -> DeviceInfo:
-        identifier = (DOMAIN, "energy")
+        identifier = energy_identifier(self._entry_id)
         return DeviceInfo(
             identifiers={identifier},
             manufacturer="Helianthus",
             model="Virtual Energy",
             name="Energy",
+            via_device=self._via_device,
         )
 
     def _series(self) -> dict[str, Any]:

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -11,17 +11,21 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .device_ids import dhw_identifier
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
+    via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
 
     dhw = coordinator.data.get("dhw") if coordinator.data else None
     if dhw is None:
         return
 
-    async_add_entities([HelianthusDhwWaterHeater(entry.entry_id, coordinator)])
+    async_add_entities(
+        [HelianthusDhwWaterHeater(entry.entry_id, coordinator, via_device)]
+    )
 
 
 class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
@@ -30,11 +34,12 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = WaterHeaterEntityFeature(0)
 
-    def __init__(self, entry_id: str, coordinator) -> None:
+    def __init__(self, entry_id: str, coordinator, via_device: tuple[str, str] | None) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
+        self._via_device = via_device
         self._attr_name = "Domestic Hot Water"
-        self._attr_unique_id = "dhw"
+        self._attr_unique_id = f"{entry_id}-dhw"
 
     def _dhw(self) -> dict[str, Any]:
         if not self.coordinator.data:
@@ -43,8 +48,8 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        identifier = (DOMAIN, "dhw")
-        via = (DOMAIN, f"adapter-{self._entry_id}")
+        identifier = dhw_identifier(self._entry_id)
+        via = self._via_device
         return DeviceInfo(
             identifiers={identifier},
             manufacturer="Helianthus",

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -2,49 +2,25 @@
 
 from custom_components.helianthus.device_ids import (
     adapter_identifier,
-    build_device_id,
     bus_identifier,
+    build_bus_device_key,
     daemon_identifier,
-    virtual_identifier,
+    dhw_identifier,
+    energy_identifier,
+    zone_identifier,
 )
 
 
-def test_build_device_id_prefers_serial_number() -> None:
-    device_id = build_device_id(
-        model="BAI00",
-        serial_number="SN123",
-        mac_address="AA:BB:CC:DD:EE:FF",
-        address=8,
-        hardware_version="7603",
-        software_version="0806",
-    )
-    assert device_id == "BAI00-SN123"
-
-
-def test_build_device_id_falls_back_to_mac_then_address_versions() -> None:
-    with_mac = build_device_id(
-        model="BASV2",
-        serial_number=None,
-        mac_address="AA:BB:CC:DD:EE:FF",
-        address=0x15,
-        hardware_version="1704",
-        software_version="0507",
-    )
-    assert with_mac == "BASV2-AA:BB:CC:DD:EE:FF-15-1704-0507"
-
-    without_mac = build_device_id(
-        model="VR_71",
-        serial_number=None,
-        mac_address=None,
-        address=0x26,
-        hardware_version="5904",
-        software_version="0100",
-    )
-    assert without_mac == "VR_71-26-5904-0100"
+def test_build_bus_device_key_is_stable() -> None:
+    assert build_bus_device_key("BAI00", 0x08) == "BAI00-08"
+    assert build_bus_device_key("BASV2", 0x15) == "BASV2-15"
+    assert build_bus_device_key("VR_71", 0x26) == "VR_71-26"
 
 
 def test_identifier_helpers_are_deterministic() -> None:
-    assert daemon_identifier() == ("helianthus", "daemon")
+    assert daemon_identifier("entry-1") == ("helianthus", "daemon-entry-1")
     assert adapter_identifier("entry-1") == ("helianthus", "adapter-entry-1")
-    assert bus_identifier("BASV2-SN") == ("helianthus", "BASV2-SN")
-    assert virtual_identifier("BASV2-SN") == ("helianthus", "BASV2-SN-virtual")
+    assert bus_identifier("entry-1", "BASV2-15") == ("helianthus", "entry-1-bus-BASV2-15")
+    assert zone_identifier("entry-1", "1") == ("helianthus", "entry-1-zone-1")
+    assert dhw_identifier("entry-1") == ("helianthus", "entry-1-dhw")
+    assert energy_identifier("entry-1") == ("helianthus", "entry-1-energy")


### PR DESCRIPTION
Closes #66.

- Removes per-device "Virtual ..." devices; keeps only physical bus devices + semantic virtuals (zones/DHW/energy).
- Stabilizes identifiers (entry-scoped; physical bus devices keyed by model+eBUS address).
- Aggressively cleans up prior Helianthus-created devices/entities on setup to eliminate duplicates from older releases.
- Parents zones/DHW/energy under the regulator device (fallback: adapter) via via_device.
- Avoids deprecated ZeroconfServiceInfo import path.

Local validation: python3 -m compileall + PYTHONPATH=. pytest.