### PR TITLE
MCP-10-303: controlled post-parity capability adoption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
       - run: python -m pip install pytest
       - run: python -m pytest
       - run: python scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json
+      - run: python scripts/run_post_parity_adoption_checks.py --artifact tests/fixtures/gateway_parity_artifact_pass.json

--- a/MCP_FIRST_ROLLOUT_GUARDRAILS.md
+++ b/MCP_FIRST_ROLLOUT_GUARDRAILS.md
@@ -20,6 +20,7 @@ The guardrail is enforced via:
 
 - `custom_components/helianthus/parity_gate.py`
 - `scripts/check_gateway_parity_gate.py`
+- `scripts/run_post_parity_adoption_checks.py`
 - CI profile checks (`scripts/ci_local.sh` and `.github/workflows/ci.yml`)
 
 ## Operator Check
@@ -32,3 +33,10 @@ python3 scripts/check_gateway_parity_gate.py \
 ```
 
 A non-zero exit code means rollout remains blocked.
+
+For adopted HA capabilities, run guarded tests:
+
+```bash
+python3 scripts/run_post_parity_adoption_checks.py \
+  --artifact tests/fixtures/gateway_parity_artifact_pass.json
+```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ python3 scripts/ha_inventory_verifier.py \
 | device identity tests | `python3 -m pytest tests/test_device_ids.py` |
 | smoke profile tests | `python3 -m pytest tests/test_smoke_profile.py` |
 | parity gate tests | `python3 -m pytest tests/test_parity_gate.py` |
+| post-parity adoption tests | `python3 -m pytest tests/test_post_parity_adoption_checks.py` |
 | gateway parity guardrail check | `python3 scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json` |
+| guarded post-parity adoption run | `python3 scripts/run_post_parity_adoption_checks.py --artifact tests/fixtures/gateway_parity_artifact_pass.json` |
 | HA inventory verifier tests | `python3 -m pytest tests/test_ha_inventory_verifier.py` |
 | smoke CLI help | `python3 -m custom_components.helianthus.smoke_profile --help` |
 | HA inventory verifier CLI help | `python3 scripts/ha_inventory_verifier.py --help` |

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -16,6 +16,9 @@ pytest
 echo "==> gateway parity gate readiness"
 python3 scripts/check_gateway_parity_gate.py --artifact tests/fixtures/gateway_parity_artifact_pass.json
 
+echo "==> post-parity adoption checks"
+python3 scripts/run_post_parity_adoption_checks.py --artifact tests/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/scripts/run_post_parity_adoption_checks.py
+++ b/scripts/run_post_parity_adoption_checks.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Run HA post-parity adoption checks only when gateway parity gate is green."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.helianthus import parity_gate
+
+ADOPTED_CAPABILITY_TESTS = (
+    "tests/test_coordinator.py",
+    "tests/test_energy.py",
+    "tests/test_smoke_profile.py",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run post-parity HA adoption checks")
+    parser.add_argument(
+        "--artifact",
+        required=True,
+        help="Path to gateway parity artifact JSON",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default="d3vi1/helianthus-ebusgateway",
+        help="Expected gateway source repository",
+    )
+    parser.add_argument(
+        "--tests",
+        nargs="+",
+        default=list(ADOPTED_CAPABILITY_TESTS),
+        help="pytest targets for adopted capabilities",
+    )
+    return parser.parse_args()
+
+
+def run_post_parity_checks(artifact: str, source_repo: str, tests: list[str]) -> int:
+    try:
+        parity_gate.enforce_gateway_parity_gate(artifact, expected_source_repo=source_repo)
+    except parity_gate.ParityGateValidationError as exc:
+        print(f"Post-parity adoption checks blocked: {exc}")
+        return 1
+
+    cmd = ["pytest", *tests]
+    print(f"Running adopted capability checks: {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT), check=False)
+    return int(result.returncode)
+
+
+def main() -> int:
+    args = parse_args()
+    return run_post_parity_checks(args.artifact, args.source_repo, args.tests)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_post_parity_adoption_checks.py
+++ b/tests/test_post_parity_adoption_checks.py
@@ -1,0 +1,135 @@
+"""Tests for post-parity adoption check runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+
+class _RunResult:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "run_post_parity_adoption_checks.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_post_parity_adoption_checks", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_post_parity_checks_blocked_on_gate_failure(monkeypatch) -> None:
+    module = _load_module()
+
+    def _raise_gate_error(*_args, **_kwargs):
+        raise module.parity_gate.ParityGateValidationError("gate failed")
+
+    monkeypatch.setattr(module.parity_gate, "enforce_gateway_parity_gate", _raise_gate_error)
+
+    called = {"value": False}
+
+    def _unexpected_run(*_args, **_kwargs):
+        called["value"] = True
+        return _RunResult(0)
+
+    monkeypatch.setattr(module.subprocess, "run", _unexpected_run)
+
+    exit_code = module.run_post_parity_checks(
+        artifact="tests/fixtures/gateway_parity_artifact_pass.json",
+        source_repo="d3vi1/helianthus-ebusgateway",
+        tests=["tests/test_energy.py"],
+    )
+
+    assert exit_code == 1
+    assert called["value"] is False
+
+
+def test_run_post_parity_checks_runs_pytest_when_gate_passes(monkeypatch) -> None:
+    module = _load_module()
+
+    def _ok_gate(*_args, **_kwargs):
+        return {
+            "source_repo": "d3vi1/helianthus-ebusgateway",
+            "gates": {
+                "parity_contract": {"status": "pass"},
+                "tool_classification": {"status": "pass"},
+            },
+        }
+
+    monkeypatch.setattr(module.parity_gate, "enforce_gateway_parity_gate", _ok_gate)
+
+    captured = {"cmd": None, "cwd": None}
+
+    def _fake_run(cmd, cwd=None, check=False):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        assert check is False
+        return _RunResult(0)
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    tests = ["tests/test_coordinator.py", "tests/test_energy.py"]
+    exit_code = module.run_post_parity_checks(
+        artifact="tests/fixtures/gateway_parity_artifact_pass.json",
+        source_repo="d3vi1/helianthus-ebusgateway",
+        tests=tests,
+    )
+
+    assert exit_code == 0
+    assert captured["cmd"][0] == "pytest"
+    assert captured["cmd"][1:] == tests
+    assert captured["cwd"] == str(module.REPO_ROOT)
+
+
+def test_run_post_parity_checks_propagates_pytest_failure(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module.parity_gate,
+        "enforce_gateway_parity_gate",
+        lambda *_args, **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(module.subprocess, "run", lambda *_args, **_kwargs: _RunResult(2))
+
+    exit_code = module.run_post_parity_checks(
+        artifact="tests/fixtures/gateway_parity_artifact_pass.json",
+        source_repo="d3vi1/helianthus-ebusgateway",
+        tests=["tests/test_smoke_profile.py"],
+    )
+
+    assert exit_code == 2
+
+
+def test_main_uses_cli_arguments(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_post_parity_adoption_checks.py",
+            "--artifact",
+            "tests/fixtures/gateway_parity_artifact_pass.json",
+            "--tests",
+            "tests/test_energy.py",
+        ],
+    )
+
+    monkeypatch.setattr(
+        module,
+        "run_post_parity_checks",
+        lambda artifact, source_repo, tests: 0
+        if artifact == "tests/fixtures/gateway_parity_artifact_pass.json"
+        and source_repo == "d3vi1/helianthus-ebusgateway"
+        and tests == ["tests/test_energy.py"]
+        else 1,
+    )
+
+    assert module.main() == 0


### PR DESCRIPTION
## Summary
- add guarded post-parity adoption runner (`scripts/run_post_parity_adoption_checks.py`)
- ensure adopted capability tests run only after gateway parity artifact validation succeeds
- add tests for blocked/pass/failure paths (`tests/test_post_parity_adoption_checks.py`)
- wire guarded adoption run into CI profiles and guardrail docs

## Validation
- pytest tests/test_post_parity_adoption_checks.py -q
- pytest -q
- ./scripts/ci_local.sh

Fixes #90
