### PR TITLE
Verifier follow-up: strict entry filtering and resilient probe selection

### DIFF
--- a/scripts/ha_inventory_verifier.py
+++ b/scripts/ha_inventory_verifier.py
@@ -40,6 +40,9 @@ def websocket_url(base_url: str) -> str:
 
 
 def should_include_device(device: dict[str, Any], domain: str, config_entry_id: str | None) -> bool:
+    if config_entry_id and config_entry_id not in (device.get("config_entries") or []):
+        return False
+
     identifiers = device.get("identifiers") or []
     for identifier in identifiers:
         if (
@@ -48,15 +51,19 @@ def should_include_device(device: dict[str, Any], domain: str, config_entry_id: 
             and identifier[0] == domain
         ):
             return True
-    if config_entry_id and config_entry_id in (device.get("config_entries") or []):
+
+    if config_entry_id:
         return True
     return False
 
 
 def should_include_entity(entity: dict[str, Any], domain: str, config_entry_id: str | None) -> bool:
+    if config_entry_id and entity.get("config_entry_id") != config_entry_id:
+        return False
+
     if entity.get("platform") == domain:
         return True
-    if config_entry_id and entity.get("config_entry_id") == config_entry_id:
+    if config_entry_id:
         return True
     return False
 
@@ -101,21 +108,25 @@ def summarize_inventory(
 
         probe = ProbeResult(entity_id=None, ok=False, state=None, error="no active entities")
         if active_entities:
-            probe_entity = str(active_entities[0].get("entity_id") or "")
-            state_payload = states_by_entity.get(probe_entity)
-            if state_payload is None:
-                probe = ProbeResult(
-                    entity_id=probe_entity,
-                    ok=False,
-                    state=None,
-                    error="state read failed",
-                )
-            else:
+            for entry in active_entities:
+                probe_entity = str(entry.get("entity_id") or "")
+                state_payload = states_by_entity.get(probe_entity)
+                if state_payload is None:
+                    continue
                 probe = ProbeResult(
                     entity_id=probe_entity,
                     ok=True,
                     state=str(state_payload.get("state")),
                     error=None,
+                )
+                break
+            if not probe.ok:
+                probe_entity = str(active_entities[0].get("entity_id") or "")
+                probe = ProbeResult(
+                    entity_id=probe_entity,
+                    ok=False,
+                    state=None,
+                    error="state read failed for all active entities",
                 )
 
         if not probe.ok:

--- a/tests/test_ha_inventory_verifier.py
+++ b/tests/test_ha_inventory_verifier.py
@@ -76,3 +76,70 @@ def test_summarize_inventory_reports_missing_entities() -> None:
     assert summary["entity_count"] == 0
     assert summary["errors"]
     assert "no active entities" in summary["errors"][0]
+
+
+def test_summarize_inventory_uses_second_active_entity_when_first_missing_state() -> None:
+    module = _load_module()
+
+    summary = module.summarize_inventory(
+        domain="helianthus",
+        devices=[
+            {
+                "id": "device-1",
+                "name": "sensoCOMFORT RF",
+                "identifiers": [["helianthus", "entry-1-bus-basv-15"]],
+            }
+        ],
+        entities=[
+            {
+                "entity_id": "sensor.helianthus_probe_a",
+                "device_id": "device-1",
+                "platform": "helianthus",
+                "disabled_by": None,
+                "hidden_by": None,
+            },
+            {
+                "entity_id": "sensor.helianthus_probe_b",
+                "device_id": "device-1",
+                "platform": "helianthus",
+                "disabled_by": None,
+                "hidden_by": None,
+            },
+        ],
+        states_by_entity={
+            "sensor.helianthus_probe_b": {
+                "state": "42",
+            }
+        },
+    )
+
+    assert summary["ok"] is True
+    probe = summary["devices"][0]["probe"]
+    assert probe["ok"] is True
+    assert probe["entity_id"] == "sensor.helianthus_probe_b"
+
+
+def test_config_entry_filter_is_strict_for_devices_and_entities() -> None:
+    module = _load_module()
+
+    device_match = {
+        "config_entries": ["entry-1"],
+        "identifiers": [["helianthus", "entry-1-bus-basv-15"]],
+    }
+    device_other_entry = {
+        "config_entries": ["entry-2"],
+        "identifiers": [["helianthus", "entry-2-bus-vr71-26"]],
+    }
+    entity_match = {
+        "platform": "helianthus",
+        "config_entry_id": "entry-1",
+    }
+    entity_other_entry = {
+        "platform": "helianthus",
+        "config_entry_id": "entry-2",
+    }
+
+    assert module.should_include_device(device_match, "helianthus", "entry-1")
+    assert not module.should_include_device(device_other_entry, "helianthus", "entry-1")
+    assert module.should_include_entity(entity_match, "helianthus", "entry-1")
+    assert not module.should_include_entity(entity_other_entry, "helianthus", "entry-1")


### PR DESCRIPTION
## Summary
- enforce strict `--config-entry-id` filtering for both devices and entities
- improve probe strategy: try all active entities and succeed on the first readable state
- return a clear failure reason only when all active entity probes fail
- add unit coverage for strict filtering and probe fallback

## Validation
- `./scripts/ci_local.sh`

Fixes #80