### PR TITLE
MCP-10-301: parity-gate readiness checks for HA integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,4 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install pytest
       - run: python -m pytest
+      - run: python scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json

--- a/custom_components/helianthus/parity_gate.py
+++ b/custom_components/helianthus/parity_gate.py
@@ -1,0 +1,76 @@
+"""Gateway parity-gate artifact validation for HA rollout readiness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_SOURCE_REPO = "d3vi1/helianthus-ebusgateway"
+REQUIRED_GATES = ("parity_contract", "tool_classification")
+
+
+class ParityGateValidationError(RuntimeError):
+    """Raised when parity gate artifact validation fails."""
+
+
+def load_gateway_parity_artifact(path: str | Path) -> dict[str, Any]:
+    artifact_path = Path(path)
+    try:
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ParityGateValidationError(f"parity artifact missing: {artifact_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ParityGateValidationError(f"parity artifact is invalid json: {artifact_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ParityGateValidationError("parity artifact root must be a JSON object")
+    return payload
+
+
+def validate_gateway_parity_artifact(
+    payload: dict[str, Any],
+    expected_source_repo: str = REQUIRED_SOURCE_REPO,
+) -> list[str]:
+    errors: list[str] = []
+
+    source_repo = str(payload.get("source_repo", "")).strip()
+    if source_repo != expected_source_repo:
+        errors.append(
+            f"source_repo mismatch: got={source_repo or '<empty>'} expected={expected_source_repo}"
+        )
+
+    source_ref = str(payload.get("source_ref", "")).strip()
+    if not source_ref:
+        errors.append("source_ref missing")
+
+    generated_at = str(payload.get("generated_at", "")).strip()
+    if not generated_at:
+        errors.append("generated_at missing")
+
+    gates = payload.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("gates missing or invalid")
+        return errors
+
+    for gate_name in REQUIRED_GATES:
+        gate = gates.get(gate_name)
+        if not isinstance(gate, dict):
+            errors.append(f"gate {gate_name} missing")
+            continue
+        status = str(gate.get("status", "")).strip().lower()
+        if status != "pass":
+            errors.append(f"gate {gate_name} status is {status or '<empty>'}, expected pass")
+
+    return errors
+
+
+def enforce_gateway_parity_gate(
+    artifact_path: str | Path,
+    expected_source_repo: str = REQUIRED_SOURCE_REPO,
+) -> dict[str, Any]:
+    payload = load_gateway_parity_artifact(artifact_path)
+    errors = validate_gateway_parity_artifact(payload, expected_source_repo=expected_source_repo)
+    if errors:
+        raise ParityGateValidationError("; ".join(errors))
+    return payload

--- a/scripts/check_gateway_parity_gate.py
+++ b/scripts/check_gateway_parity_gate.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate gateway parity gate artifact for HA integration rollout readiness."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.helianthus.parity_gate import (
+    ParityGateValidationError,
+    enforce_gateway_parity_gate,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate gateway parity gate artifact")
+    parser.add_argument(
+        "--artifact",
+        required=True,
+        help="Path to gateway parity gate artifact JSON",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default="d3vi1/helianthus-ebusgateway",
+        help="Expected gateway source repository",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        enforce_gateway_parity_gate(args.artifact, expected_source_repo=args.source_repo)
+    except ParityGateValidationError as exc:
+        print(f"Gateway parity gate: FAIL ({exc})")
+        return 1
+
+    print("Gateway parity gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -13,6 +13,9 @@ fi
 echo "==> python tests"
 pytest
 
+echo "==> gateway parity gate readiness"
+python3 scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/tests/fixtures/gateway_parity_artifact_pass.json
+++ b/tests/fixtures/gateway_parity_artifact_pass.json
@@ -1,0 +1,15 @@
+{
+  "source_repo": "d3vi1/helianthus-ebusgateway",
+  "source_ref": "refs/heads/mcpfirst-cruise-control",
+  "generated_at": "2026-02-24T00:00:00Z",
+  "gates": {
+    "parity_contract": {
+      "status": "pass",
+      "details": "mcp parity_contract_test passed"
+    },
+    "tool_classification": {
+      "status": "pass",
+      "details": "mcp tool_classification_test passed"
+    }
+  }
+}

--- a/tests/test_parity_gate.py
+++ b/tests/test_parity_gate.py
@@ -1,0 +1,114 @@
+"""Tests for gateway parity-gate readiness validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from custom_components.helianthus import parity_gate
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).resolve().parent / "fixtures" / name
+
+
+def _load_script_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "check_gateway_parity_gate.py"
+    spec = importlib.util.spec_from_file_location("check_gateway_parity_gate", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_enforce_gateway_parity_gate_pass_fixture() -> None:
+    payload = parity_gate.enforce_gateway_parity_gate(_fixture_path("gateway_parity_artifact_pass.json"))
+
+    assert payload["source_repo"] == "d3vi1/helianthus-ebusgateway"
+    assert payload["gates"]["parity_contract"]["status"] == "pass"
+    assert payload["gates"]["tool_classification"]["status"] == "pass"
+
+
+def test_validate_gateway_parity_artifact_missing_gate() -> None:
+    payload = {
+        "source_repo": "d3vi1/helianthus-ebusgateway",
+        "source_ref": "refs/heads/mcpfirst-cruise-control",
+        "generated_at": "2026-02-24T00:00:00Z",
+        "gates": {
+            "parity_contract": {"status": "pass"},
+        },
+    }
+
+    errors = parity_gate.validate_gateway_parity_artifact(payload)
+
+    assert "gate tool_classification missing" in errors
+
+
+def test_enforce_gateway_parity_gate_rejects_failed_status(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "source_repo": "d3vi1/helianthus-ebusgateway",
+                "source_ref": "refs/heads/mcpfirst-cruise-control",
+                "generated_at": "2026-02-24T00:00:00Z",
+                "gates": {
+                    "parity_contract": {"status": "fail"},
+                    "tool_classification": {"status": "pass"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(parity_gate.ParityGateValidationError):
+        parity_gate.enforce_gateway_parity_gate(artifact)
+
+
+def test_enforce_gateway_parity_gate_rejects_invalid_json(tmp_path: Path) -> None:
+    artifact = tmp_path / "invalid.json"
+    artifact.write_text("{", encoding="utf-8")
+
+    with pytest.raises(parity_gate.ParityGateValidationError):
+        parity_gate.enforce_gateway_parity_gate(artifact)
+
+
+def test_check_gateway_parity_script_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_gateway_parity_gate.py",
+            "--artifact",
+            str(_fixture_path("gateway_parity_artifact_pass.json")),
+        ],
+    )
+
+    assert module.main() == 0
+
+
+def test_check_gateway_parity_script_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script_module()
+    artifact = tmp_path / "missing_gate.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "source_repo": "d3vi1/helianthus-ebusgateway",
+                "source_ref": "refs/heads/mcpfirst-cruise-control",
+                "generated_at": "2026-02-24T00:00:00Z",
+                "gates": {
+                    "parity_contract": {"status": "pass"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["check_gateway_parity_gate.py", "--artifact", str(artifact)])
+
+    assert module.main() == 1


### PR DESCRIPTION
## Summary
- add gateway parity-gate artifact validator (`custom_components/helianthus/parity_gate.py`)
- add CI/local readiness check script (`scripts/check_gateway_parity_gate.py`)
- add parity artifact pass fixture and tests (`tests/test_parity_gate.py`)
- wire parity-gate readiness into CI profiles:
  - `.github/workflows/ci.yml`
  - `scripts/ci_local.sh`

## Validation
- pytest tests/test_parity_gate.py -q
- pytest -q
- ./scripts/ci_local.sh

Fixes #88
