### PR TITLE
Fix Helianthus setup crash on legacy device identifiers

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -90,6 +90,15 @@ def _identifier_matches_any_entry(token: str, active_entry_ids: set[str]) -> boo
     return False
 
 
+def _iter_identifier_pairs(identifiers: set[object]) -> tuple[tuple[str, str], ...]:
+    pairs: list[tuple[str, str]] = []
+    for identifier in identifiers:
+        if not isinstance(identifier, (tuple, list)) or len(identifier) < 2:
+            continue
+        pairs.append((str(identifier[0]), str(identifier[1])))
+    return tuple(pairs)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Helianthus from a config entry."""
     from homeassistant.helpers import device_registry as dr
@@ -128,9 +137,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     stale_devices_removed = 0
     for device_entry in tuple(device_registry.devices.values()):
+        identifier_pairs = _iter_identifier_pairs(device_entry.identifiers)
         domain_tokens = [
             token
-            for identifier_domain, token in device_entry.identifiers
+            for identifier_domain, token in identifier_pairs
             if identifier_domain == DOMAIN
         ]
         if not domain_tokens:
@@ -154,7 +164,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     removed_devices = 0
     for device_entry in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
-        if any(identifier[0] == DOMAIN for identifier in device_entry.identifiers):
+        if any(
+            identifier_domain == DOMAIN
+            for identifier_domain, _ in _iter_identifier_pairs(device_entry.identifiers)
+        ):
             device_registry.async_remove_device(device_entry.id)
             removed_devices += 1
 

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -6,6 +6,7 @@ from custom_components.helianthus import (
     _clean_label,
     _identifier_belongs_to_entry,
     _identifier_matches_any_entry,
+    _iter_identifier_pairs,
 )
 
 
@@ -43,3 +44,16 @@ def test_identifier_matches_any_entry() -> None:
     assert _identifier_matches_any_entry("entry-2-energy", active)
     assert _identifier_matches_any_entry("entry-1-bus-VR_71-26", active)
     assert not _identifier_matches_any_entry("legacy-device", active)
+
+
+def test_iter_identifier_pairs_ignores_legacy_shapes() -> None:
+    raw = {
+        ("helianthus", "entry-1-bus-BASV2-15"),
+        ("helianthus", "entry-1-zone-1", "legacy-extra"),
+        "legacy-string-id",
+        ("malformed",),
+    }
+    assert _iter_identifier_pairs(raw) == (
+        ("helianthus", "entry-1-bus-BASV2-15"),
+        ("helianthus", "entry-1-zone-1"),
+    )


### PR DESCRIPTION
## Summary
- harden identifier parsing during stale device cleanup so legacy/malformed entries do not crash setup
- reuse normalized identifier pairs for both stale-device pruning and per-entry cleanup
- add regression test for mixed identifier shapes (2-tuple, 3-tuple, string, malformed tuple)

## Validation
- `pytest -q`

Closes #82
