### PR TITLE
HA-5: reduced boiler sensors + pump binary sensor (FAIL profile)

### DIFF
--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -28,6 +28,8 @@ def _normalize_preset(value: Any) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
+    boiler_coordinator = data.get("boiler_coordinator")
+    boiler_device_id = data.get("boiler_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
     zones = coordinator.data.get("zones", []) if coordinator.data else []
@@ -74,6 +76,15 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     schedule_label=schedule_label,
                 )
             )
+
+    if boiler_coordinator and boiler_device_id:
+        entities.append(
+            HelianthusBoilerPumpBinarySensor(
+                coordinator=boiler_coordinator,
+                entry_id=entry.entry_id,
+                boiler_device_id=boiler_device_id,
+            )
+        )
 
     async_add_entities(entities)
 
@@ -145,3 +156,35 @@ class HelianthusScheduleBinarySensor(CoordinatorEntity, BinarySensorEntity):
             model=model,
             name=name,
         )
+
+
+class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Reduced-profile central heating pump state on physical BAI00."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        boiler_device_id: tuple[str, str],
+    ) -> None:
+        super().__init__(coordinator)
+        self._boiler_device_id = boiler_device_id
+        self._attr_name = "Boiler Central Heating Pump Active"
+        self._attr_unique_id = f"{entry_id}-boiler-central-heating-pump-active"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={self._boiler_device_id})
+
+    @property
+    def is_on(self) -> bool | None:
+        payload = self.coordinator.data or {}
+        boiler_status = payload.get("boilerStatus") or {}
+        state = boiler_status.get("state") or {}
+        value = state.get("centralHeatingPumpActive")
+        if isinstance(value, bool):
+            return value
+        return None

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
-from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfEnergy
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfEnergy, UnitOfTemperature
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -28,6 +28,12 @@ class InventoryField:
     name: str
 
 
+@dataclass(frozen=True)
+class BoilerTemperatureField:
+    key: str
+    label: str
+
+
 STATUS_FIELDS = [
     InventoryField("status", "Status"),
     InventoryField("firmwareVersion", "Firmware Version"),
@@ -39,6 +45,13 @@ DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
 ]
 
 ADAPTER_STATUS_FIELDS = STATUS_FIELDS
+
+REDUCED_BOILER_TEMPERATURE_FIELDS = [
+    BoilerTemperatureField("flowTemperatureC", "Flow Temperature"),
+    BoilerTemperatureField("returnTemperatureC", "Return Temperature"),
+    BoilerTemperatureField("dhwTemperatureC", "DHW Temperature"),
+    BoilerTemperatureField("dhwStorageTemperatureC", "DHW Storage Temperature"),
+]
 
 
 def _clean_text(value: object | None) -> str | None:
@@ -54,6 +67,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     status_coordinator = data["status_coordinator"]
     semantic_coordinator = data.get("semantic_coordinator")
     energy_coordinator = data.get("energy_coordinator")
+    boiler_coordinator = data.get("boiler_coordinator")
+    boiler_device_id = data.get("boiler_device_id")
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
@@ -103,6 +118,17 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         )
         for field in ADAPTER_STATUS_FIELDS
     )
+
+    if boiler_coordinator and boiler_device_id:
+        sensors.extend(
+            HelianthusBoilerTemperatureSensor(
+                boiler_coordinator,
+                entry.entry_id,
+                boiler_device_id,
+                field,
+            )
+            for field in REDUCED_BOILER_TEMPERATURE_FIELDS
+        )
 
     if semantic_coordinator and semantic_coordinator.data:
         zones = semantic_coordinator.data.get("zones", []) or []
@@ -211,6 +237,41 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         return self._status.get(self._field.key)
+
+
+class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
+    """Reduced-profile boiler temperature sensor on physical BAI00."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        boiler_device_id: tuple[str, str],
+        field: BoilerTemperatureField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._boiler_device_id = boiler_device_id
+        self._field = field
+        self._attr_name = f"Boiler {field.label}"
+        self._attr_unique_id = f"{entry_id}-boiler-{field.key}"
+
+    def _boiler_state(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        boiler_status = payload.get("boilerStatus") or {}
+        return boiler_status.get("state") or {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={self._boiler_device_id})
+
+    @property
+    def native_value(self) -> Any:
+        state = self._boiler_state()
+        return state.get(self._field.key)
 
 
 class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,151 @@
+"""Tests for reduced boiler binary sensors."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    binary_sensor_module = sys.modules.setdefault(
+        "homeassistant.components.binary_sensor",
+        types.ModuleType("homeassistant.components.binary_sensor"),
+    )
+
+    if not hasattr(binary_sensor_module, "BinarySensorEntity"):
+        class _BinarySensorEntity:
+            pass
+
+        binary_sensor_module.BinarySensorEntity = _BinarySensorEntity
+
+    if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
+        class _BinarySensorDeviceClass:
+            RUNNING = "running"
+
+        binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import binary_sensor as binary_sensor_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
+    return {
+        "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
+        "boiler_coordinator": _FakeCoordinator(
+            {"boilerStatus": {"state": {"centralHeatingPumpActive": True}}}
+        ),
+        "boiler_device_id": boiler_device_id,
+        "boiler_physical_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
+        "boiler_burner_device_id": ("helianthus", "entry-1-boiler-burner"),
+        "boiler_hydraulics_device_id": ("helianthus", "entry-1-boiler-hydraulics"),
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_async_setup_entry_adds_reduced_boiler_pump_binary_sensor_on_bai00_only() -> None:
+    boiler_device_id = ("helianthus", "entry-1-bus-BAI00-08")
+    payload = _build_payload(boiler_device_id=boiler_device_id)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    pump_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusBoilerPumpBinarySensor)
+    ]
+
+    assert len(pump_entities) == 1
+    pump = pump_entities[0]
+    assert pump._attr_name == "Boiler Central Heating Pump Active"
+    assert pump._attr_unique_id == "entry-1-boiler-central-heating-pump-active"
+    assert pump._attr_device_class == binary_sensor_platform.BinarySensorDeviceClass.RUNNING
+    assert pump.is_on is True
+    assert pump.device_info["identifiers"] == {boiler_device_id}
+    assert payload["boiler_burner_device_id"] not in pump.device_info["identifiers"]
+    assert payload["boiler_hydraulics_device_id"] not in pump.device_info["identifiers"]
+
+
+def test_async_setup_entry_skips_reduced_boiler_pump_without_physical_bai00() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    pump_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusBoilerPumpBinarySensor)
+    ]
+
+    assert pump_entities == []

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,214 @@
+"""Tests for reduced boiler sensors in sensor platform."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
+    return {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": None,
+        "energy_coordinator": None,
+        "boiler_coordinator": _FakeCoordinator(
+            {
+                "boilerStatus": {
+                    "state": {
+                        "flowTemperatureC": 63.1,
+                        "returnTemperatureC": 51.0,
+                        "dhwTemperatureC": 49.5,
+                        "dhwStorageTemperatureC": 46.2,
+                    }
+                }
+            }
+        ),
+        "boiler_device_id": boiler_device_id,
+        "boiler_physical_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
+        "boiler_burner_device_id": ("helianthus", "entry-1-boiler-burner"),
+        "boiler_hydraulics_device_id": ("helianthus", "entry-1-boiler-hydraulics"),
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_async_setup_entry_adds_reduced_boiler_temperature_sensors_on_bai00_only() -> None:
+    boiler_device_id = ("helianthus", "entry-1-bus-BAI00-08")
+    payload = _build_payload(boiler_device_id=boiler_device_id)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusBoilerTemperatureSensor)
+    ]
+
+    assert len(boiler_entities) == 4
+    assert {entity._attr_unique_id for entity in boiler_entities} == {
+        "entry-1-boiler-flowTemperatureC",
+        "entry-1-boiler-returnTemperatureC",
+        "entry-1-boiler-dhwTemperatureC",
+        "entry-1-boiler-dhwStorageTemperatureC",
+    }
+    assert {entity._attr_name for entity in boiler_entities} == {
+        "Boiler Flow Temperature",
+        "Boiler Return Temperature",
+        "Boiler DHW Temperature",
+        "Boiler DHW Storage Temperature",
+    }
+    assert {entity.native_value for entity in boiler_entities} == {
+        63.1,
+        51.0,
+        49.5,
+        46.2,
+    }
+
+    for entity in boiler_entities:
+        assert entity._attr_device_class == sensor_platform.SensorDeviceClass.TEMPERATURE
+        assert (
+            entity._attr_native_unit_of_measurement
+            == sensor_platform.UnitOfTemperature.CELSIUS
+        )
+        assert entity._attr_state_class == sensor_platform.SensorStateClass.MEASUREMENT
+        assert entity.device_info["identifiers"] == {boiler_device_id}
+        assert payload["boiler_burner_device_id"] not in entity.device_info["identifiers"]
+        assert payload["boiler_hydraulics_device_id"] not in entity.device_info["identifiers"]
+
+
+def test_async_setup_entry_skips_reduced_boiler_sensors_without_physical_bai00() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusBoilerTemperatureSensor)
+    ]
+
+    assert boiler_entities == []


### PR DESCRIPTION
## What
Implements HA-5 on FAIL/reduced profile by adding boiler sensor + binary sensor entities bound to the physical BAI00 device.

## Why
After HA-1 wiring, reduced-profile boiler entities are required for observable boiler state on HA while B509/full PASS profile remains out of scope.

## Key Changes
- Added reduced boiler temperature sensors (BAI00):
  - `flowTemperatureC`
  - `returnTemperatureC`
  - `dhwTemperatureC`
  - `dhwStorageTemperatureC`
- Added reduced boiler binary sensor (BAI00):
  - `centralHeatingPumpActive`
- Enforced FAIL profile scope:
  - no Burner entities
  - no Hydraulics entities
- Added/updated tests in sensor + binary_sensor suites.

## Validation
- `pytest tests/`
  - `72 passed`

Fixes #116
