### PR TITLE
MCP-10-302: consumer rollout guardrail policy (post-parity only)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,6 +32,11 @@ Device IDs must be stable and deterministic.
 
 The integration consumes a semantic GraphQL layer (zones, dhw, energy, errors). If only raw device/plane/method is available, the integration uses a minimal fallback and exposes diagnostics only.
 
+## MCP-first Consumer Guardrails
+
+Consumer rollout is blocked until gateway parity artifacts report green status for parity and classification gates.
+The blocker mapping and operator policy are defined in `MCP_FIRST_ROLLOUT_GUARDRAILS.md`.
+
 ## Energy Indexing
 
 Expose monotonic totals only:

--- a/MCP_FIRST_ROLLOUT_GUARDRAILS.md
+++ b/MCP_FIRST_ROLLOUT_GUARDRAILS.md
@@ -1,0 +1,34 @@
+# MCP-first Rollout Guardrails (HA Integration)
+
+## Policy
+
+Home Assistant capability rollout is blocked until gateway parity artifacts are green.
+No new consumer-facing capability may be enabled while any blocker below is active.
+
+## Blocker Map (Gateway Output -> HA Blocker)
+
+| Blocker ID | Gateway artifact field | Required value | Effect in HA integration |
+|---|---|---|---|
+| `BLOCKER_GATEWAY_SOURCE_MISMATCH` | `source_repo` | `d3vi1/helianthus-ebusgateway` | Rollout blocked; artifact rejected |
+| `BLOCKER_GATEWAY_SOURCE_REF_MISSING` | `source_ref` | non-empty | Rollout blocked; artifact rejected |
+| `BLOCKER_GATEWAY_PARITY_CONTRACT` | `gates.parity_contract.status` | `pass` | Rollout blocked; parity gate not satisfied |
+| `BLOCKER_GATEWAY_TOOL_CLASSIFICATION` | `gates.tool_classification.status` | `pass` | Rollout blocked; cleanup/classification gate not satisfied |
+
+## Enforcement Path
+
+The guardrail is enforced via:
+
+- `custom_components/helianthus/parity_gate.py`
+- `scripts/check_gateway_parity_gate.py`
+- CI profile checks (`scripts/ci_local.sh` and `.github/workflows/ci.yml`)
+
+## Operator Check
+
+Run before enabling new HA capabilities:
+
+```bash
+python3 scripts/check_gateway_parity_gate.py \
+  --artifact tests/fixtures/gateway_parity_artifact_pass.json
+```
+
+A non-zero exit code means rollout remains blocked.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ python3 scripts/ha_inventory_verifier.py \
 | GraphQL client tests | `python3 -m pytest tests/test_graphql.py` |
 | device identity tests | `python3 -m pytest tests/test_device_ids.py` |
 | smoke profile tests | `python3 -m pytest tests/test_smoke_profile.py` |
+| parity gate tests | `python3 -m pytest tests/test_parity_gate.py` |
+| gateway parity guardrail check | `python3 scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json` |
 | HA inventory verifier tests | `python3 -m pytest tests/test_ha_inventory_verifier.py` |
 | smoke CLI help | `python3 -m custom_components.helianthus.smoke_profile --help` |
 | HA inventory verifier CLI help | `python3 scripts/ha_inventory_verifier.py --help` |
@@ -149,6 +151,7 @@ python3 scripts/ha_inventory_verifier.py \
 ### Local docs in this repo
 
 - Architecture baseline: `ARCHITECTURE.md`
+- MCP-first rollout guardrails: `MCP_FIRST_ROLLOUT_GUARDRAILS.md`
 - Working conventions: `CONVENTIONS.md`
 - Agent workflow instructions: `AGENT.md`
 


### PR DESCRIPTION
## Summary
- document MCP-first consumer rollout guardrail policy for HA integration
- add explicit blocker map from gateway gate outputs to HA rollout blockers
- wire docs references from `README.md` and `ARCHITECTURE.md`

## Validation
- ./scripts/ci_local.sh

Fixes #89
