### PR TITLE
Inventory: canonical HA devices for alias eBUS faces (#86)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -117,6 +117,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         build_bus_device_key,
         bus_identifier,
         daemon_identifier,
+        resolve_bus_address,
     )
     from .subscriptions import start_subscriptions
 
@@ -232,11 +233,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
     def resolved_bus_device_key(device: dict) -> str | None:
-        address = device.get("address")
-        device_id = device.get("deviceId", "unknown")
+        address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:
             return None
-        return build_bus_device_key(model=str(device_id), address=int(address))
+        model = _clean_label(device.get("productModel")) or _clean_label(device.get("deviceId"))
+        return build_bus_device_key(
+            model=model,
+            address=address,
+            serial_number=_clean_label(device.get("serialNumber")),
+            mac_address=_clean_label(device.get("macAddress")),
+            hardware_version=_clean_label(device.get("hardwareVersion")),
+            software_version=_clean_label(device.get("softwareVersion")),
+        )
 
     def is_regulator_device(device: dict) -> bool:
         device_id = str(device.get("deviceId") or "").upper()
@@ -252,7 +260,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     known_bus_devices: set[str] = set()
     regulator_device: tuple[str, str] | None = None
     for device in devices:
-        address = device.get("address")
+        address = resolve_bus_address(device.get("address"), device.get("addresses"))
         device_id = device.get("deviceId", "unknown")
         serial_number = device.get("serialNumber")
         manufacturer = _clean_label(device.get("manufacturer")) or "Unknown"

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -15,6 +15,7 @@ QUERY_EXTENDED_V3 = """
 query Devices {
   devices {
     address
+    addresses
     manufacturer
     deviceId
     displayName
@@ -30,6 +31,42 @@ query Devices {
 """
 
 QUERY_EXTENDED_V3_NO_PART = """
+query Devices {
+  devices {
+    address
+    addresses
+    manufacturer
+    deviceId
+    displayName
+    productFamily
+    productModel
+    serialNumber
+    macAddress
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_EXTENDED_V3_NO_ADDRESSES = """
+query Devices {
+  devices {
+    address
+    manufacturer
+    deviceId
+    displayName
+    productFamily
+    productModel
+    partNumber
+    serialNumber
+    macAddress
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_EXTENDED_V3_NO_PART_NO_ADDRESSES = """
 query Devices {
   devices {
     address
@@ -50,6 +87,21 @@ QUERY_EXTENDED_V2 = """
 query Devices {
   devices {
     address
+    addresses
+    manufacturer
+    deviceId
+    serialNumber
+    macAddress
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_EXTENDED_V2_NO_ADDRESSES = """
+query Devices {
+  devices {
+    address
     manufacturer
     deviceId
     serialNumber
@@ -61,6 +113,19 @@ query Devices {
 """
 
 QUERY_BASE = """
+query Devices {
+  devices {
+    address
+    addresses
+    manufacturer
+    deviceId
+    softwareVersion
+    hardwareVersion
+  }
+}
+"""
+
+QUERY_BASE_NO_ADDRESSES = """
 query Devices {
   devices {
     address
@@ -153,72 +218,58 @@ class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 return list(payload.get("devices", []))
             return []
 
-        def is_missing_field_error(errors: object, fields: list[str]) -> bool:
-            if not isinstance(errors, list):
-                return False
-            for error in errors:
-                message = ""
-                if isinstance(error, dict):
-                    message = str(error.get("message", ""))
-                else:
-                    message = str(error)
-                for field in fields:
-                    if f'Cannot query field "{field}"' in message:
-                        return True
-            return False
+        async def fetch_with_addresses(
+            query_with_addresses: str, query_without_addresses: str
+        ) -> list[dict[str, Any]]:
+            try:
+                return await fetch(query_with_addresses)
+            except GraphQLResponseError as exc:
+                if _is_missing_field_error(exc.errors, ["addresses"]):
+                    return await fetch(query_without_addresses)
+                raise
+
+        async def fetch_base_devices() -> list[dict[str, Any]]:
+            try:
+                return await fetch_with_addresses(QUERY_BASE, QUERY_BASE_NO_ADDRESSES)
+            except GraphQLClientError as exc:
+                raise UpdateFailed(str(exc)) from exc
+            except GraphQLResponseError as exc:
+                raise UpdateFailed(str(exc)) from exc
+
+        async def fetch_v2_devices() -> list[dict[str, Any]]:
+            try:
+                return await fetch_with_addresses(QUERY_EXTENDED_V2, QUERY_EXTENDED_V2_NO_ADDRESSES)
+            except GraphQLClientError as exc:
+                raise UpdateFailed(str(exc)) from exc
+            except GraphQLResponseError as exc:
+                if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+                    return await fetch_base_devices()
+                raise UpdateFailed(str(exc)) from exc
+
+        async def fetch_v3_no_part_devices() -> list[dict[str, Any]]:
+            try:
+                return await fetch_with_addresses(
+                    QUERY_EXTENDED_V3_NO_PART,
+                    QUERY_EXTENDED_V3_NO_PART_NO_ADDRESSES,
+                )
+            except GraphQLClientError as exc:
+                raise UpdateFailed(str(exc)) from exc
+            except GraphQLResponseError as exc:
+                if _is_missing_field_error(exc.errors, ["displayName", "productFamily", "productModel"]):
+                    return await fetch_v2_devices()
+                if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+                    return await fetch_base_devices()
+                raise UpdateFailed(str(exc)) from exc
 
         try:
-            return await fetch(QUERY_EXTENDED_V3)
+            return await fetch_with_addresses(QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_ADDRESSES)
         except GraphQLResponseError as exc:
-            if is_missing_field_error(exc.errors, ["partNumber"]):
-                try:
-                    return await fetch(QUERY_EXTENDED_V3_NO_PART)
-                except GraphQLClientError as nested:
-                    raise UpdateFailed(str(nested)) from nested
-                except GraphQLResponseError as nested:
-                    if is_missing_field_error(nested.errors, ["displayName", "productFamily", "productModel"]):
-                        try:
-                            return await fetch(QUERY_EXTENDED_V2)
-                        except GraphQLClientError as fallback_exc:
-                            raise UpdateFailed(str(fallback_exc)) from fallback_exc
-                        except GraphQLResponseError as fallback_exc:
-                            if is_missing_field_error(fallback_exc.errors, ["serialNumber", "macAddress"]):
-                                try:
-                                    return await fetch(QUERY_BASE)
-                                except GraphQLClientError as base_exc:
-                                    raise UpdateFailed(str(base_exc)) from base_exc
-                                except GraphQLResponseError as base_exc:
-                                    raise UpdateFailed(str(base_exc)) from base_exc
-                            raise UpdateFailed(str(fallback_exc)) from fallback_exc
-                    if is_missing_field_error(nested.errors, ["serialNumber", "macAddress"]):
-                        try:
-                            return await fetch(QUERY_BASE)
-                        except GraphQLClientError as base_exc:
-                            raise UpdateFailed(str(base_exc)) from base_exc
-                        except GraphQLResponseError as base_exc:
-                            raise UpdateFailed(str(base_exc)) from base_exc
-                    raise UpdateFailed(str(nested)) from nested
-            if is_missing_field_error(exc.errors, ["displayName", "productFamily", "productModel"]):
-                try:
-                    return await fetch(QUERY_EXTENDED_V2)
-                except GraphQLClientError as nested:
-                    raise UpdateFailed(str(nested)) from nested
-                except GraphQLResponseError as nested:
-                    if is_missing_field_error(nested.errors, ["serialNumber", "macAddress"]):
-                        try:
-                            return await fetch(QUERY_BASE)
-                        except GraphQLClientError as base_exc:
-                            raise UpdateFailed(str(base_exc)) from base_exc
-                        except GraphQLResponseError as base_exc:
-                            raise UpdateFailed(str(base_exc)) from base_exc
-                    raise UpdateFailed(str(nested)) from nested
-            if is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
-                try:
-                    return await fetch(QUERY_BASE)
-                except GraphQLClientError as nested:
-                    raise UpdateFailed(str(nested)) from nested
-                except GraphQLResponseError as nested:
-                    raise UpdateFailed(str(nested)) from nested
+            if _is_missing_field_error(exc.errors, ["partNumber"]):
+                return await fetch_v3_no_part_devices()
+            if _is_missing_field_error(exc.errors, ["displayName", "productFamily", "productModel"]):
+                return await fetch_v2_devices()
+            if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+                return await fetch_base_devices()
             raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+import re
+
 from .const import DOMAIN
+
+_MAC_TOKEN_RE = re.compile(r"[^0-9A-Fa-f]")
 
 
 def _token(value: object | None) -> str:
@@ -11,15 +16,85 @@ def _token(value: object | None) -> str:
     return str(value).strip().replace(" ", "-")
 
 
-def build_bus_device_key(model: str | None, address: int | None) -> str:
+def _clean(value: object | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _parse_bus_address(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    try:
+        if cleaned.lower().startswith("0x"):
+            return int(cleaned, 16)
+        return int(cleaned)
+    except ValueError:
+        return None
+
+
+def _normalized_mac(value: object | None) -> str | None:
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    compact = _MAC_TOKEN_RE.sub("", cleaned)
+    if len(compact) not in {12, 16}:
+        return None
+    return compact.lower()
+
+
+def resolve_bus_address(address: object | None, addresses: object | None = None) -> int | None:
+    """Return a stable eBUS address from `address` / `addresses` payload fields."""
+
+    parsed: list[int] = []
+    if isinstance(addresses, Iterable) and not isinstance(addresses, (str, bytes, bytearray)):
+        for item in addresses:
+            parsed_item = _parse_bus_address(item)
+            if parsed_item is not None:
+                parsed.append(parsed_item)
+
+    parsed_single = _parse_bus_address(address)
+    if parsed_single is not None:
+        parsed.append(parsed_single)
+    if not parsed:
+        return None
+    return min(parsed)
+
+
+def build_bus_device_key(
+    model: str | None,
+    address: int | None,
+    *,
+    serial_number: str | None = None,
+    mac_address: str | None = None,
+    hardware_version: str | None = None,
+    software_version: str | None = None,
+) -> str:
     """Return a stable identifier key for a physical eBUS device.
 
-    This is intentionally independent of volatile fields (serial number, MAC, software version).
+    Identity priority: serial number, then MAC, then model+address+hw/sw fallback.
     """
 
     model_token = _token(model) if model else "unknown"
+
+    serial_token = _clean(serial_number)
+    if serial_token:
+        return f"{model_token}-sn-{_token(serial_token).upper()}"
+
+    mac_token = _normalized_mac(mac_address)
+    if mac_token:
+        return f"{model_token}-mac-{mac_token}"
+
     address_token = f"{address:02x}" if isinstance(address, int) else _token(address)
-    return f"{model_token}-{address_token}"
+    hw_token = _token(hardware_version)
+    sw_token = _token(software_version)
+    return f"{model_token}-{address_token}-{hw_token}-{sw_token}"
 
 
 def daemon_identifier(config_entry_id: str) -> tuple[str, str]:

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -16,6 +16,7 @@ from .device_ids import (
     bus_identifier,
     dhw_identifier,
     energy_identifier,
+    resolve_bus_address,
     zone_identifier,
 )
 from .energy import compute_total
@@ -40,6 +41,13 @@ DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
 ADAPTER_STATUS_FIELDS = STATUS_FIELDS
 
 
+def _clean_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     device_coordinator = data["device_coordinator"]
@@ -49,14 +57,26 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
 
     sensors: list[SensorEntity] = []
+    seen_bus_keys: set[str] = set()
     for device in device_coordinator.data or []:
-        device_id = device.get("deviceId", "unknown")
-        address = device.get("address")
+        device_id = _clean_text(device.get("deviceId")) or "unknown"
+        address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:
             continue
-        bus_key = build_bus_device_key(model=str(device_id), address=int(address))
+        model = _clean_text(device.get("productModel")) or device_id
+        bus_key = build_bus_device_key(
+            model=model,
+            address=address,
+            serial_number=_clean_text(device.get("serialNumber")),
+            mac_address=_clean_text(device.get("macAddress")),
+            hardware_version=_clean_text(device.get("hardwareVersion")),
+            software_version=_clean_text(device.get("softwareVersion")),
+        )
+        if bus_key in seen_bus_keys:
+            continue
+        seen_bus_keys.add(bus_key)
         bus_id = bus_identifier(entry.entry_id, bus_key)
-        sensors.append(HelianthusBusAddressSensor(device_coordinator, bus_id, int(address)))
+        sensors.append(HelianthusBusAddressSensor(device_coordinator, bus_id, address))
 
     status_entries = status_coordinator.data or {}
     daemon_status = status_entries.get("daemon", {})

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -33,7 +33,9 @@ sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_coordi
 
 from custom_components.helianthus.coordinator import (
     QUERY_EXTENDED_V2,
+    QUERY_EXTENDED_V2_NO_ADDRESSES,
     QUERY_EXTENDED_V3,
+    QUERY_EXTENDED_V3_NO_ADDRESSES,
     QUERY_EXTENDED_V3_NO_PART,
     QUERY_STATUS,
     QUERY_STATUS_LEGACY,
@@ -97,6 +99,32 @@ def test_v3_falls_back_to_v3_without_part_number() -> None:
     assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_PART]
 
 
+def test_v3_falls_back_when_addresses_field_missing() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "addresses" on type "Device".'}]
+            ),
+            {
+                "devices": [
+                    {
+                        "address": 8,
+                        "manufacturer": "Vaillant",
+                        "deviceId": "BASV2",
+                    }
+                ]
+            },
+        ]
+    )
+    coordinator = _build_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert len(data) == 1
+    assert data[0]["address"] == 8
+    assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_ADDRESSES]
+
+
 def test_v2_fallback_wraps_transport_error_as_update_failed() -> None:
     client = _ScriptedClient(
         [
@@ -116,6 +144,35 @@ def test_v2_fallback_wraps_transport_error_as_update_failed() -> None:
         raise AssertionError("expected UpdateFailed")
 
     assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V2]
+
+
+def test_v2_fallback_drops_addresses_when_missing() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "displayName" on type "Device".'}]
+            ),
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "addresses" on type "Device".'}]
+            ),
+            {
+                "devices": [
+                    {
+                        "address": 21,
+                        "manufacturer": "Vaillant",
+                        "deviceId": "BASV2",
+                    }
+                ]
+            },
+        ]
+    )
+    coordinator = _build_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert len(data) == 1
+    assert data[0]["address"] == 21
+    assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V2, QUERY_EXTENDED_V2_NO_ADDRESSES]
 
 
 def test_status_query_uses_initiator_field_when_available() -> None:

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -7,20 +7,88 @@ from custom_components.helianthus.device_ids import (
     daemon_identifier,
     dhw_identifier,
     energy_identifier,
+    resolve_bus_address,
     zone_identifier,
 )
 
 
-def test_build_bus_device_key_is_stable() -> None:
-    assert build_bus_device_key("BAI00", 0x08) == "BAI00-08"
-    assert build_bus_device_key("BASV2", 0x15) == "BASV2-15"
-    assert build_bus_device_key("VR_71", 0x26) == "VR_71-26"
+def test_build_bus_device_key_prefers_serial() -> None:
+    first = build_bus_device_key(
+        model="BAI00",
+        address=0x08,
+        serial_number="ABC123",
+        mac_address="aa:bb:cc:dd:ee:ff",
+    )
+    second = build_bus_device_key(
+        model="VR_71",
+        address=0x26,
+        serial_number="abc123",
+        mac_address="11:22:33:44:55:66",
+    )
+    assert first == "BAI00-sn-ABC123"
+    assert second == "VR_71-sn-ABC123"
+
+
+def test_build_bus_device_key_prefers_mac_when_serial_missing() -> None:
+    assert (
+        build_bus_device_key(
+            model="BASV2",
+            address=0x15,
+            mac_address="AA:BB:CC:DD:EE:FF",
+        )
+        == "BASV2-mac-aabbccddeeff"
+    )
+    assert (
+        build_bus_device_key(
+            model="BASV2",
+            address=0x16,
+            mac_address="aa-bb-cc-dd-ee-ff",
+        )
+        == "BASV2-mac-aabbccddeeff"
+    )
+
+
+def test_build_bus_device_key_falls_back_to_model_address_hw_sw() -> None:
+    assert (
+        build_bus_device_key(
+            model="BASV2",
+            address=0x15,
+            hardware_version="7",
+            software_version="0125",
+        )
+        == "BASV2-15-7-0125"
+    )
+
+
+def test_resolve_bus_address_uses_alias_list_when_available() -> None:
+    assert resolve_bus_address(0x15, [0x08, "0x15"]) == 0x08
+    assert resolve_bus_address("0x26", None) == 0x26
+    assert resolve_bus_address(None, None) is None
+
+
+def test_alias_faces_share_fallback_key_when_alias_addresses_match() -> None:
+    first_address = resolve_bus_address(0x08, [0x08, 0x15])
+    second_address = resolve_bus_address(0x15, [0x08, 0x15])
+    assert first_address == second_address == 0x08
+    first_key = build_bus_device_key(
+        model="VRC 720f/2",
+        address=first_address,
+        hardware_version="7",
+        software_version="0125",
+    )
+    second_key = build_bus_device_key(
+        model="VRC 720f/2",
+        address=second_address,
+        hardware_version="7",
+        software_version="0125",
+    )
+    assert first_key == second_key
 
 
 def test_identifier_helpers_are_deterministic() -> None:
     assert daemon_identifier("entry-1") == ("helianthus", "daemon-entry-1")
     assert adapter_identifier("entry-1") == ("helianthus", "adapter-entry-1")
-    assert bus_identifier("entry-1", "BASV2-15") == ("helianthus", "entry-1-bus-BASV2-15")
+    assert bus_identifier("entry-1", "BASV2-sn-ABC123") == ("helianthus", "entry-1-bus-BASV2-sn-ABC123")
     assert zone_identifier("entry-1", "1") == ("helianthus", "entry-1-zone-1")
     assert dhw_identifier("entry-1") == ("helianthus", "entry-1-dhw")
     assert energy_identifier("entry-1") == ("helianthus", "entry-1-energy")


### PR DESCRIPTION
## Summary
- query `Device.addresses` when available and gracefully fall back if the field is missing
- use stable physical device key priority (serial -> mac -> model+addr+hw/sw fallback)
- normalize canonical eBUS address from `address`/`addresses` so alias faces map to one HA physical device
- deduplicate bus-address diagnostics per physical key while keeping regulator-linked virtual entities (zones/DHW/energy)

## Validation
- `pytest -q`

Closes #86