### PR TITLE
Fix CI pytest imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for repo-local imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+


### PR DESCRIPTION
Closes #68.

Adds tests/conftest.py to ensure repo root is on sys.path so pytest can import custom_components.* without requiring PYTHONPATH hacks.

Local validation: pytest (28 passed).