### PR TITLE
HA-6: circuit coordinator and entities

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -138,7 +138,11 @@ def _identifier_belongs_to_entry(token: str, entry_id: str) -> bool:
         f"{entry_id}-energy",
         f"{entry_id}-boiler-burner",
         f"{entry_id}-boiler-hydraulics",
-    } or token.startswith(f"{entry_id}-bus-") or token.startswith(f"{entry_id}-zone-")
+    } or (
+        token.startswith(f"{entry_id}-bus-")
+        or token.startswith(f"{entry_id}-zone-")
+        or token.startswith(f"{entry_id}-circuit-")
+    )
 
 
 def _identifier_matches_any_entry(token: str, active_entry_ids: set[str]) -> bool:
@@ -203,6 +207,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .graphql import GraphQLClient, build_graphql_url
     from .coordinator import (
         HelianthusBoilerCoordinator,
+        HelianthusCircuitCoordinator,
         HelianthusCoordinator,
         HelianthusEnergyCoordinator,
         HelianthusSemanticCoordinator,
@@ -214,7 +219,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         boiler_hydraulics_identifier,
         build_bus_device_key,
         bus_identifier,
+        circuit_identifier,
         daemon_identifier,
+        managing_device_identifier,
         resolve_bus_address,
         resolve_boiler_physical_device_id,
         resolve_boiler_via_device_id,
@@ -316,11 +323,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     status_coordinator = HelianthusStatusCoordinator(hass, client, scan_interval)
     semantic_coordinator = HelianthusSemanticCoordinator(hass, client, scan_interval)
     energy_coordinator = HelianthusEnergyCoordinator(hass, client, scan_interval)
+    circuit_coordinator = HelianthusCircuitCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
     await status_coordinator.async_config_entry_first_refresh()
     await semantic_coordinator.async_config_entry_first_refresh()
     await energy_coordinator.async_config_entry_first_refresh()
+    await circuit_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
 
     devices = device_coordinator.data or []
@@ -358,6 +367,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             or "SENSOCOMFORT" in display_name
             or "SENSOCOMFORT" in product_family
         )
+
+    def parse_circuit_index(circuit: dict) -> int | None:
+        index = circuit.get("index")
+        if isinstance(index, bool):
+            return None
+        try:
+            parsed = int(index)
+        except (TypeError, ValueError):
+            return None
+        if parsed < 0:
+            return None
+        return parsed
+
+    def circuit_type_display_name(value: object | None) -> str:
+        token = str(value or "").strip().lower()
+        return {
+            "heating": "Heating",
+            "fixed_value": "Fixed Value",
+            "dhw": "DHW",
+            "return_increase": "Return Increase",
+        }.get(token, token.replace("_", " ").title() or "Circuit")
 
     known_bus_devices: set[str] = set()
     regulator_device: tuple[str, str] | None = None
@@ -423,6 +453,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if mfr:
                 regulator_manufacturer = mfr
                 break
+
+    circuits_payload = circuit_coordinator.data or {}
+    circuits = circuits_payload.get("circuits", []) or []
+    known_circuit_indexes: set[int] = set()
+    fm5_config: int | None = None
+    vr71_circuit_start = -1
+    for circuit in circuits:
+        if not isinstance(circuit, dict):
+            continue
+        index = parse_circuit_index(circuit)
+        if index is None:
+            continue
+        known_circuit_indexes.add(index)
+        circuit_type_name = circuit_type_display_name(circuit.get("circuitType"))
+        managing_device = managing_device_identifier(
+            group=0x02,
+            instance=index,
+            regulator_device_id=regulator_device,
+            vr71_device_id=vr71_device,
+            adapter_device_id=adapter_device_id,
+            fm5_config=fm5_config,
+            vr71_circuit_start=vr71_circuit_start,
+        )
+        circuit_device_id = circuit_identifier(entry.entry_id, index)
+        device_kwargs: dict[str, object] = {
+            "config_entry_id": entry.entry_id,
+            "identifiers": {circuit_device_id},
+            "manufacturer": regulator_manufacturer,
+            "model": circuit_type_name,
+            "name": f"Circuit {index + 1} ({circuit_type_name})",
+        }
+        if managing_device is not None:
+            device_kwargs["via_device"] = managing_device
+        device_registry.async_get_or_create(**device_kwargs)
 
     daemon_data = status_coordinator.data.get("daemon", {}) if status_coordinator.data else {}
     daemon_source_addr = _parse_bus_address(daemon_data.get("initiatorAddress"))
@@ -529,9 +593,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if has_new_zones or has_new_dhw:
             schedule_reload("semantic inventory became available")
 
+    def handle_circuit_update() -> None:
+        payload = circuit_coordinator.data or {}
+        current_indexes: set[int] = set()
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            index = parse_circuit_index(circuit)
+            if index is not None:
+                current_indexes.add(index)
+        if current_indexes - known_circuit_indexes:
+            schedule_reload("circuit inventory became available")
+
     unsub_listeners: list[Callable[[], None]] = []
     unsub_listeners.append(device_coordinator.async_add_listener(handle_device_update))
     unsub_listeners.append(semantic_coordinator.async_add_listener(handle_semantic_update))
+    unsub_listeners.append(circuit_coordinator.async_add_listener(handle_circuit_update))
 
     for zone_id, helper_entity in zone_schedule_helpers.items():
         @callback
@@ -593,6 +670,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "status_coordinator": status_coordinator,
         "semantic_coordinator": semantic_coordinator,
         "energy_coordinator": energy_coordinator,
+        "circuit_coordinator": circuit_coordinator,
         "boiler_coordinator": boiler_coordinator,
         "graphql_client": client,
         "subscription_task": subscription_task,
@@ -605,6 +683,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "regulator_manufacturer": regulator_manufacturer,
         "regulator_bus_address": regulator_bus_address,
         "daemon_source_address": daemon_source_addr,
+        "fm5_config": fm5_config,
+        "vr71_circuit_start": vr71_circuit_start,
         "boiler_physical_device_id": boiler_physical_device_id,
         "boiler_via_device_id": boiler_via_device_id,
         "boiler_burner_device_id": boiler_burner_device_id,

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -205,6 +205,37 @@ query Semantic {
 }
 """
 
+QUERY_CIRCUITS = """
+query Circuits {
+  circuits {
+    index
+    circuitType
+    hasMixer
+    state {
+      pumpActive
+      mixerPositionPct
+      flowTemperatureC
+      flowSetpointC
+      calcFlowTempC
+      circuitState
+      humidity
+      dewPoint
+      pumpHours
+      pumpStarts
+    }
+    config {
+      heatingCurve
+      flowTempMaxC
+      flowTempMinC
+      summerLimitC
+      frostProtC
+      roomTempControl
+      coolingEnabled
+    }
+  }
+}
+"""
+
 QUERY_ENERGY = """
 query Energy {
   devices {
@@ -373,6 +404,69 @@ class HelianthusSemanticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {
             "zones": payload.get("zones", []) or [],
             "dhw": payload.get("dhw"),
+        }
+
+
+class HelianthusCircuitCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator fetching semantic heating circuit data."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_circuits",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+        self._client = client
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        try:
+            payload = await self._client.execute(QUERY_CIRCUITS)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(
+                exc.errors,
+                [
+                    "circuits",
+                    "index",
+                    "circuitType",
+                    "hasMixer",
+                    "state",
+                    "config",
+                    "pumpActive",
+                    "mixerPositionPct",
+                    "flowTemperatureC",
+                    "flowSetpointC",
+                    "calcFlowTempC",
+                    "circuitState",
+                    "humidity",
+                    "dewPoint",
+                    "pumpHours",
+                    "pumpStarts",
+                    "heatingCurve",
+                    "flowTempMaxC",
+                    "flowTempMinC",
+                    "summerLimitC",
+                    "frostProtC",
+                    "roomTempControl",
+                    "coolingEnabled",
+                ],
+            ):
+                return {"circuits": []}
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            return {"circuits": []}
+        circuits = payload.get("circuits")
+        if not isinstance(circuits, list):
+            return {"circuits": []}
+        return {
+            "circuits": [
+                circuit
+                for circuit in circuits
+                if isinstance(circuit, dict)
+            ]
         }
 
 

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -40,6 +40,23 @@ def _parse_bus_address(value: object | None) -> int | None:
         return None
 
 
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    try:
+        parsed = int(cleaned, 10)
+    except ValueError:
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
 def _normalized_mac(value: object | None) -> str | None:
     cleaned = _clean(value)
     if cleaned is None:
@@ -114,6 +131,12 @@ def zone_identifier(config_entry_id: str, zone_id: str) -> tuple[str, str]:
     return (DOMAIN, f"{_token(config_entry_id)}-zone-{_token(zone_id)}")
 
 
+def circuit_identifier(config_entry_id: str, circuit_index: object) -> DeviceIdentifier:
+    index = _parse_circuit_index(circuit_index)
+    token = str(index) if index is not None else _token(circuit_index)
+    return (DOMAIN, f"{_token(config_entry_id)}-circuit-{token}")
+
+
 def dhw_identifier(config_entry_id: str) -> tuple[str, str]:
     return (DOMAIN, f"{_token(config_entry_id)}-dhw")
 
@@ -151,3 +174,30 @@ def resolve_boiler_via_device_id(
     """Return preferred via_device chain for boiler virtual entities."""
 
     return boiler_device_id or regulator_device_id or adapter_device_id
+
+
+def managing_device_identifier(
+    *,
+    group: int,
+    instance: int,
+    regulator_device_id: DeviceIdentifier | None,
+    vr71_device_id: DeviceIdentifier | None,
+    adapter_device_id: DeviceIdentifier | None = None,
+    fm5_config: int | None = None,
+    vr71_circuit_start: int = -1,
+) -> DeviceIdentifier | None:
+    """Resolve the physical manager device for a semantic sub-device.
+
+    R6 rules:
+    - solar/cylinder groups use VR_71 when FM5 is present;
+    - circuits can use VR_71 starting from `vr71_circuit_start`;
+    - otherwise use controller/regulator, then adapter fallback.
+    """
+
+    if group in (0x04, 0x05) and vr71_device_id and fm5_config is not None:
+        if 1 <= int(fm5_config) <= 2:
+            return vr71_device_id
+    if group == 0x02 and vr71_device_id and vr71_circuit_start >= 0:
+        if instance >= vr71_circuit_start:
+            return vr71_device_id
+    return regulator_device_id or adapter_device_id or vr71_device_id

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -1,8 +1,136 @@
-"""Boiler fan platform stub (HA-1 reduced profile)."""
+"""Circuit fan entities for Helianthus."""
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components.fan import FanEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import circuit_identifier
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+
+
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    """Reduced profile: no fan entities are registered."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("circuit_coordinator")
+    manufacturer = data.get("regulator_manufacturer") or "Helianthus"
+    if coordinator is None or not coordinator.data:
+        async_add_entities([])
+        return
 
+    entities: list[HelianthusCircuitPumpFan] = []
+    for circuit in coordinator.data.get("circuits", []) or []:
+        if not isinstance(circuit, dict):
+            continue
+        index = _parse_circuit_index(circuit.get("index"))
+        if index is None:
+            continue
+        entities.append(
+            HelianthusCircuitPumpFan(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                circuit_index=index,
+                initial_name=_circuit_name(circuit, index),
+            )
+        )
+    async_add_entities(entities)
+
+
+class HelianthusCircuitPumpFan(CoordinatorEntity, FanEntity):
+    """Read-only circuit pump state as a fan entity."""
+
+    _attr_icon = "mdi:pump"
+    _attr_supported_features = 0
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        circuit_index: int,
+        initial_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-pump"
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} Pump"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        circuit = self._circuit()
+        state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
+        value = state.get("pumpActive")
+        if isinstance(value, bool):
+            return value
+        return None
+
+    @property
+    def percentage(self) -> int | None:
+        is_on = self.is_on
+        if is_on is None:
+            return None
+        return 100 if is_on else 0
+
+    @property
+    def speed_count(self) -> int:
+        return 1

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -1,8 +1,231 @@
-"""Boiler number platform stub (HA-1 reduced profile)."""
+"""Number entities for Helianthus circuits."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import circuit_identifier
+from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
+
+_SET_CIRCUIT_CONFIG_MUTATION = """
+mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
+  setCircuitConfig(index: $index, field: $field, value: $value) {
+    success
+    error
+  }
+}
+"""
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+
+
+@dataclass(frozen=True)
+class CircuitNumberField:
+    key: str
+    label: str
+    minimum: float
+    maximum: float
+    step: float
+    unit: str | None = None
+
+
+_CIRCUIT_NUMBER_FIELDS = [
+    CircuitNumberField("heatingCurve", "Heating Curve", 0.1, 4.0, 0.1),
+    CircuitNumberField(
+        "flowTempMaxC",
+        "Flow Temperature Maximum",
+        15.0,
+        80.0,
+        1.0,
+        UnitOfTemperature.CELSIUS,
+    ),
+    CircuitNumberField(
+        "flowTempMinC",
+        "Flow Temperature Minimum",
+        5.0,
+        30.0,
+        1.0,
+        UnitOfTemperature.CELSIUS,
+    ),
+    CircuitNumberField(
+        "summerLimitC",
+        "Summer Limit",
+        15.0,
+        30.0,
+        1.0,
+        UnitOfTemperature.CELSIUS,
+    ),
+    CircuitNumberField(
+        "frostProtC",
+        "Frost Protection",
+        -20.0,
+        10.0,
+        1.0,
+        UnitOfTemperature.CELSIUS,
+    ),
+]
+
+
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    """Reduced profile: no number entities are registered."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("circuit_coordinator")
+    manufacturer = data.get("regulator_manufacturer") or "Helianthus"
+    client = data.get("graphql_client")
+    if coordinator is None or not coordinator.data:
+        async_add_entities([])
+        return
 
+    entities: list[HelianthusCircuitNumber] = []
+    for circuit in coordinator.data.get("circuits", []) or []:
+        if not isinstance(circuit, dict):
+            continue
+        index = _parse_circuit_index(circuit.get("index"))
+        if index is None:
+            continue
+        initial_name = _circuit_name(circuit, index)
+        for field in _CIRCUIT_NUMBER_FIELDS:
+            entities.append(
+                HelianthusCircuitNumber(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    client=client,
+                    circuit_index=index,
+                    initial_name=initial_name,
+                    field=field,
+                )
+            )
+    async_add_entities(entities)
+
+
+class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
+    """Writable circuit configuration number."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        circuit_index: int,
+        initial_name: str,
+        field: CircuitNumberField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._client = client
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._field = field
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-number-{field.key}"
+        self._attr_name = f"{initial_name} {field.label}"
+        self._attr_native_min_value = field.minimum
+        self._attr_native_max_value = field.maximum
+        self._attr_native_step = field.step
+        if field.unit is not None:
+            self._attr_native_unit_of_measurement = field.unit
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} {self._field.label}"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        circuit = self._circuit()
+        config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
+        value = config.get(self._field.key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        if value < self._field.minimum or value > self._field.maximum:
+            raise HomeAssistantError(
+                f"Value {value} outside allowed range [{self._field.minimum}, {self._field.maximum}]"
+            )
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        variables = {
+            "index": int(self._circuit_index),
+            "field": self._field.key,
+            "value": str(float(value)),
+        }
+        try:
+            payload = await self._client.mutation(_SET_CIRCUIT_CONFIG_MUTATION, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = ""
+        if isinstance(result, dict):
+            error = str(result.get("error") or "")
+        message = error or "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {message}")

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -1,8 +1,171 @@
-"""Boiler select platform stub (HA-1 reduced profile)."""
+"""Select entities for Helianthus circuits."""
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import circuit_identifier
+from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
+
+_SET_CIRCUIT_CONFIG_MUTATION = """
+mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
+  setCircuitConfig(index: $index, field: $field, value: $value) {
+    success
+    error
+  }
+}
+"""
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+_OPTIONS = ["off", "modulating", "thermostat"]
+
+
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    """Reduced profile: no select entities are registered."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("circuit_coordinator")
+    manufacturer = data.get("regulator_manufacturer") or "Helianthus"
+    client = data.get("graphql_client")
+    if coordinator is None or not coordinator.data:
+        async_add_entities([])
+        return
 
+    entities: list[HelianthusCircuitRoomTempControlSelect] = []
+    for circuit in coordinator.data.get("circuits", []) or []:
+        if not isinstance(circuit, dict):
+            continue
+        index = _parse_circuit_index(circuit.get("index"))
+        if index is None:
+            continue
+        entities.append(
+            HelianthusCircuitRoomTempControlSelect(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                client=client,
+                circuit_index=index,
+                initial_name=_circuit_name(circuit, index),
+            )
+        )
+    async_add_entities(entities)
+
+
+class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
+    """Circuit room temperature control select."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = _OPTIONS
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        circuit_index: int,
+        initial_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._client = client
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-room-temp-control"
+        self._attr_name = f"{initial_name} Room Temperature Control"
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} Room Temperature Control"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        circuit = self._circuit()
+        config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
+        token = str(config.get("roomTempControl") or "").strip().lower()
+        if token in _OPTIONS:
+            return token
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        token = str(option or "").strip().lower()
+        if token not in _OPTIONS:
+            raise HomeAssistantError(f"Unsupported roomTempControl option: {option}")
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        variables = {
+            "index": int(self._circuit_index),
+            "field": "roomTempControl",
+            "value": token,
+        }
+        try:
+            payload = await self._client.mutation(_SET_CIRCUIT_CONFIG_MUTATION, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = ""
+        if isinstance(result, dict):
+            error = str(result.get("error") or "")
+        message = error or "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {message}")

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -14,6 +14,7 @@ from .const import DOMAIN
 from .device_ids import (
     build_bus_device_key,
     bus_identifier,
+    circuit_identifier,
     dhw_identifier,
     energy_identifier,
     resolve_bus_address,
@@ -32,6 +33,18 @@ class InventoryField:
 class BoilerTemperatureField:
     key: str
     label: str
+
+
+@dataclass(frozen=True)
+class CircuitSensorField:
+    key: str
+    label: str
+    device_class: str | None = None
+    native_unit: str | None = None
+    state_class: str | None = None
+    entity_category: str | None = None
+    cast_int: bool = False
+    include_circuit_attributes: bool = False
 
 
 STATUS_FIELDS = [
@@ -53,6 +66,75 @@ REDUCED_BOILER_TEMPERATURE_FIELDS = [
     BoilerTemperatureField("dhwStorageTemperatureC", "DHW Storage Temperature"),
 ]
 
+_SENSOR_DEVICE_CLASS_HUMIDITY = getattr(SensorDeviceClass, "HUMIDITY", None)
+_SENSOR_DEVICE_CLASS_DURATION = getattr(SensorDeviceClass, "DURATION", None)
+_SENSOR_STATE_CLASS_TOTAL_INCREASING = getattr(SensorStateClass, "TOTAL_INCREASING", None)
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+
+CIRCUIT_SENSOR_FIELDS = [
+    CircuitSensorField(
+        key="flowTemperatureC",
+        label="Flow Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    CircuitSensorField(
+        key="flowSetpointC",
+        label="Flow Setpoint",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    CircuitSensorField(
+        key="calcFlowTempC",
+        label="Calculated Flow Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    CircuitSensorField(
+        key="circuitState",
+        label="State",
+        include_circuit_attributes=True,
+    ),
+    CircuitSensorField(
+        key="humidity",
+        label="Humidity",
+        device_class=_SENSOR_DEVICE_CLASS_HUMIDITY,
+        native_unit=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    CircuitSensorField(
+        key="dewPoint",
+        label="Dew Point",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    CircuitSensorField(
+        key="pumpHours",
+        label="Pump Hours",
+        device_class=_SENSOR_DEVICE_CLASS_DURATION,
+        native_unit="h",
+        state_class=_SENSOR_STATE_CLASS_TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    CircuitSensorField(
+        key="pumpStarts",
+        label="Pump Starts",
+        state_class=_SENSOR_STATE_CLASS_TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        cast_int=True,
+    ),
+]
+
 
 def _clean_text(value: object | None) -> str | None:
     if value is None:
@@ -61,12 +143,31 @@ def _clean_text(value: object | None) -> str | None:
     return cleaned or None
 
 
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     device_coordinator = data["device_coordinator"]
     status_coordinator = data["status_coordinator"]
     semantic_coordinator = data.get("semantic_coordinator")
     energy_coordinator = data.get("energy_coordinator")
+    circuit_coordinator = data.get("circuit_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
@@ -129,6 +230,27 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             )
             for field in REDUCED_BOILER_TEMPERATURE_FIELDS
         )
+
+    if circuit_coordinator and circuit_coordinator.data:
+        circuits = circuit_coordinator.data.get("circuits", []) or []
+        for circuit in circuits:
+            if not isinstance(circuit, dict):
+                continue
+            circuit_index = _parse_circuit_index(circuit.get("index"))
+            if circuit_index is None:
+                continue
+            initial_name = _circuit_name(circuit, circuit_index)
+            for field in CIRCUIT_SENSOR_FIELDS:
+                sensors.append(
+                    HelianthusCircuitSensor(
+                        coordinator=circuit_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        circuit_index=circuit_index,
+                        initial_name=initial_name,
+                        field=field,
+                    )
+                )
 
     if semantic_coordinator and semantic_coordinator.data:
         zones = semantic_coordinator.data.get("zones", []) or []
@@ -272,6 +394,98 @@ class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Any:
         state = self._boiler_state()
         return state.get(self._field.key)
+
+
+class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
+    """Per-circuit sensor values sourced from the circuit coordinator."""
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        circuit_index: int,
+        initial_name: str,
+        field: CircuitSensorField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._field = field
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-sensor-{field.key}"
+        self._attr_name = f"{initial_name} {field.label}"
+        if field.device_class is not None:
+            self._attr_device_class = field.device_class
+        if field.native_unit is not None:
+            self._attr_native_unit_of_measurement = field.native_unit
+        if field.state_class is not None:
+            self._attr_state_class = field.state_class
+        if field.entity_category is not None:
+            self._attr_entity_category = field.entity_category
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} {self._field.label}"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def native_value(self) -> Any:
+        circuit = self._circuit()
+        state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
+        value = state.get(self._field.key)
+        if value is None:
+            return None
+        if self._field.cast_int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+        if isinstance(value, (bool, int, float, str)):
+            return value
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self._field.include_circuit_attributes:
+            return {}
+        circuit = self._circuit()
+        attrs: dict[str, Any] = {
+            "circuit_index": self._circuit_index,
+        }
+        circuit_type = circuit.get("circuitType")
+        if circuit_type is not None and str(circuit_type).strip() != "":
+            attrs["circuit_type"] = str(circuit_type)
+        has_mixer = circuit.get("hasMixer")
+        if isinstance(has_mixer, bool):
+            attrs["has_mixer"] = has_mixer
+        return attrs
 
 
 class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -1,8 +1,172 @@
-"""Boiler switch platform stub (HA-1 reduced profile)."""
+"""Switch entities for Helianthus circuits."""
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import circuit_identifier
+from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
+
+_SET_CIRCUIT_CONFIG_MUTATION = """
+mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
+  setCircuitConfig(index: $index, field: $field, value: $value) {
+    success
+    error
+  }
+}
+"""
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+
+
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    """Reduced profile: no switch entities are registered."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("circuit_coordinator")
+    manufacturer = data.get("regulator_manufacturer") or "Helianthus"
+    client = data.get("graphql_client")
+    if coordinator is None or not coordinator.data:
+        async_add_entities([])
+        return
 
+    entities: list[HelianthusCircuitCoolingEnabledSwitch] = []
+    for circuit in coordinator.data.get("circuits", []) or []:
+        if not isinstance(circuit, dict):
+            continue
+        index = _parse_circuit_index(circuit.get("index"))
+        if index is None:
+            continue
+        entities.append(
+            HelianthusCircuitCoolingEnabledSwitch(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                client=client,
+                circuit_index=index,
+                initial_name=_circuit_name(circuit, index),
+            )
+        )
+    async_add_entities(entities)
+
+
+class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
+    """Writable switch for circuit cooling mode."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        circuit_index: int,
+        initial_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._client = client
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-cooling-enabled"
+        self._attr_name = f"{initial_name} Cooling Enabled"
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} Cooling Enabled"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        circuit = self._circuit()
+        config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
+        value = config.get("coolingEnabled")
+        if isinstance(value, bool):
+            return value
+        return None
+
+    async def _write(self, enabled: bool) -> None:
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        variables = {
+            "index": int(self._circuit_index),
+            "field": "coolingEnabled",
+            "value": "true" if enabled else "false",
+        }
+        try:
+            payload = await self._client.mutation(_SET_CIRCUIT_CONFIG_MUTATION, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = ""
+        if isinstance(result, dict):
+            error = str(result.get("error") or "")
+        message = error or "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {message}")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._write(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._write(False)

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -1,8 +1,135 @@
-"""Boiler valve platform stub (HA-1 reduced profile)."""
+"""Valve entities for Helianthus circuits."""
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components.valve import ValveEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import circuit_identifier
+
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
+
+
+def _parse_circuit_index(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    token = str(circuit.get("circuitType") or "").strip().lower()
+    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+    return f"Circuit {index + 1} ({label})"
+
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    """Reduced profile: no valve entities are registered."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("circuit_coordinator")
+    manufacturer = data.get("regulator_manufacturer") or "Helianthus"
+    if coordinator is None or not coordinator.data:
+        async_add_entities([])
+        return
 
+    entities: list[HelianthusCircuitMixingValve] = []
+    for circuit in coordinator.data.get("circuits", []) or []:
+        if not isinstance(circuit, dict):
+            continue
+        if not bool(circuit.get("hasMixer")):
+            continue
+        index = _parse_circuit_index(circuit.get("index"))
+        if index is None:
+            continue
+        entities.append(
+            HelianthusCircuitMixingValve(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                circuit_index=index,
+                initial_name=_circuit_name(circuit, index),
+            )
+        )
+    async_add_entities(entities)
+
+
+class HelianthusCircuitMixingValve(CoordinatorEntity, ValveEntity):
+    """Read-only circuit mixing valve position."""
+
+    _attr_icon = "mdi:valve"
+    _attr_reports_position = True
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        circuit_index: int,
+        initial_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._circuit_index = circuit_index
+        self._initial_name = initial_name
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-mixing-valve"
+
+    def _circuit(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if _parse_circuit_index(circuit.get("index")) == self._circuit_index:
+                return circuit
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        return f"{self._device_name()} Mixing Valve"
+
+    def _device_name(self) -> str:
+        circuit = self._circuit()
+        if circuit:
+            return _circuit_name(circuit, self._circuit_index)
+        return self._initial_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = circuit_identifier(self._entry_id, self._circuit_index)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Circuit",
+            name=self._device_name(),
+        )
+
+    @property
+    def current_valve_position(self) -> int | None:
+        circuit = self._circuit()
+        state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
+        value = state.get("mixerPositionPct")
+        if value is None:
+            return None
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        if parsed < 0:
+            parsed = 0
+        if parsed > 100:
+            parsed = 100
+        return int(round(parsed))

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1,0 +1,384 @@
+"""Tests for HA-6 circuit entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    fan_module = sys.modules.setdefault(
+        "homeassistant.components.fan",
+        types.ModuleType("homeassistant.components.fan"),
+    )
+    if not hasattr(fan_module, "FanEntity"):
+        class _FanEntity:
+            pass
+
+        fan_module.FanEntity = _FanEntity
+
+    valve_module = sys.modules.setdefault(
+        "homeassistant.components.valve",
+        types.ModuleType("homeassistant.components.valve"),
+    )
+    if not hasattr(valve_module, "ValveEntity"):
+        class _ValveEntity:
+            pass
+
+        valve_module.ValveEntity = _ValveEntity
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+            HUMIDITY = "humidity"
+            DURATION = "duration"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+            TOTAL_INCREASING = "total_increasing"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    number_module = sys.modules.setdefault(
+        "homeassistant.components.number",
+        types.ModuleType("homeassistant.components.number"),
+    )
+    if not hasattr(number_module, "NumberEntity"):
+        class _NumberEntity:
+            pass
+
+        number_module.NumberEntity = _NumberEntity
+
+    select_module = sys.modules.setdefault(
+        "homeassistant.components.select",
+        types.ModuleType("homeassistant.components.select"),
+    )
+    if not hasattr(select_module, "SelectEntity"):
+        class _SelectEntity:
+            pass
+
+        select_module.SelectEntity = _SelectEntity
+
+    switch_module = sys.modules.setdefault(
+        "homeassistant.components.switch",
+        types.ModuleType("homeassistant.components.switch"),
+    )
+    if not hasattr(switch_module, "SwitchEntity"):
+        class _SwitchEntity:
+            pass
+
+        switch_module.SwitchEntity = _SwitchEntity
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import fan as fan_platform
+from custom_components.helianthus import number as number_platform
+from custom_components.helianthus import select as select_platform
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus import switch as switch_platform
+from custom_components.helianthus import valve as valve_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+        self.refresh_requests = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refresh_requests += 1
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def mutation(self, query: str, variables: dict):  # noqa: ANN201
+        self.calls.append({"query": query, "variables": variables})
+        return {"setCircuitConfig": {"success": True, "error": None}}
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _circuits() -> list[dict]:
+    return [
+        {
+            "index": 0,
+            "circuitType": "heating",
+            "hasMixer": True,
+            "state": {
+                "pumpActive": True,
+                "mixerPositionPct": 37.8,
+                "flowTemperatureC": 42.5,
+                "flowSetpointC": 45.0,
+                "calcFlowTempC": 44.0,
+                "circuitState": "heating",
+                "humidity": 49.2,
+                "dewPoint": 11.1,
+                "pumpHours": 120.0,
+                "pumpStarts": 55,
+            },
+            "config": {
+                "heatingCurve": 1.3,
+                "flowTempMaxC": 70.0,
+                "flowTempMinC": 20.0,
+                "summerLimitC": 22.0,
+                "frostProtC": -5.0,
+                "roomTempControl": "modulating",
+                "coolingEnabled": False,
+            },
+        },
+        {
+            "index": 1,
+            "circuitType": "fixed_value",
+            "hasMixer": False,
+            "state": {
+                "pumpActive": False,
+                "mixerPositionPct": None,
+                "flowTemperatureC": 31.0,
+                "flowSetpointC": 33.0,
+                "calcFlowTempC": 32.5,
+                "circuitState": "standby",
+                "humidity": None,
+                "dewPoint": None,
+                "pumpHours": 10.0,
+                "pumpStarts": 3,
+            },
+            "config": {
+                "heatingCurve": 1.0,
+                "flowTempMaxC": 55.0,
+                "flowTempMinC": 15.0,
+                "summerLimitC": 24.0,
+                "frostProtC": -3.0,
+                "roomTempControl": "off",
+                "coolingEnabled": True,
+            },
+        },
+    ]
+
+
+def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
+    circuit_coordinator = _FakeCoordinator({"circuits": _circuits()})
+    client = _FakeClient()
+    payload = {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
+        "energy_coordinator": None,
+        "circuit_coordinator": circuit_coordinator,
+        "boiler_coordinator": None,
+        "boiler_device_id": None,
+        "graphql_client": client,
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "regulator_manufacturer": "Vaillant",
+    }
+    return payload, circuit_coordinator, client
+
+
+def test_circuit_fan_platform_adds_one_pump_per_circuit() -> None:
+    payload, _, _ = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, entities.extend))
+
+    pump_entities = [
+        entity for entity in entities if isinstance(entity, fan_platform.HelianthusCircuitPumpFan)
+    ]
+    assert len(pump_entities) == 2
+    assert {entity._attr_unique_id for entity in pump_entities} == {
+        "entry-1-circuit-0-pump",
+        "entry-1-circuit-1-pump",
+    }
+    first = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("-0-pump"))
+    second = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("-1-pump"))
+    assert first.is_on is True
+    assert first.percentage == 100
+    assert second.is_on is False
+    assert second.percentage == 0
+
+
+def test_circuit_valve_platform_respects_has_mixer_gate() -> None:
+    payload, _, _ = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(valve_platform.async_setup_entry(hass, entry, entities.extend))
+
+    mixer_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, valve_platform.HelianthusCircuitMixingValve)
+    ]
+    assert len(mixer_entities) == 1
+    mixer = mixer_entities[0]
+    assert mixer._attr_unique_id == "entry-1-circuit-0-mixing-valve"
+    assert mixer.current_valve_position == 38
+
+
+def test_circuit_sensor_platform_adds_expected_sensors_without_zone_link_attrs() -> None:
+    payload, _, _ = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    circuit_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusCircuitSensor)
+    ]
+    assert len(circuit_entities) == len(_circuits()) * len(sensor_platform.CIRCUIT_SENSOR_FIELDS)
+
+    state_sensor = next(
+        entity for entity in circuit_entities if entity._attr_unique_id == "entry-1-circuit-0-sensor-circuitState"
+    )
+    attrs = state_sensor.extra_state_attributes
+    assert attrs["circuit_index"] == 0
+    assert attrs["circuit_type"] == "heating"
+    assert "connected_zone_indices" not in attrs
+    assert "connected_zone_names" not in attrs
+
+
+def test_circuit_number_select_switch_entities_call_circuit_config_mutation() -> None:
+    payload, circuit_coordinator, client = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    number_entities: list = []
+    select_entities: list = []
+    switch_entities: list = []
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+    asyncio.run(select_platform.async_setup_entry(hass, entry, select_entities.extend))
+    asyncio.run(switch_platform.async_setup_entry(hass, entry, switch_entities.extend))
+
+    heating_curve = next(
+        entity
+        for entity in number_entities
+        if isinstance(entity, number_platform.HelianthusCircuitNumber) and entity._field.key == "heatingCurve"
+    )
+    room_temp_control = next(
+        entity
+        for entity in select_entities
+        if isinstance(entity, select_platform.HelianthusCircuitRoomTempControlSelect)
+        and entity._attr_unique_id == "entry-1-circuit-0-room-temp-control"
+    )
+    cooling_enabled = next(
+        entity
+        for entity in switch_entities
+        if isinstance(entity, switch_platform.HelianthusCircuitCoolingEnabledSwitch)
+        and entity._attr_unique_id == "entry-1-circuit-0-cooling-enabled"
+    )
+
+    asyncio.run(heating_curve.async_set_native_value(1.7))
+    asyncio.run(room_temp_control.async_select_option("thermostat"))
+    asyncio.run(cooling_enabled.async_turn_on())
+
+    fields_written = [call["variables"]["field"] for call in client.calls]
+    assert fields_written == ["heatingCurve", "roomTempControl", "coolingEnabled"]
+    assert circuit_coordinator.refresh_requests == 3

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -33,6 +33,7 @@ sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_coordi
 
 from custom_components.helianthus.coordinator import (
     QUERY_BOILER,
+    QUERY_CIRCUITS,
     QUERY_EXTENDED_V2,
     QUERY_EXTENDED_V2_NO_ADDRESSES,
     QUERY_EXTENDED_V3,
@@ -42,6 +43,7 @@ from custom_components.helianthus.coordinator import (
     QUERY_STATUS_LEGACY,
     UpdateFailed,
     HelianthusBoilerCoordinator,
+    HelianthusCircuitCoordinator,
     HelianthusCoordinator,
     HelianthusStatusCoordinator,
 )
@@ -77,6 +79,12 @@ def _build_boiler_coordinator(client: _ScriptedClient) -> HelianthusBoilerCoordi
     coordinator = object.__new__(HelianthusBoilerCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     coordinator.boiler_supported = True  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_circuit_coordinator(client: _ScriptedClient) -> HelianthusCircuitCoordinator:
+    coordinator = object.__new__(HelianthusCircuitCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -293,3 +301,40 @@ def test_boiler_query_missing_nested_field_falls_back_to_none() -> None:
     assert data == {"boilerStatus": None}
     assert client.calls == [QUERY_BOILER]
     assert coordinator.boiler_supported is False
+
+
+def test_circuit_query_returns_circuit_payload() -> None:
+    payload = {
+        "circuits": [
+            {
+                "index": 0,
+                "circuitType": "heating",
+                "hasMixer": True,
+                "state": {"pumpActive": True},
+                "config": {"coolingEnabled": False},
+            }
+        ]
+    }
+    client = _ScriptedClient([payload])
+    coordinator = _build_circuit_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data == payload
+    assert client.calls == [QUERY_CIRCUITS]
+
+
+def test_circuit_query_missing_field_falls_back_to_empty_payload() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "circuits" on type "Query".'}]
+            )
+        ]
+    )
+    coordinator = _build_circuit_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data == {"circuits": []}
+    assert client.calls == [QUERY_CIRCUITS]

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -6,9 +6,11 @@ from custom_components.helianthus.device_ids import (
     boiler_hydraulics_identifier,
     bus_identifier,
     build_bus_device_key,
+    circuit_identifier,
     daemon_identifier,
     dhw_identifier,
     energy_identifier,
+    managing_device_identifier,
     resolve_boiler_physical_device_id,
     resolve_boiler_via_device_id,
     resolve_bus_address,
@@ -94,6 +96,7 @@ def test_identifier_helpers_are_deterministic() -> None:
     assert adapter_identifier("entry-1") == ("helianthus", "adapter-entry-1")
     assert bus_identifier("entry-1", "BASV2-sn-ABC123") == ("helianthus", "entry-1-bus-BASV2-sn-ABC123")
     assert zone_identifier("entry-1", "1") == ("helianthus", "entry-1-zone-1")
+    assert circuit_identifier("entry-1", 0) == ("helianthus", "entry-1-circuit-0")
     assert dhw_identifier("entry-1") == ("helianthus", "entry-1-dhw")
     assert energy_identifier("entry-1") == ("helianthus", "entry-1-energy")
 
@@ -119,3 +122,41 @@ def test_boiler_device_contract_helpers_fall_back_to_regulator_or_adapter() -> N
     assert resolve_boiler_physical_device_id(None, regulator) == regulator
     assert resolve_boiler_via_device_id(None, regulator, adapter) == regulator
     assert resolve_boiler_via_device_id(None, None, adapter) == adapter
+
+
+def test_managing_device_identifier_prefers_regulator_for_circuits_by_default() -> None:
+    regulator = ("helianthus", "entry-1-bus-BASV-15")
+    vr71 = ("helianthus", "entry-1-bus-VR_71-26")
+    adapter = ("helianthus", "adapter-entry-1")
+
+    assert (
+        managing_device_identifier(
+            group=0x02,
+            instance=0,
+            regulator_device_id=regulator,
+            vr71_device_id=vr71,
+            adapter_device_id=adapter,
+            fm5_config=None,
+            vr71_circuit_start=-1,
+        )
+        == regulator
+    )
+
+
+def test_managing_device_identifier_routes_to_vr71_when_circuit_is_fm5_managed() -> None:
+    regulator = ("helianthus", "entry-1-bus-BASV-15")
+    vr71 = ("helianthus", "entry-1-bus-VR_71-26")
+    adapter = ("helianthus", "adapter-entry-1")
+
+    assert (
+        managing_device_identifier(
+            group=0x02,
+            instance=2,
+            regulator_device_id=regulator,
+            vr71_device_id=vr71,
+            adapter_device_id=adapter,
+            fm5_config=1,
+            vr71_circuit_start=2,
+        )
+        == vr71
+    )

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -45,6 +45,7 @@ def test_identifier_belongs_to_entry() -> None:
     assert _identifier_belongs_to_entry("adapter-entry-1", "entry-1")
     assert _identifier_belongs_to_entry("entry-1-bus-BASV2-15", "entry-1")
     assert _identifier_belongs_to_entry("entry-1-zone-2", "entry-1")
+    assert _identifier_belongs_to_entry("entry-1-circuit-0", "entry-1")
     assert not _identifier_belongs_to_entry("legacy-device", "entry-1")
 
 


### PR DESCRIPTION
## Summary
- add `HelianthusCircuitCoordinator` with `circuits` GraphQL query + compatibility fallback
- add per-circuit device registration and managing-device IDs
- implement circuit entity platforms (`fan`, `valve`, `sensor`, `number`, `select`, `switch`)
- add tests for coordinator, device IDs, init labels, and circuit entities

## Testing
- `pytest tests/`

Fixes #117
