### PR TITLE
Add daemon initiator address diagnostic sensor

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -78,6 +78,22 @@ query Status {
     status
     firmwareVersion
     updatesAvailable
+    initiatorAddress
+  }
+  adapterStatus {
+    status
+    firmwareVersion
+    updatesAvailable
+  }
+}
+"""
+
+QUERY_STATUS_LEGACY = """
+query Status {
+  daemonStatus {
+    status
+    firmwareVersion
+    updatesAvailable
   }
   adapterStatus {
     status
@@ -223,6 +239,16 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         try:
             payload = await self._client.execute(QUERY_STATUS)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, ["initiatorAddress"]):
+                try:
+                    payload = await self._client.execute(QUERY_STATUS_LEGACY)
+                except GraphQLClientError as nested:
+                    raise UpdateFailed(str(nested)) from nested
+                except GraphQLResponseError as nested:
+                    raise UpdateFailed(str(nested)) from nested
+            else:
+                raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -33,6 +33,12 @@ STATUS_FIELDS = [
     InventoryField("updatesAvailable", "Updates Available"),
 ]
 
+DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
+    InventoryField("initiatorAddress", "eBUS Initiator Address")
+]
+
+ADAPTER_STATUS_FIELDS = STATUS_FIELDS
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
@@ -64,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             data.get("daemon_device_id"),
             field,
         )
-        for field in STATUS_FIELDS
+        for field in DAEMON_STATUS_FIELDS
     )
     sensors.extend(
         HelianthusStatusSensor(
@@ -74,7 +80,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             data.get("adapter_device_id"),
             field,
         )
-        for field in STATUS_FIELDS
+        for field in ADAPTER_STATUS_FIELDS
     )
 
     if semantic_coordinator and semantic_coordinator.data:

--- a/custom_components/helianthus/smoke_profile.py
+++ b/custom_components/helianthus/smoke_profile.py
@@ -61,6 +61,22 @@ query SmokeStatus {
     status
     firmwareVersion
     updatesAvailable
+    initiatorAddress
+  }
+  adapterStatus {
+    status
+    firmwareVersion
+    updatesAvailable
+  }
+}
+"""
+
+QUERY_STATUS_LEGACY = """
+query SmokeStatus {
+  daemonStatus {
+    status
+    firmwareVersion
+    updatesAvailable
   }
   adapterStatus {
     status
@@ -103,7 +119,8 @@ query SmokeEnergy {
 
 MISSING_DEVICE_FIELDS = ["serialNumber", "macAddress"]
 INVENTORY_FIELD_COUNT = 7
-STATUS_FIELD_COUNT = 3
+DAEMON_STATUS_FIELD_COUNT = 4
+ADAPTER_STATUS_FIELD_COUNT = 3
 
 GraphQLExecutor = Callable[[str], dict[str, Any]]
 EndpointProbe = Callable[[str, int, float], str | None]
@@ -341,7 +358,8 @@ def _check_entity_creation(execute: GraphQLExecutor) -> SmokeCheck:
 
         diagnostics_count = (
             len(valid_devices) * INVENTORY_FIELD_COUNT
-            + STATUS_FIELD_COUNT * 2
+            + DAEMON_STATUS_FIELD_COUNT
+            + ADAPTER_STATUS_FIELD_COUNT
             + zone_count
             + 1
         )
@@ -452,7 +470,14 @@ def _fetch_status(execute: GraphQLExecutor) -> tuple[dict[str, Any], str | None]
         return {}, execution_error
     if response is None:
         return {}, "status query returned no response"
-    data, error = _extract_data(response)
+    data, error, errors = _extract_data_with_errors(response)
+    if error and _is_missing_field_error(errors, ["initiatorAddress"]):
+        fallback, fallback_error = _execute_graphql(execute, QUERY_STATUS_LEGACY, "status_legacy")
+        if fallback_error:
+            return {}, fallback_error
+        if fallback is None:
+            return {}, "status legacy query returned no response"
+        data, error, _ = _extract_data_with_errors(fallback)
     if error:
         return {}, f"status query failed: {error}"
     if not isinstance(data, dict):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -35,8 +35,11 @@ from custom_components.helianthus.coordinator import (
     QUERY_EXTENDED_V2,
     QUERY_EXTENDED_V3,
     QUERY_EXTENDED_V3_NO_PART,
+    QUERY_STATUS,
+    QUERY_STATUS_LEGACY,
     UpdateFailed,
     HelianthusCoordinator,
+    HelianthusStatusCoordinator,
 )
 from custom_components.helianthus.graphql import GraphQLClientError, GraphQLResponseError
 
@@ -56,6 +59,12 @@ class _ScriptedClient:
 
 def _build_coordinator(client: _ScriptedClient) -> HelianthusCoordinator:
     coordinator = object.__new__(HelianthusCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_status_coordinator(client: _ScriptedClient) -> HelianthusStatusCoordinator:
+    coordinator = object.__new__(HelianthusStatusCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     return coordinator
 
@@ -107,3 +116,58 @@ def test_v2_fallback_wraps_transport_error_as_update_failed() -> None:
         raise AssertionError("expected UpdateFailed")
 
     assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V2]
+
+
+def test_status_query_uses_initiator_field_when_available() -> None:
+    client = _ScriptedClient(
+        [
+            {
+                "daemonStatus": {
+                    "status": "running",
+                    "firmwareVersion": "0.3.10",
+                    "updatesAvailable": False,
+                    "initiatorAddress": "0xF7",
+                },
+                "adapterStatus": {
+                    "status": "ok",
+                    "firmwareVersion": "3.0",
+                    "updatesAvailable": False,
+                },
+            }
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["daemon"]["initiatorAddress"] == "0xF7"
+    assert client.calls == [QUERY_STATUS]
+
+
+def test_status_query_falls_back_when_initiator_field_missing() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "initiatorAddress" on type "ServiceStatus".'}]
+            ),
+            {
+                "daemonStatus": {
+                    "status": "running",
+                    "firmwareVersion": "0.3.10",
+                    "updatesAvailable": False,
+                },
+                "adapterStatus": {
+                    "status": "ok",
+                    "firmwareVersion": "3.0",
+                    "updatesAvailable": False,
+                },
+            },
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["daemon"]["status"] == "running"
+    assert "initiatorAddress" not in data["daemon"]
+    assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -53,7 +53,7 @@ def test_iter_identifier_pairs_ignores_legacy_shapes() -> None:
         "legacy-string-id",
         ("malformed",),
     }
-    assert _iter_identifier_pairs(raw) == (
+    assert set(_iter_identifier_pairs(raw)) == {
         ("helianthus", "entry-1-bus-BASV2-15"),
         ("helianthus", "entry-1-zone-1"),
-    )
+    }

--- a/tests/test_smoke_profile.py
+++ b/tests/test_smoke_profile.py
@@ -64,7 +64,7 @@ def _success_responses() -> dict[str, dict]:
         },
         "SmokeStatus": {
             "data": {
-                "daemonStatus": {"status": "ok"},
+                "daemonStatus": {"status": "ok", "initiatorAddress": "0xF7"},
                 "adapterStatus": {"status": "ok"},
             }
         },
@@ -90,7 +90,7 @@ def test_run_smoke_profile_success_with_subscription_type() -> None:
         "entity_creation",
     ]
     assert "mode=subscriptions_available" in result.checks[1].details
-    assert "diagnostics_sensors=15" in result.checks[2].details
+    assert "diagnostics_sensors=16" in result.checks[2].details
     lines = result.to_checklist_lines()
     assert lines[2].startswith("[PASS] CHECK_CONNECTION ::")
     assert lines[3].startswith("[PASS] CHECK_SUBSCRIPTIONS_FALLBACK ::")


### PR DESCRIPTION
## Summary
- extend status coordinator query with `daemonStatus.initiatorAddress` and add fallback query for older gateway schemas
- publish `Daemon eBUS Initiator Address` as a diagnostic sensor on the Helianthus Daemon device
- update smoke profile status checks/counts and add coordinator fallback tests

## Validation
- `pytest -q`

## Compatibility
- If backend schema does not have `initiatorAddress`, integration automatically falls back to legacy status query.

Depends on d3vi1/helianthus-ebusgateway#126
Closes #84
