### PR TITLE
META-01: add local CI entrypoint

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6,19 +6,9 @@ You are the development agent for the Helianthus Home Assistant integration. Thi
 
 You do **not** make architectural decisions. Those are defined in `ARCHITECTURE.md`. If something is not covered there, stop and ask. You do **not** skip ahead of the milestone/issue order.
 
----
+## Workflow Note
 
-## Bootstrap Issue (No PR Required)
-
-The very first action is the **bootstrap issue**. It is implemented directly on `main` without a PR and includes exactly:
-
-- Repo metadata: `README.md`, `LICENSE`, `AGENT.md`, `ARCHITECTURE.md`, `CONVENTIONS.md`
-- `.gitignore` (includes `AGENT-local.md`)
-- Minimal HA component skeleton under `custom_components/helianthus/`
-- Minimal CI workflow
-- A trivial test under `tests/`
-
-No logic beyond scaffolding.
+The bootstrap scaffolding is already in place. All changes must go through a PR; do not commit directly to `main`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ helianthus-ebusgo -> helianthus-ebusreg -> helianthus-ebusgateway -> helianthus-
 ```bash
 git clone https://github.com/d3vi1/helianthus-ha-integration.git
 cd helianthus-ha-integration
-python3 -m venv .venv
-source .venv/bin/activate
-python3 -m pip install --upgrade pip pytest
-python3 -m pytest
+./scripts/ci_local.sh
 ```
 
 ### 2) Focused test runs
@@ -70,7 +67,7 @@ Restart Home Assistant, then add integration **Helianthus** from **Settings → 
 Config flow fields:
 
 ```yaml
-host: "127.0.0.1"
+host: "203.0.113.10"
 port: 8080
 path: "/graphql"
 transport: "http"     # http | https
@@ -90,7 +87,7 @@ Standard smoke check against local gateway:
 
 ```bash
 python3 -m custom_components.helianthus.smoke_profile \
-  --host 127.0.0.1 \
+  --host 203.0.113.10 \
   --port 8080 \
   --path /graphql
 ```
@@ -99,7 +96,7 @@ JSON output mode:
 
 ```bash
 python3 -m custom_components.helianthus.smoke_profile \
-  --url http://127.0.0.1:8080/graphql \
+  --url http://203.0.113.10:8080/graphql \
   --json
 ```
 
@@ -107,14 +104,14 @@ Dual-topology path mode (`ebusd` + adapter-proxy):
 
 ```bash
 python3 -m custom_components.helianthus.smoke_profile \
-  --host 127.0.0.1 \
+  --host 203.0.113.10 \
   --port 8080 \
   --path /graphql \
   --dual-topology \
-  --ebusd-host 127.0.0.1 \
+  --ebusd-host 203.0.113.10 \
   --ebusd-port 8888 \
   --proxy-profile enh \
-  --proxy-host 127.0.0.1 \
+  --proxy-host 203.0.113.10 \
   --proxy-port 19001
 ```
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> terminology gate"
+if git grep -nIwiE 'm[a]ster|s[l]ave'; then
+  echo "Found legacy terminology."
+  exit 1
+fi
+
+echo "==> python tests"
+pytest
+
+echo "==> private IPv4 address gate (docs must use placeholders)"
+python3 - <<'PY'
+from __future__ import annotations
+
+import ipaddress
+import pathlib
+import re
+import subprocess
+import sys
+
+md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
+
+private_nets = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+]
+
+def is_leaked_private(ip: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    if addr.version != 4:
+        return False
+    return any(addr in net for net in private_nets)
+
+failed = False
+
+for file_path in md_files:
+    text = pathlib.Path(file_path).read_text(encoding="utf-8")
+    for match in ipv4_re.finditer(text):
+        ip = match.group(0)
+        if not is_leaked_private(ip):
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        print(f"{file_path}:{line}: private IPv4 address found (use a placeholder)", file=sys.stderr)
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("Private IPv4 gate passed.")
+PY


### PR DESCRIPTION
Fixes #74.

- Add ==> terminology gate
==> python tests
============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/razvan/Desktop/Helianthus Project/helianthus-ha-integration
collected 28 items

tests/test_coordinator.py ..                                             [  7%]
tests/test_device_ids.py ..                                              [ 14%]
tests/test_discovery.py ...                                              [ 25%]
tests/test_energy.py .                                                   [ 28%]
tests/test_graphql.py ......                                             [ 50%]
tests/test_hello.py .                                                    [ 53%]
tests/test_init_labels.py ..                                             [ 60%]
tests/test_smoke_profile.py ...........                                  [100%]

============================== 28 passed in 0.04s ==============================
==> private IPv4 address gate (docs must use placeholders)
Private IPv4 gate passed. to run terminology gate, tests, and private IPv4 leak gate.
- Update README to use the local CI script and placeholders instead of private IPs.
- Update AGENT.md workflow note (PRs only; no direct main commits).