### PR TITLE
Skip DHW entities when dhw is null

### DIFF
--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -91,15 +91,16 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         ("zone", str(zone_id)),
                     )
                 )
-        sensors.append(
-            HelianthusDemandSensor(
-                semantic_coordinator,
-                entry.entry_id,
-                via_device,
-                "DHW",
-                ("dhw", None),
+        if semantic_coordinator.data.get("dhw") is not None:
+            sensors.append(
+                HelianthusDemandSensor(
+                    semantic_coordinator,
+                    entry.entry_id,
+                    via_device,
+                    "DHW",
+                    ("dhw", None),
+                )
             )
-        )
 
     if energy_coordinator and energy_coordinator.data:
         sensors.extend(


### PR DESCRIPTION
Closes #72.

Only creates DHW-related diagnostics when semantic GraphQL returns a non-null dhw payload. This avoids placeholder devices when DHW is currently unavailable and relies on the existing semantic inventory reload logic when DHW becomes available.

Local validation: pytest (28 passed).