### PR TITLE
HA-7: add BASV2 system coordinator and entities

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -211,6 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HelianthusCoordinator,
         HelianthusEnergyCoordinator,
         HelianthusSemanticCoordinator,
+        HelianthusSystemCoordinator,
         HelianthusStatusCoordinator,
     )
     from .device_ids import (
@@ -324,12 +325,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     semantic_coordinator = HelianthusSemanticCoordinator(hass, client, scan_interval)
     energy_coordinator = HelianthusEnergyCoordinator(hass, client, scan_interval)
     circuit_coordinator = HelianthusCircuitCoordinator(hass, client, scan_interval)
+    system_coordinator = HelianthusSystemCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
     await status_coordinator.async_config_entry_first_refresh()
     await semantic_coordinator.async_config_entry_first_refresh()
     await energy_coordinator.async_config_entry_first_refresh()
     await circuit_coordinator.async_config_entry_first_refresh()
+    await system_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
 
     devices = device_coordinator.data or []
@@ -379,6 +382,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if parsed < 0:
             return None
         return parsed
+
+    def parse_optional_int(value: object | None) -> int | None:
+        if isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def circuit_type_display_name(value: object | None) -> str:
         token = str(value or "").strip().lower()
@@ -454,11 +465,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 regulator_manufacturer = mfr
                 break
 
+    system_payload = system_coordinator.data or {}
+    system_properties = system_payload.get("properties")
+    if not isinstance(system_properties, dict):
+        system_properties = {}
+    fm5_raw = parse_optional_int(system_properties.get("moduleConfigurationVR71"))
+    fm5_config = fm5_raw if fm5_raw is not None and fm5_raw >= 0 else None
+    vr71_start_raw = parse_optional_int(system_properties.get("vr71CircuitStartIndex"))
+    vr71_circuit_start = vr71_start_raw if vr71_start_raw is not None and vr71_start_raw >= 0 else -1
+
     circuits_payload = circuit_coordinator.data or {}
     circuits = circuits_payload.get("circuits", []) or []
     known_circuit_indexes: set[int] = set()
-    fm5_config: int | None = None
-    vr71_circuit_start = -1
     for circuit in circuits:
         if not isinstance(circuit, dict):
             continue
@@ -671,6 +689,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "semantic_coordinator": semantic_coordinator,
         "energy_coordinator": energy_coordinator,
         "circuit_coordinator": circuit_coordinator,
+        "system_coordinator": system_coordinator,
         "boiler_coordinator": boiler_coordinator,
         "graphql_client": client,
         "subscription_task": subscription_task,

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .device_ids import dhw_identifier, zone_identifier
+
+_BINARY_SENSOR_DEVICE_CLASS_PROBLEM = getattr(BinarySensorDeviceClass, "PROBLEM", None)
 
 
 def _normalize_preset(value: Any) -> str:
@@ -28,8 +31,10 @@ def _normalize_preset(value: Any) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
+    system_coordinator = data.get("system_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
+    regulator_device_id = data.get("regulator_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
     zones = coordinator.data.get("zones", []) if coordinator.data else []
@@ -84,6 +89,34 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 entry_id=entry.entry_id,
                 boiler_device_id=boiler_device_id,
             )
+        )
+
+    if system_coordinator and system_coordinator.data and regulator_device_id:
+        entities.extend(
+            [
+                HelianthusSystemBinarySensor(
+                    coordinator=system_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    regulator_device_id=regulator_device_id,
+                    source="state",
+                    key="maintenanceDue",
+                    label="Maintenance Due",
+                    device_class=_BINARY_SENSOR_DEVICE_CLASS_PROBLEM,
+                    entity_category=EntityCategory.DIAGNOSTIC,
+                ),
+                HelianthusSystemBinarySensor(
+                    coordinator=system_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    regulator_device_id=regulator_device_id,
+                    source="config",
+                    key="adaptiveHeatingCurve",
+                    label="Adaptive Heating Curve",
+                    device_class=None,
+                    entity_category=EntityCategory.CONFIG,
+                ),
+            ]
         )
 
     async_add_entities(entities)
@@ -185,6 +218,53 @@ class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
         boiler_status = payload.get("boilerStatus") or {}
         state = boiler_status.get("state") or {}
         value = state.get("centralHeatingPumpActive")
+        if isinstance(value, bool):
+            return value
+        return None
+
+
+class HelianthusSystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """System-level BASV2 binary sensor."""
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        regulator_device_id: tuple[str, str],
+        source: str,
+        key: str,
+        label: str,
+        device_class: str | None,
+        entity_category: str | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._regulator_device_id = regulator_device_id
+        self._source = source
+        self._key = key
+        self._attr_name = label
+        self._attr_unique_id = f"{entry_id}-system-binary-{key}"
+        if device_class is not None:
+            self._attr_device_class = device_class
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._regulator_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        payload = self.coordinator.data or {}
+        source = payload.get(self._source)
+        if not isinstance(source, dict):
+            return None
+        value = source.get(self._key)
         if isinstance(value, bool):
             return value
         return None

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -236,6 +236,63 @@ query Circuits {
 }
 """
 
+QUERY_SYSTEM = """
+query System {
+  system {
+    state {
+      systemWaterPressure
+      systemFlowTemperature
+      outdoorTemperature
+      outdoorTemperatureAvg24h
+      maintenanceDue
+      hwcCylinderTemperatureTop
+      hwcCylinderTemperatureBottom
+    }
+    config {
+      adaptiveHeatingCurve
+      heatingCircuitBivalencePoint
+      dhwBivalencePoint
+      hcEmergencyTemperature
+      hwcMaxFlowTempDesired
+      maxRoomHumidity
+    }
+    properties {
+      systemScheme
+      moduleConfigurationVR71
+      vr71CircuitStartIndex
+    }
+  }
+}
+"""
+
+QUERY_SYSTEM_LEGACY = """
+query System {
+  system {
+    state {
+      systemWaterPressure
+      systemFlowTemperature
+      outdoorTemperature
+      outdoorTemperatureAvg24h
+      maintenanceDue
+      hwcCylinderTemperatureTop
+      hwcCylinderTemperatureBottom
+    }
+    config {
+      adaptiveHeatingCurve
+      heatingCircuitBivalencePoint
+      dhwBivalencePoint
+      hcEmergencyTemperature
+      hwcMaxFlowTempDesired
+      maxRoomHumidity
+    }
+    properties {
+      systemScheme
+      moduleConfigurationVR71
+    }
+  }
+}
+"""
+
 QUERY_ENERGY = """
 query Energy {
   devices {
@@ -467,6 +524,78 @@ class HelianthusCircuitCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 for circuit in circuits
                 if isinstance(circuit, dict)
             ]
+        }
+
+
+class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator fetching semantic system data."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_system",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+        self._client = client
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        empty = {"state": {}, "config": {}, "properties": {}}
+        missing_fields = [
+            "system",
+            "state",
+            "config",
+            "properties",
+            "systemWaterPressure",
+            "systemFlowTemperature",
+            "outdoorTemperature",
+            "outdoorTemperatureAvg24h",
+            "maintenanceDue",
+            "hwcCylinderTemperatureTop",
+            "hwcCylinderTemperatureBottom",
+            "adaptiveHeatingCurve",
+            "heatingCircuitBivalencePoint",
+            "dhwBivalencePoint",
+            "hcEmergencyTemperature",
+            "hwcMaxFlowTempDesired",
+            "maxRoomHumidity",
+            "systemScheme",
+            "moduleConfigurationVR71",
+        ]
+
+        try:
+            payload = await self._client.execute(QUERY_SYSTEM)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, ["vr71CircuitStartIndex"]):
+                try:
+                    payload = await self._client.execute(QUERY_SYSTEM_LEGACY)
+                except GraphQLResponseError as nested:
+                    if _is_missing_field_error(nested.errors, missing_fields):
+                        return empty
+                    raise UpdateFailed(str(nested)) from nested
+                except GraphQLClientError as nested:
+                    raise UpdateFailed(str(nested)) from nested
+            elif _is_missing_field_error(exc.errors, missing_fields):
+                return empty
+            else:
+                raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            return empty
+
+        system = payload.get("system")
+        if not isinstance(system, dict):
+            return empty
+
+        state = system.get("state")
+        config = system.get("config")
+        properties = system.get("properties")
+        return {
+            "state": state if isinstance(state, dict) else {},
+            "config": config if isinstance(config, dict) else {},
+            "properties": properties if isinstance(properties, dict) else {},
         }
 
 

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -18,6 +18,15 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 _SET_CIRCUIT_CONFIG_MUTATION = """
 mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
   setCircuitConfig(index: $index, field: $field, value: $value) {
+    success
+    error
+  }
+}
+"""
+
+_SET_SYSTEM_CONFIG_MUTATION = """
+mutation SetSystemConfig($field: String!, $value: String!) {
+  setSystemConfig(field: $field, value: $value) {
     success
     error
   }
@@ -40,6 +49,18 @@ class CircuitNumberField:
     maximum: float
     step: float
     unit: str | None = None
+
+
+@dataclass(frozen=True)
+class SystemNumberField:
+    mutation_field: str
+    config_key: str
+    label: str
+    minimum: float
+    maximum: float
+    step: float
+    unit: str | None = None
+    cast_int: bool = False
 
 
 _CIRCUIT_NUMBER_FIELDS = [
@@ -78,6 +99,55 @@ _CIRCUIT_NUMBER_FIELDS = [
     ),
 ]
 
+_SYSTEM_NUMBER_FIELDS = [
+    SystemNumberField(
+        mutation_field="hcBivalencePointC",
+        config_key="heatingCircuitBivalencePoint",
+        label="HC Bivalence Point",
+        minimum=-20.0,
+        maximum=30.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    SystemNumberField(
+        mutation_field="dhwBivalencePointC",
+        config_key="dhwBivalencePoint",
+        label="DHW Bivalence Point",
+        minimum=-20.0,
+        maximum=50.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    SystemNumberField(
+        mutation_field="hcEmergencyTempC",
+        config_key="hcEmergencyTemperature",
+        label="HC Emergency Temperature",
+        minimum=20.0,
+        maximum=80.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    SystemNumberField(
+        mutation_field="hwcMaxFlowTempC",
+        config_key="hwcMaxFlowTempDesired",
+        label="HWC Max Flow Temperature",
+        minimum=15.0,
+        maximum=80.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    SystemNumberField(
+        mutation_field="maxRoomHumidityPct",
+        config_key="maxRoomHumidity",
+        label="Max Room Humidity",
+        minimum=30.0,
+        maximum=80.0,
+        step=1.0,
+        unit=PERCENTAGE,
+        cast_int=True,
+    ),
+]
+
 
 def _parse_circuit_index(value: object | None) -> int | None:
     if isinstance(value, bool):
@@ -100,32 +170,46 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
+    system_coordinator = data.get("system_coordinator")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
-    if coordinator is None or not coordinator.data:
-        async_add_entities([])
-        return
+    regulator_device_id = data.get("regulator_device_id")
 
-    entities: list[HelianthusCircuitNumber] = []
-    for circuit in coordinator.data.get("circuits", []) or []:
-        if not isinstance(circuit, dict):
-            continue
-        index = _parse_circuit_index(circuit.get("index"))
-        if index is None:
-            continue
-        initial_name = _circuit_name(circuit, index)
-        for field in _CIRCUIT_NUMBER_FIELDS:
+    entities: list[NumberEntity] = []
+    if coordinator and coordinator.data:
+        for circuit in coordinator.data.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            index = _parse_circuit_index(circuit.get("index"))
+            if index is None:
+                continue
+            initial_name = _circuit_name(circuit, index)
+            for field in _CIRCUIT_NUMBER_FIELDS:
+                entities.append(
+                    HelianthusCircuitNumber(
+                        coordinator=coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        client=client,
+                        circuit_index=index,
+                        initial_name=initial_name,
+                        field=field,
+                    )
+                )
+
+    if system_coordinator and system_coordinator.data and regulator_device_id:
+        for field in _SYSTEM_NUMBER_FIELDS:
             entities.append(
-                HelianthusCircuitNumber(
-                    coordinator=coordinator,
+                HelianthusSystemNumber(
+                    coordinator=system_coordinator,
                     entry_id=entry.entry_id,
                     manufacturer=manufacturer,
                     client=client,
-                    circuit_index=index,
-                    initial_name=initial_name,
+                    regulator_device_id=regulator_device_id,
                     field=field,
                 )
             )
+
     async_add_entities(entities)
 
 
@@ -220,6 +304,87 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
         result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = ""
+        if isinstance(result, dict):
+            error = str(result.get("error") or "")
+        message = error or "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {message}")
+
+
+class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
+    """Writable BASV2 system configuration number."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        regulator_device_id: tuple[str, str],
+        field: SystemNumberField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._client = client
+        self._regulator_device_id = regulator_device_id
+        self._field = field
+        self._attr_unique_id = f"{entry_id}-system-number-{field.mutation_field}"
+        self._attr_name = field.label
+        self._attr_native_min_value = field.minimum
+        self._attr_native_max_value = field.maximum
+        self._attr_native_step = field.step
+        if field.unit is not None:
+            self._attr_native_unit_of_measurement = field.unit
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._regulator_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        payload = self.coordinator.data or {}
+        config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+        value = config.get(self._field.config_key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        if value < self._field.minimum or value > self._field.maximum:
+            raise HomeAssistantError(
+                f"Value {value} outside allowed range [{self._field.minimum}, {self._field.maximum}]"
+            )
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        payload_value = (
+            str(int(round(value)))
+            if self._field.cast_int
+            else str(float(value))
+        )
+        variables = {
+            "field": self._field.mutation_field,
+            "value": payload_value,
+        }
+        try:
+            payload = await self._client.mutation(_SET_SYSTEM_CONFIG_MUTATION, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -47,6 +47,18 @@ class CircuitSensorField:
     include_circuit_attributes: bool = False
 
 
+@dataclass(frozen=True)
+class SystemSensorField:
+    key: str
+    label: str
+    source: str
+    device_class: str | None = None
+    native_unit: str | None = None
+    state_class: str | None = None
+    entity_category: str | None = None
+    cast_int: bool = False
+
+
 STATUS_FIELDS = [
     InventoryField("status", "Status"),
     InventoryField("firmwareVersion", "Firmware Version"),
@@ -68,6 +80,7 @@ REDUCED_BOILER_TEMPERATURE_FIELDS = [
 
 _SENSOR_DEVICE_CLASS_HUMIDITY = getattr(SensorDeviceClass, "HUMIDITY", None)
 _SENSOR_DEVICE_CLASS_DURATION = getattr(SensorDeviceClass, "DURATION", None)
+_SENSOR_DEVICE_CLASS_PRESSURE = getattr(SensorDeviceClass, "PRESSURE", None)
 _SENSOR_STATE_CLASS_TOTAL_INCREASING = getattr(SensorStateClass, "TOTAL_INCREASING", None)
 
 _CIRCUIT_TYPE_LABELS = {
@@ -135,6 +148,64 @@ CIRCUIT_SENSOR_FIELDS = [
     ),
 ]
 
+SYSTEM_SENSOR_FIELDS = [
+    SystemSensorField(
+        key="systemWaterPressure",
+        label="System Water Pressure",
+        source="state",
+        device_class=_SENSOR_DEVICE_CLASS_PRESSURE,
+        native_unit="bar",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="outdoorTemperature",
+        label="Outdoor Temperature",
+        source="state",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="outdoorTemperatureAvg24h",
+        label="Outdoor Temperature 24h Average",
+        source="state",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="systemFlowTemperature",
+        label="System Flow Temperature",
+        source="state",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="hwcCylinderTemperatureTop",
+        label="HWC Cylinder Temperature Top",
+        source="state",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="hwcCylinderTemperatureBottom",
+        label="HWC Cylinder Temperature Bottom",
+        source="state",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SystemSensorField(
+        key="systemScheme",
+        label="System Scheme",
+        source="properties",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        cast_int=True,
+    ),
+]
+
 
 def _clean_text(value: object | None) -> str | None:
     if value is None:
@@ -168,8 +239,10 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     semantic_coordinator = data.get("semantic_coordinator")
     energy_coordinator = data.get("energy_coordinator")
     circuit_coordinator = data.get("circuit_coordinator")
+    system_coordinator = data.get("system_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
+    regulator_device_id = data.get("regulator_device_id")
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
@@ -251,6 +324,18 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         field=field,
                     )
                 )
+
+    if system_coordinator and system_coordinator.data and regulator_device_id:
+        for field in SYSTEM_SENSOR_FIELDS:
+            sensors.append(
+                HelianthusSystemSensor(
+                    coordinator=system_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    regulator_device_id=regulator_device_id,
+                    field=field,
+                )
+            )
 
     if semantic_coordinator and semantic_coordinator.data:
         zones = semantic_coordinator.data.get("zones", []) or []
@@ -486,6 +571,62 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
         if isinstance(has_mixer, bool):
             attrs["has_mixer"] = has_mixer
         return attrs
+
+
+class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
+    """System-level BASV2 sensor."""
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        regulator_device_id: tuple[str, str],
+        field: SystemSensorField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._regulator_device_id = regulator_device_id
+        self._field = field
+        self._attr_name = field.label
+        self._attr_unique_id = f"{entry_id}-system-sensor-{field.key}"
+        if field.device_class is not None:
+            self._attr_device_class = field.device_class
+        if field.native_unit is not None:
+            self._attr_native_unit_of_measurement = field.native_unit
+        if field.state_class is not None:
+            self._attr_state_class = field.state_class
+        if field.entity_category is not None:
+            self._attr_entity_category = field.entity_category
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._regulator_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    def _bucket(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        source = payload.get(self._field.source)
+        if isinstance(source, dict):
+            return source
+        return {}
+
+    @property
+    def native_value(self) -> Any:
+        value = self._bucket().get(self._field.key)
+        if value is None:
+            return None
+        if self._field.cast_int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+        if isinstance(value, (bool, int, float, str)):
+            return value
+        return None
 
 
 class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -34,6 +34,14 @@ def _ensure_homeassistant_stubs() -> None:
 
         binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
 
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+
     device_registry_module = sys.modules.setdefault(
         "homeassistant.helpers.device_registry",
         types.ModuleType("homeassistant.helpers.device_registry"),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -41,10 +41,12 @@ from custom_components.helianthus.coordinator import (
     QUERY_EXTENDED_V3_NO_PART,
     QUERY_STATUS,
     QUERY_STATUS_LEGACY,
+    QUERY_SYSTEM,
     UpdateFailed,
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
     HelianthusCoordinator,
+    HelianthusSystemCoordinator,
     HelianthusStatusCoordinator,
 )
 from custom_components.helianthus.graphql import GraphQLClientError, GraphQLResponseError
@@ -84,6 +86,12 @@ def _build_boiler_coordinator(client: _ScriptedClient) -> HelianthusBoilerCoordi
 
 def _build_circuit_coordinator(client: _ScriptedClient) -> HelianthusCircuitCoordinator:
     coordinator = object.__new__(HelianthusCircuitCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_system_coordinator(client: _ScriptedClient) -> HelianthusSystemCoordinator:
+    coordinator = object.__new__(HelianthusSystemCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     return coordinator
 
@@ -338,3 +346,47 @@ def test_circuit_query_missing_field_falls_back_to_empty_payload() -> None:
 
     assert data == {"circuits": []}
     assert client.calls == [QUERY_CIRCUITS]
+
+
+def test_system_query_returns_system_payload() -> None:
+    payload = {
+        "system": {
+            "state": {
+                "systemWaterPressure": 1.7,
+                "maintenanceDue": False,
+            },
+            "config": {
+                "adaptiveHeatingCurve": True,
+                "maxRoomHumidity": 60,
+            },
+            "properties": {
+                "systemScheme": 3,
+                "moduleConfigurationVR71": 1,
+            },
+        }
+    }
+    client = _ScriptedClient([payload])
+    coordinator = _build_system_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["state"]["systemWaterPressure"] == 1.7
+    assert data["config"]["adaptiveHeatingCurve"] is True
+    assert data["properties"]["systemScheme"] == 3
+    assert client.calls == [QUERY_SYSTEM]
+
+
+def test_system_query_missing_field_falls_back_to_empty_payload() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "system" on type "Query".'}]
+            )
+        ]
+    )
+    coordinator = _build_system_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data == {"state": {}, "config": {}, "properties": {}}
+    assert client.calls == [QUERY_SYSTEM]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,319 @@
+"""Tests for HA-7 BASV2 system entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+            PRESSURE = "pressure"
+            HUMIDITY = "humidity"
+            DURATION = "duration"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+            TOTAL_INCREASING = "total_increasing"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    binary_sensor_module = sys.modules.setdefault(
+        "homeassistant.components.binary_sensor",
+        types.ModuleType("homeassistant.components.binary_sensor"),
+    )
+    if not hasattr(binary_sensor_module, "BinarySensorEntity"):
+        class _BinarySensorEntity:
+            pass
+
+        binary_sensor_module.BinarySensorEntity = _BinarySensorEntity
+    if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
+        class _BinarySensorDeviceClass:
+            RUNNING = "running"
+            PROBLEM = "problem"
+
+        binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
+
+    number_module = sys.modules.setdefault(
+        "homeassistant.components.number",
+        types.ModuleType("homeassistant.components.number"),
+    )
+    if not hasattr(number_module, "NumberEntity"):
+        class _NumberEntity:
+            pass
+
+        number_module.NumberEntity = _NumberEntity
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import binary_sensor as binary_sensor_platform
+from custom_components.helianthus import number as number_platform
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+        self.refresh_requests = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refresh_requests += 1
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def mutation(self, query: str, variables: dict):  # noqa: ANN201
+        self.calls.append({"query": query, "variables": variables})
+        return {"setSystemConfig": {"success": True, "error": None}}
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
+    system_coordinator = _FakeCoordinator(
+        {
+            "state": {
+                "systemWaterPressure": 1.8,
+                "outdoorTemperature": 6.2,
+                "outdoorTemperatureAvg24h": 4.1,
+                "systemFlowTemperature": 48.0,
+                "hwcCylinderTemperatureTop": 46.5,
+                "hwcCylinderTemperatureBottom": 38.0,
+                "maintenanceDue": True,
+            },
+            "config": {
+                "adaptiveHeatingCurve": False,
+                "heatingCircuitBivalencePoint": -2.0,
+                "dhwBivalencePoint": 5.0,
+                "hcEmergencyTemperature": 55.0,
+                "hwcMaxFlowTempDesired": 62.0,
+                "maxRoomHumidity": 65,
+            },
+            "properties": {
+                "systemScheme": 3,
+                "moduleConfigurationVR71": 1,
+            },
+        }
+    )
+    client = _FakeClient()
+    payload = {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
+        "energy_coordinator": None,
+        "circuit_coordinator": None,
+        "system_coordinator": system_coordinator,
+        "boiler_coordinator": None,
+        "boiler_device_id": None,
+        "graphql_client": client,
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "regulator_manufacturer": "Vaillant",
+    }
+    return payload, system_coordinator, client
+
+
+def test_system_sensor_entities_attach_to_basv2_device() -> None:
+    payload, _, _ = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    system_entities = [
+        entity for entity in entities if isinstance(entity, sensor_platform.HelianthusSystemSensor)
+    ]
+    assert len(system_entities) == len(sensor_platform.SYSTEM_SENSOR_FIELDS)
+    assert {entity._attr_unique_id for entity in system_entities} == {
+        "entry-1-system-sensor-systemWaterPressure",
+        "entry-1-system-sensor-outdoorTemperature",
+        "entry-1-system-sensor-outdoorTemperatureAvg24h",
+        "entry-1-system-sensor-systemFlowTemperature",
+        "entry-1-system-sensor-hwcCylinderTemperatureTop",
+        "entry-1-system-sensor-hwcCylinderTemperatureBottom",
+        "entry-1-system-sensor-systemScheme",
+    }
+    pressure = next(
+        entity
+        for entity in system_entities
+        if entity._attr_unique_id == "entry-1-system-sensor-systemWaterPressure"
+    )
+    scheme = next(
+        entity
+        for entity in system_entities
+        if entity._attr_unique_id == "entry-1-system-sensor-systemScheme"
+    )
+    assert pressure.native_value == 1.8
+    assert scheme.native_value == 3
+    assert scheme._attr_entity_category == sensor_platform.EntityCategory.DIAGNOSTIC
+    assert pressure.device_info["identifiers"] == {payload["regulator_device_id"]}
+
+
+def test_system_binary_sensors_expose_maintenance_and_adaptive_flags() -> None:
+    payload, _, _ = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    system_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusSystemBinarySensor)
+    ]
+    assert len(system_entities) == 2
+    maintenance = next(
+        entity
+        for entity in system_entities
+        if entity._attr_unique_id == "entry-1-system-binary-maintenanceDue"
+    )
+    adaptive = next(
+        entity
+        for entity in system_entities
+        if entity._attr_unique_id == "entry-1-system-binary-adaptiveHeatingCurve"
+    )
+    assert maintenance.is_on is True
+    assert adaptive.is_on is False
+    assert maintenance._attr_entity_category == binary_sensor_platform.EntityCategory.DIAGNOSTIC
+    assert adaptive._attr_entity_category == binary_sensor_platform.EntityCategory.CONFIG
+    assert maintenance.device_info["identifiers"] == {payload["regulator_device_id"]}
+
+
+def test_system_number_entities_write_set_system_config_mutation() -> None:
+    payload, system_coordinator, client = _build_payload()
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    system_numbers = [
+        entity for entity in entities if isinstance(entity, number_platform.HelianthusSystemNumber)
+    ]
+    assert len(system_numbers) == 5
+
+    hc_bivalence = next(
+        entity for entity in system_numbers if entity._field.mutation_field == "hcBivalencePointC"
+    )
+    max_humidity = next(
+        entity for entity in system_numbers if entity._field.mutation_field == "maxRoomHumidityPct"
+    )
+
+    asyncio.run(hc_bivalence.async_set_native_value(-1.0))
+    asyncio.run(max_humidity.async_set_native_value(70.0))
+
+    assert [call["variables"]["field"] for call in client.calls] == [
+        "hcBivalencePointC",
+        "maxRoomHumidityPct",
+    ]
+    assert [call["variables"]["value"] for call in client.calls] == ["-1.0", "70"]
+    assert system_coordinator.refresh_requests == 2
+    assert hc_bivalence.device_info["identifiers"] == {payload["regulator_device_id"]}


### PR DESCRIPTION
## What
- add `HelianthusSystemCoordinator` for GraphQL `system` data with legacy-schema fallback
- expose BASV2 system sensors, binary sensors, and config numbers on regulator device
- wire `system_coordinator` into integration setup and VR71/FM5 hints
- add unit tests for coordinator behavior and new entity platforms

## Why
- closes HA-7 by exposing controller-level system telemetry/config in HA using proper device anchoring

## Testing
- `pytest tests/`

Fixes #118