### PR TITLE
HA-11: add radio coordinator, entities, and zone candidate indexing

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -142,6 +142,7 @@ def _identifier_belongs_to_entry(token: str, entry_id: str) -> bool:
         token.startswith(f"{entry_id}-bus-")
         or token.startswith(f"{entry_id}-zone-")
         or token.startswith(f"{entry_id}-circuit-")
+        or token.startswith(f"{entry_id}-radio-")
     )
 
 
@@ -210,6 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HelianthusCircuitCoordinator,
         HelianthusCoordinator,
         HelianthusEnergyCoordinator,
+        HelianthusRadioDeviceCoordinator,
         HelianthusSemanticCoordinator,
         HelianthusSystemCoordinator,
         HelianthusStatusCoordinator,
@@ -218,11 +220,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         adapter_identifier,
         boiler_burner_identifier,
         boiler_hydraulics_identifier,
+        build_radio_bus_key,
         build_bus_device_key,
         bus_identifier,
         circuit_identifier,
         daemon_identifier,
         managing_device_identifier,
+        radio_device_identifier,
         resolve_bus_address,
         resolve_boiler_physical_device_id,
         resolve_boiler_via_device_id,
@@ -325,6 +329,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     semantic_coordinator = HelianthusSemanticCoordinator(hass, client, scan_interval)
     energy_coordinator = HelianthusEnergyCoordinator(hass, client, scan_interval)
     circuit_coordinator = HelianthusCircuitCoordinator(hass, client, scan_interval)
+    radio_coordinator = HelianthusRadioDeviceCoordinator(hass, client, scan_interval)
     system_coordinator = HelianthusSystemCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
@@ -332,6 +337,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await semantic_coordinator.async_config_entry_first_refresh()
     await energy_coordinator.async_config_entry_first_refresh()
     await circuit_coordinator.async_config_entry_first_refresh()
+    await radio_coordinator.async_config_entry_first_refresh()
     await system_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
 
@@ -390,6 +396,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return int(value)
         except (TypeError, ValueError):
             return None
+
+    def radio_model_name(device: dict) -> str:
+        model = _clean_label(device.get("deviceModel"))
+        if model:
+            return model
+        class_address = parse_optional_int(device.get("deviceClassAddress"))
+        if class_address == 0x15:
+            return "VRC720f/2"
+        if class_address == 0x35:
+            return "VR92f"
+        if class_address == 0x26:
+            return "VR71/FM5"
+        if class_address is not None and class_address >= 0:
+            return f"Unknown Radio (0x{class_address:02X})"
+        return "Unknown Radio"
+
+    def radio_firmware_display(value: object | None) -> str | None:
+        token = _clean_label(value)
+        if not token:
+            return None
+        compact = token.replace(".", "")
+        if len(compact) == 6 and compact.isdigit():
+            major = compact[0:2]
+            minor = compact[2:4]
+            patch = compact[4:6]
+            if patch == "00":
+                return f"{major}.{minor}"
+            return f"{major}.{minor}.{patch}"
+        if len(compact) == 4 and compact.isdigit():
+            return f"{compact[0:2]}.{compact[2:4]}"
+        if "." in token:
+            parts = [part.strip() for part in token.split(".") if part.strip()]
+            if len(parts) >= 2:
+                major = parts[0]
+                minor = parts[1]
+                patch = parts[2] if len(parts) >= 3 else ""
+                if patch in {"", "0", "00"}:
+                    return f"{major}.{minor}"
+                return f"{major}.{minor}.{patch}"
+        return token
 
     def circuit_type_display_name(value: object | None) -> str:
         token = str(value or "").strip().lower()
@@ -464,6 +510,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if mfr:
                 regulator_manufacturer = mfr
                 break
+
+    radio_payload = radio_coordinator.data or {}
+    radio_devices_payload = radio_payload.get("radioDevices")
+    if not isinstance(radio_devices_payload, list):
+        radio_devices_payload = []
+    known_radio_bus_keys: set[str] = set()
+    radio_parent = regulator_device or adapter_device_id
+    for device in radio_devices_payload:
+        if not isinstance(device, dict):
+            continue
+        group = parse_optional_int(device.get("group"))
+        instance = parse_optional_int(device.get("instance"))
+        if group is None or instance is None:
+            continue
+        bus_key = str(device.get("radioBusKey") or "").strip()
+        if not bus_key:
+            bus_key = build_radio_bus_key(group, instance)
+        known_radio_bus_keys.add(bus_key)
+        radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
+        model_name = radio_model_name(device)
+        device_kwargs: dict[str, object] = {
+            "config_entry_id": entry.entry_id,
+            "identifiers": {radio_device_id},
+            "manufacturer": "Vaillant",
+            "model": model_name,
+            "name": model_name,
+        }
+        if radio_parent is not None:
+            device_kwargs["via_device"] = radio_parent
+        sw_version = radio_firmware_display(device.get("firmwareVersion"))
+        if sw_version:
+            device_kwargs["sw_version"] = sw_version
+        hardware_identifier = parse_optional_int(device.get("hardwareIdentifier"))
+        if hardware_identifier is not None and hardware_identifier >= 0:
+            device_kwargs["hw_version"] = f"0x{hardware_identifier:04X}"
+        device_registry.async_get_or_create(**device_kwargs)
 
     system_payload = system_coordinator.data or {}
     system_properties = system_payload.get("properties")
@@ -623,10 +705,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if current_indexes - known_circuit_indexes:
             schedule_reload("circuit inventory became available")
 
+    def handle_radio_update() -> None:
+        payload = radio_coordinator.data or {}
+        current_keys: set[str] = set()
+        for radio in payload.get("radioDevices", []) or []:
+            if not isinstance(radio, dict):
+                continue
+            key = str(radio.get("radioBusKey") or "").strip()
+            if key:
+                current_keys.add(key)
+                continue
+            group = parse_optional_int(radio.get("group"))
+            instance = parse_optional_int(radio.get("instance"))
+            if group is None or instance is None:
+                continue
+            current_keys.add(build_radio_bus_key(group, instance))
+        if current_keys - known_radio_bus_keys:
+            schedule_reload("radio inventory became available")
+
     unsub_listeners: list[Callable[[], None]] = []
     unsub_listeners.append(device_coordinator.async_add_listener(handle_device_update))
     unsub_listeners.append(semantic_coordinator.async_add_listener(handle_semantic_update))
     unsub_listeners.append(circuit_coordinator.async_add_listener(handle_circuit_update))
+    unsub_listeners.append(radio_coordinator.async_add_listener(handle_radio_update))
 
     for zone_id, helper_entity in zone_schedule_helpers.items():
         @callback
@@ -668,6 +769,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             semantic_coordinator,
             energy_coordinator,
             boiler_subscription_coordinator,
+            radio_coordinator,
         )
 
     boiler_physical_device_id = resolve_boiler_physical_device_id(
@@ -689,6 +791,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "semantic_coordinator": semantic_coordinator,
         "energy_coordinator": energy_coordinator,
         "circuit_coordinator": circuit_coordinator,
+        "radio_coordinator": radio_coordinator,
         "system_coordinator": system_coordinator,
         "boiler_coordinator": boiler_coordinator,
         "graphql_client": client,

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -10,9 +10,10 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import dhw_identifier, zone_identifier
+from .device_ids import build_radio_bus_key, dhw_identifier, radio_device_identifier, zone_identifier
 
 _BINARY_SENSOR_DEVICE_CLASS_PROBLEM = getattr(BinarySensorDeviceClass, "PROBLEM", None)
+_RADIO_STALE_GRACE_CYCLES = 3
 
 
 def _normalize_preset(value: Any) -> str:
@@ -28,9 +29,39 @@ def _normalize_preset(value: Any) -> str:
     return token
 
 
+def _parse_optional_int(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _radio_slot(device: dict[str, Any]) -> tuple[int, int] | None:
+    group = _parse_optional_int(device.get("group"))
+    instance = _parse_optional_int(device.get("instance"))
+    if group is None or instance is None:
+        return None
+    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
+        return None
+    return (group, instance)
+
+
+def _radio_bus_key(device: dict[str, Any]) -> str | None:
+    slot = _radio_slot(device)
+    if slot is None:
+        return None
+    explicit = str(device.get("radioBusKey") or "").strip()
+    if explicit:
+        return explicit
+    return build_radio_bus_key(slot[0], slot[1])
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
+    radio_coordinator = data.get("radio_coordinator")
     system_coordinator = data.get("system_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
@@ -118,6 +149,26 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 ),
             ]
         )
+
+    if radio_coordinator and radio_coordinator.data:
+        for radio in radio_coordinator.data.get("radioDevices", []) or []:
+            if not isinstance(radio, dict):
+                continue
+            slot = _radio_slot(radio)
+            bus_key = _radio_bus_key(radio)
+            if slot is None or bus_key is None:
+                continue
+            group, instance = slot
+            entities.append(
+                HelianthusRadioConnectedBinarySensor(
+                    coordinator=radio_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    radio_device_id=radio_device_identifier(entry.entry_id, bus_key),
+                    group=group,
+                    instance=instance,
+                )
+            )
 
     async_add_entities(entities)
 
@@ -265,6 +316,64 @@ class HelianthusSystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
         if not isinstance(source, dict):
             return None
         value = source.get(self._key)
+        if isinstance(value, bool):
+            return value
+        return None
+
+
+class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Remote-slot connected-state binary sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        radio_device_id: tuple[str, str],
+        group: int,
+        instance: int,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._radio_device_id = radio_device_id
+        self._group = group
+        self._instance = instance
+        self._attr_name = "Device Connected"
+        self._attr_unique_id = f"{entry_id}-radio-{group:02x}-{instance:02d}-connected"
+
+    def _device(self) -> dict[str, Any] | None:
+        payload = self.coordinator.data or {}
+        for device in payload.get("radioDevices", []) or []:
+            if not isinstance(device, dict):
+                continue
+            if _radio_slot(device) == (self._group, self._instance):
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        device = self._device()
+        if device is None:
+            return False
+        stale = _parse_optional_int(device.get("staleCycles")) or 0
+        return stale < _RADIO_STALE_GRACE_CYCLES
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._radio_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        device = self._device()
+        if not isinstance(device, dict):
+            return None
+        value = device.get("deviceConnected")
         if isinstance(value, bool):
             return value
         return None

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import timedelta
 import logging
 from typing import Any
@@ -236,6 +237,27 @@ query Circuits {
 }
 """
 
+QUERY_RADIO_DEVICES = """
+query RadioDevices {
+  radioDevices {
+    group
+    instance
+    slotMode
+    deviceConnected
+    deviceClassAddress
+    deviceModel
+    firmwareVersion
+    hardwareIdentifier
+    remoteControlAddress
+    devicePaired
+    receptionStrength
+    zoneAssignment
+    roomTemperatureC
+    roomHumidityPct
+  }
+}
+"""
+
 QUERY_SYSTEM = """
 query System {
   system {
@@ -321,6 +343,11 @@ query BoilerStatus {
   }
 }
 """
+
+_RADIO_GROUP_ZONE_VRC = 0x09
+_RADIO_GROUP_ZONE_VR92 = 0x0A
+_RADIO_GROUP_INVENTORY = 0x0C
+_RADIO_STALE_GRACE_CYCLES = 3
 
 class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     """Coordinator fetching GraphQL device inventory."""
@@ -527,6 +554,125 @@ class HelianthusCircuitCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
 
 
+class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator fetching remote-slot radio device snapshots."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_radio_devices",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+        self._client = client
+        self._last_by_slot: dict[tuple[int, int], dict[str, Any]] = {}
+        self._stale_cycles: dict[tuple[int, int], int] = {}
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        empty = {"radioDevices": [], "radioZoneCandidates": {}}
+        missing_fields = [
+            "radioDevices",
+            "group",
+            "instance",
+            "slotMode",
+            "deviceConnected",
+            "deviceClassAddress",
+            "deviceModel",
+            "firmwareVersion",
+            "hardwareIdentifier",
+            "remoteControlAddress",
+            "devicePaired",
+            "receptionStrength",
+            "zoneAssignment",
+            "roomTemperatureC",
+            "roomHumidityPct",
+        ]
+        try:
+            payload = await self._client.execute(QUERY_RADIO_DEVICES)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, missing_fields):
+                self._last_by_slot = {}
+                self._stale_cycles = {}
+                return empty
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            self._last_by_slot = {}
+            self._stale_cycles = {}
+            return empty
+        devices = payload.get("radioDevices")
+        if not isinstance(devices, list):
+            self._last_by_slot = {}
+            self._stale_cycles = {}
+            return empty
+        return self._materialize_snapshot(devices)
+
+    def apply_radio_update(self, devices: Any) -> None:
+        if not isinstance(devices, list):
+            return
+        self.async_set_updated_data(self._materialize_snapshot(devices))
+
+    def _materialize_snapshot(self, devices: list[Any]) -> dict[str, Any]:
+        observed_by_slot: dict[tuple[int, int], dict[str, Any]] = {}
+        active_by_slot: dict[tuple[int, int], dict[str, Any]] = {}
+        for raw_device in devices:
+            if not isinstance(raw_device, dict):
+                continue
+            normalized = _normalize_radio_device(raw_device)
+            if normalized is None:
+                continue
+            slot = (normalized["group"], normalized["instance"])
+            observed_by_slot[slot] = normalized
+            if _is_active_radio_device(normalized):
+                active_by_slot[slot] = normalized
+
+        combined: dict[tuple[int, int], dict[str, Any]] = {}
+        next_stale_cycles: dict[tuple[int, int], int] = {}
+        for slot, device in active_by_slot.items():
+            current = dict(device)
+            current["staleCycles"] = 0
+            current["radioBusKey"] = _radio_bus_key(slot[0], slot[1])
+            combined[slot] = current
+            next_stale_cycles[slot] = 0
+
+        for slot, previous in self._last_by_slot.items():
+            if slot in combined:
+                continue
+            stale = self._stale_cycles.get(slot, 0) + 1
+            if stale > _RADIO_STALE_GRACE_CYCLES:
+                continue
+            carried = dict(previous)
+            observed = observed_by_slot.get(slot)
+            if isinstance(observed, dict):
+                carried.update(observed)
+            if observed is None or not _is_active_radio_device(observed):
+                carried["deviceConnected"] = False
+            carried["staleCycles"] = stale
+            carried["radioBusKey"] = _radio_bus_key(slot[0], slot[1])
+            combined[slot] = carried
+            next_stale_cycles[slot] = stale
+
+        sorted_slots = sorted(combined.keys(), key=lambda item: (item[0], item[1]))
+        radio_devices = [combined[slot] for slot in sorted_slots]
+        candidates = _build_radio_zone_candidates(active_by_slot)
+
+        self._last_by_slot = {
+            slot: {
+                key: value
+                for key, value in combined[slot].items()
+                if key not in {"staleCycles"}
+            }
+            for slot in sorted_slots
+        }
+        self._stale_cycles = dict(next_stale_cycles)
+        return {
+            "radioDevices": radio_devices,
+            "radioZoneCandidates": candidates,
+        }
+
+
 class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator fetching semantic system data."""
 
@@ -669,6 +815,149 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return {"boilerStatus": None}
         self.boiler_supported = True
         return {"boilerStatus": payload.get("boilerStatus")}
+
+
+def _parse_optional_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_optional_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_radio_device(raw: dict[str, Any]) -> dict[str, Any] | None:
+    group = _parse_optional_int(raw.get("group"))
+    instance = _parse_optional_int(raw.get("instance"))
+    if group is None or instance is None:
+        return None
+    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
+        return None
+
+    normalized: dict[str, Any] = {
+        "group": group,
+        "instance": instance,
+        "slotMode": str(raw.get("slotMode") or "").strip() or "active",
+    }
+
+    connected = raw.get("deviceConnected")
+    if isinstance(connected, bool):
+        normalized["deviceConnected"] = connected
+    class_address = _parse_optional_int(raw.get("deviceClassAddress"))
+    if class_address is not None and 0 <= class_address <= 0xFF:
+        normalized["deviceClassAddress"] = class_address
+
+    device_model = str(raw.get("deviceModel") or "").strip()
+    if device_model:
+        normalized["deviceModel"] = device_model
+    firmware = str(raw.get("firmwareVersion") or "").strip()
+    if firmware:
+        normalized["firmwareVersion"] = firmware
+
+    hardware_identifier = _parse_optional_int(raw.get("hardwareIdentifier"))
+    if hardware_identifier is not None and hardware_identifier >= 0:
+        normalized["hardwareIdentifier"] = hardware_identifier
+    remote_control_address = _parse_optional_int(raw.get("remoteControlAddress"))
+    if remote_control_address is not None and remote_control_address >= 0:
+        normalized["remoteControlAddress"] = remote_control_address
+    paired = raw.get("devicePaired")
+    if isinstance(paired, bool):
+        normalized["devicePaired"] = paired
+    reception_strength = _parse_optional_int(raw.get("receptionStrength"))
+    if reception_strength is not None:
+        normalized["receptionStrength"] = reception_strength
+    zone_assignment = _parse_optional_int(raw.get("zoneAssignment"))
+    if zone_assignment is not None and zone_assignment >= 0:
+        normalized["zoneAssignment"] = zone_assignment
+    room_temperature = _parse_optional_float(raw.get("roomTemperatureC"))
+    if room_temperature is not None:
+        normalized["roomTemperatureC"] = room_temperature
+    room_humidity = _parse_optional_float(raw.get("roomHumidityPct"))
+    if room_humidity is not None:
+        normalized["roomHumidityPct"] = room_humidity
+
+    return normalized
+
+
+def _has_radio_identity_evidence(device: dict[str, Any]) -> bool:
+    class_address = _parse_optional_int(device.get("deviceClassAddress"))
+    if class_address == 0x26:
+        return True
+    if str(device.get("deviceModel") or "").strip():
+        return True
+    if str(device.get("firmwareVersion") or "").strip():
+        return True
+    if _parse_optional_int(device.get("hardwareIdentifier")) is not None:
+        return True
+    return False
+
+
+def _is_active_radio_device(device: dict[str, Any]) -> bool:
+    group = _parse_optional_int(device.get("group"))
+    if group is None:
+        return False
+    connected = device.get("deviceConnected") is True
+    if group in (_RADIO_GROUP_ZONE_VRC, _RADIO_GROUP_ZONE_VR92):
+        return connected
+    if group == _RADIO_GROUP_INVENTORY:
+        return _has_radio_identity_evidence(device)
+    return connected or _has_radio_identity_evidence(device)
+
+
+def _radio_bus_key(group: int, instance: int) -> str:
+    return f"g{group:02x}-i{instance:02d}"
+
+
+def _build_radio_zone_candidates(
+    active_by_slot: dict[tuple[int, int], dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+    by_zone: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
+    for (_, _), device in active_by_slot.items():
+        group = _parse_optional_int(device.get("group"))
+        instance = _parse_optional_int(device.get("instance"))
+        if group not in (_RADIO_GROUP_ZONE_VRC, _RADIO_GROUP_ZONE_VR92):
+            continue
+        if instance is None:
+            continue
+        if device.get("deviceConnected") is not True:
+            continue
+        zone_assignment = _parse_optional_int(device.get("zoneAssignment"))
+        if zone_assignment is None or zone_assignment <= 0:
+            continue
+        zone_instance = zone_assignment - 1
+        by_zone[zone_instance].append(
+            {
+                "group": group,
+                "instance": instance,
+                "remote_control_address": _parse_optional_int(device.get("remoteControlAddress")),
+                "radio_bus_key": _radio_bus_key(group, instance),
+            }
+        )
+
+    out: dict[int, list[dict[str, Any]]] = {}
+    for zone_instance, candidates in by_zone.items():
+        candidates.sort(
+            key=lambda item: (
+                int(item.get("group") or 0),
+                (
+                    int(item["remote_control_address"])
+                    if isinstance(item.get("remote_control_address"), int)
+                    else 255
+                ),
+                int(item.get("instance") or 0),
+            )
+        )
+        out[zone_instance] = candidates
+    return out
 
 
 def _is_missing_field_error(errors: object, fields: list[str]) -> bool:

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -137,6 +137,14 @@ def circuit_identifier(config_entry_id: str, circuit_index: object) -> DeviceIde
     return (DOMAIN, f"{_token(config_entry_id)}-circuit-{token}")
 
 
+def build_radio_bus_key(group: int, instance: int) -> str:
+    return f"g{group:02x}-i{instance:02d}"
+
+
+def radio_device_identifier(config_entry_id: str, radio_bus_key: str) -> DeviceIdentifier:
+    return (DOMAIN, f"{_token(config_entry_id)}-radio-{_token(radio_bus_key)}")
+
+
 def dhw_identifier(config_entry_id: str) -> tuple[str, str]:
     return (DOMAIN, f"{_token(config_entry_id)}-dhw")
 

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -12,11 +12,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .device_ids import (
+    build_radio_bus_key,
     build_bus_device_key,
     bus_identifier,
     circuit_identifier,
     dhw_identifier,
     energy_identifier,
+    radio_device_identifier,
     resolve_bus_address,
     zone_identifier,
 )
@@ -82,6 +84,8 @@ _SENSOR_DEVICE_CLASS_HUMIDITY = getattr(SensorDeviceClass, "HUMIDITY", None)
 _SENSOR_DEVICE_CLASS_DURATION = getattr(SensorDeviceClass, "DURATION", None)
 _SENSOR_DEVICE_CLASS_PRESSURE = getattr(SensorDeviceClass, "PRESSURE", None)
 _SENSOR_STATE_CLASS_TOTAL_INCREASING = getattr(SensorStateClass, "TOTAL_INCREASING", None)
+_RADIO_ROOM_CLASSES = {0x15, 0x35}
+_RADIO_STALE_GRACE_CYCLES = 3
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -226,6 +230,51 @@ def _parse_circuit_index(value: object | None) -> int | None:
     return parsed
 
 
+def _parse_optional_int(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _radio_slot(device: dict[str, Any]) -> tuple[int, int] | None:
+    group = _parse_optional_int(device.get("group"))
+    instance = _parse_optional_int(device.get("instance"))
+    if group is None or instance is None:
+        return None
+    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
+        return None
+    return (group, instance)
+
+
+def _radio_bus_key(device: dict[str, Any]) -> str | None:
+    slot = _radio_slot(device)
+    if slot is None:
+        return None
+    explicit = _clean_text(device.get("radioBusKey"))
+    if explicit:
+        return explicit
+    return build_radio_bus_key(slot[0], slot[1])
+
+
+def _radio_model_name(device: dict[str, Any]) -> str:
+    model = _clean_text(device.get("deviceModel"))
+    if model:
+        return model
+    class_address = _parse_optional_int(device.get("deviceClassAddress"))
+    if class_address == 0x15:
+        return "VRC720f/2"
+    if class_address == 0x35:
+        return "VR92f"
+    if class_address == 0x26:
+        return "VR71/FM5"
+    if class_address is not None and class_address >= 0:
+        return f"Unknown Radio (0x{class_address:02X})"
+    return "Unknown Radio"
+
+
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     token = str(circuit.get("circuitType") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
@@ -239,6 +288,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     semantic_coordinator = data.get("semantic_coordinator")
     energy_coordinator = data.get("energy_coordinator")
     circuit_coordinator = data.get("circuit_coordinator")
+    radio_coordinator = data.get("radio_coordinator")
     system_coordinator = data.get("system_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
@@ -336,6 +386,94 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     field=field,
                 )
             )
+
+    if radio_coordinator and radio_coordinator.data:
+        radio_devices = radio_coordinator.data.get("radioDevices", []) or []
+        for radio in radio_devices:
+            if not isinstance(radio, dict):
+                continue
+            slot = _radio_slot(radio)
+            bus_key = _radio_bus_key(radio)
+            if slot is None or bus_key is None:
+                continue
+            group, instance = slot
+            class_address = _parse_optional_int(radio.get("deviceClassAddress"))
+            is_room = class_address in _RADIO_ROOM_CLASSES
+            radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
+            radio_name = _radio_model_name(radio)
+            if is_room or radio.get("receptionStrength") is not None:
+                sensors.append(
+                    HelianthusRadioSensor(
+                        coordinator=radio_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        radio_device_id=radio_device_id,
+                        radio_name=radio_name,
+                        group=group,
+                        instance=instance,
+                        key="receptionStrength",
+                        label="Signal Quality",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        cast_int=True,
+                    )
+                )
+            if is_room:
+                sensors.append(
+                    HelianthusRadioSensor(
+                        coordinator=radio_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        radio_device_id=radio_device_id,
+                        radio_name=radio_name,
+                        group=group,
+                        instance=instance,
+                        key="roomTemperatureC",
+                        label="Room Temperature",
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit=UnitOfTemperature.CELSIUS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    )
+                )
+                sensors.append(
+                    HelianthusRadioSensor(
+                        coordinator=radio_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        radio_device_id=radio_device_id,
+                        radio_name=radio_name,
+                        group=group,
+                        instance=instance,
+                        key="roomHumidityPct",
+                        label="Room Humidity",
+                        device_class=_SENSOR_DEVICE_CLASS_HUMIDITY,
+                        native_unit=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    )
+                )
+            elif group == 0x0C:
+                for key, label in [
+                    ("deviceClassAddress", "Device Class Address"),
+                    ("hardwareIdentifier", "Hardware Identifier"),
+                    ("remoteControlAddress", "Remote Control Address"),
+                    ("zoneAssignment", "Zone Assignment"),
+                ]:
+                    if radio.get(key) is None:
+                        continue
+                    sensors.append(
+                        HelianthusRadioSensor(
+                            coordinator=radio_coordinator,
+                            entry_id=entry.entry_id,
+                            manufacturer=manufacturer,
+                            radio_device_id=radio_device_id,
+                            radio_name=radio_name,
+                            group=group,
+                            instance=instance,
+                            key=key,
+                            label=label,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            cast_int=True,
+                        )
+                    )
 
     if semantic_coordinator and semantic_coordinator.data:
         zones = semantic_coordinator.data.get("zones", []) or []
@@ -620,6 +758,90 @@ class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
         if value is None:
             return None
         if self._field.cast_int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+        if isinstance(value, (bool, int, float, str)):
+            return value
+        return None
+
+
+class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
+    """Per-slot remote radio sensor."""
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        radio_device_id: tuple[str, str],
+        radio_name: str,
+        group: int,
+        instance: int,
+        key: str,
+        label: str,
+        device_class: str | None = None,
+        native_unit: str | None = None,
+        state_class: str | None = None,
+        entity_category: str | None = None,
+        cast_int: bool = False,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._radio_device_id = radio_device_id
+        self._radio_name = radio_name
+        self._group = group
+        self._instance = instance
+        self._key = key
+        self._cast_int = cast_int
+        self._attr_name = f"{radio_name} {label}"
+        self._attr_unique_id = f"{entry_id}-radio-{group:02x}-{instance:02d}-sensor-{key}"
+        if device_class is not None:
+            self._attr_device_class = device_class
+        if native_unit is not None:
+            self._attr_native_unit_of_measurement = native_unit
+        if state_class is not None:
+            self._attr_state_class = state_class
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
+
+    def _device(self) -> dict[str, Any] | None:
+        payload = self.coordinator.data or {}
+        for device in payload.get("radioDevices", []) or []:
+            if not isinstance(device, dict):
+                continue
+            slot = _radio_slot(device)
+            if slot == (self._group, self._instance):
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        device = self._device()
+        if device is None:
+            return False
+        stale = _parse_optional_int(device.get("staleCycles")) or 0
+        return stale < _RADIO_STALE_GRACE_CYCLES
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._radio_device_id},
+            manufacturer=self._manufacturer,
+            name=self._radio_name,
+        )
+
+    @property
+    def native_value(self) -> Any:
+        device = self._device()
+        if not isinstance(device, dict):
+            return None
+        value = device.get(self._key)
+        if value is None:
+            return None
+        if self._cast_int:
             try:
                 return int(value)
             except (TypeError, ValueError):

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -75,6 +75,26 @@ SUBSCRIPTIONS = {
       }
     }
     """,
+    "radio_devices": """
+    subscription {
+      radioDevicesUpdate {
+        group
+        instance
+        slotMode
+        deviceConnected
+        deviceClassAddress
+        deviceModel
+        firmwareVersion
+        hardwareIdentifier
+        remoteControlAddress
+        devicePaired
+        receptionStrength
+        zoneAssignment
+        roomTemperatureC
+        roomHumidityPct
+      }
+    }
+    """,
 }
 
 
@@ -93,6 +113,7 @@ async def start_subscriptions(
     semantic_coordinator,
     energy_coordinator,
     boiler_coordinator,
+    radio_coordinator,
 ) -> asyncio.Task:
     ws_url = _to_ws_url(url)
     return asyncio.create_task(
@@ -102,6 +123,7 @@ async def start_subscriptions(
             semantic_coordinator,
             energy_coordinator,
             boiler_coordinator,
+            radio_coordinator,
         )
     )
 
@@ -112,6 +134,7 @@ async def _subscription_loop(
     semantic_coordinator,
     energy_coordinator,
     boiler_coordinator,
+    radio_coordinator,
 ) -> None:
     try:
         async with session.ws_connect(ws_url, protocols=["graphql-transport-ws"]) as ws:
@@ -125,6 +148,8 @@ async def _subscription_loop(
             }
             if boiler_coordinator is not None:
                 subscriptions["boiler"] = SUBSCRIPTIONS["boiler"]
+            if radio_coordinator is not None:
+                subscriptions["radio_devices"] = SUBSCRIPTIONS["radio_devices"]
 
             for key, query in subscriptions.items():
                 await ws.send_json({"id": key, "type": "subscribe", "payload": {"query": query}})
@@ -136,6 +161,7 @@ async def _subscription_loop(
                         semantic_coordinator,
                         energy_coordinator,
                         boiler_coordinator,
+                        radio_coordinator,
                     )
                 elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR):
                     break
@@ -158,6 +184,7 @@ async def _handle_message(
     semantic_coordinator,
     energy_coordinator,
     boiler_coordinator,
+    radio_coordinator,
 ) -> None:
     if message.get("type") == "error":
         _LOGGER.debug("GraphQL subscription error frame: %s", message)
@@ -193,3 +220,12 @@ async def _handle_message(
     if "boilerStatusUpdate" in data and boiler_coordinator:
         boiler = data.get("boilerStatusUpdate")
         boiler_coordinator.async_set_updated_data({"boilerStatus": boiler})
+
+    if "radioDevicesUpdate" in data and radio_coordinator:
+        radio_devices = data.get("radioDevicesUpdate")
+        if hasattr(radio_coordinator, "apply_radio_update"):
+            radio_coordinator.apply_radio_update(radio_devices)
+        elif isinstance(radio_devices, list):
+            radio_coordinator.async_set_updated_data(
+                {"radioDevices": radio_devices, "radioZoneCandidates": {}}
+            )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -39,6 +39,7 @@ from custom_components.helianthus.coordinator import (
     QUERY_EXTENDED_V3,
     QUERY_EXTENDED_V3_NO_ADDRESSES,
     QUERY_EXTENDED_V3_NO_PART,
+    QUERY_RADIO_DEVICES,
     QUERY_STATUS,
     QUERY_STATUS_LEGACY,
     QUERY_SYSTEM,
@@ -46,6 +47,7 @@ from custom_components.helianthus.coordinator import (
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
     HelianthusCoordinator,
+    HelianthusRadioDeviceCoordinator,
     HelianthusSystemCoordinator,
     HelianthusStatusCoordinator,
 )
@@ -93,6 +95,16 @@ def _build_circuit_coordinator(client: _ScriptedClient) -> HelianthusCircuitCoor
 def _build_system_coordinator(client: _ScriptedClient) -> HelianthusSystemCoordinator:
     coordinator = object.__new__(HelianthusSystemCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_radio_coordinator(client: _ScriptedClient) -> HelianthusRadioDeviceCoordinator:
+    coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
+    coordinator._last_by_slot = {}  # type: ignore[attr-defined]
+    coordinator._stale_cycles = {}  # type: ignore[attr-defined]
+    coordinator.data = {}  # type: ignore[attr-defined]
+    coordinator.async_set_updated_data = lambda payload: setattr(coordinator, "data", payload)  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -390,3 +402,76 @@ def test_system_query_missing_field_falls_back_to_empty_payload() -> None:
 
     assert data == {"state": {}, "config": {}, "properties": {}}
     assert client.calls == [QUERY_SYSTEM]
+
+
+def test_radio_query_builds_candidates_and_inventory_slot() -> None:
+    payload = {
+        "radioDevices": [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "deviceConnected": True,
+                "deviceClassAddress": 0x15,
+                "zoneAssignment": 2,
+                "remoteControlAddress": 0,
+            },
+            {
+                "group": 0x09,
+                "instance": 2,
+                "deviceConnected": False,
+                "deviceClassAddress": 0x15,
+                "zoneAssignment": 3,
+            },
+            {
+                "group": 0x0C,
+                "instance": 1,
+                "deviceConnected": False,
+                "deviceClassAddress": 0x26,
+                "firmwareVersion": "0805",
+                "hardwareIdentifier": 0x1234,
+            },
+        ]
+    }
+    client = _ScriptedClient([payload])
+    coordinator = _build_radio_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    slots = {(int(item["group"]), int(item["instance"])) for item in data["radioDevices"]}
+    assert slots == {(0x09, 1), (0x0C, 1)}
+    assert 1 in data["radioZoneCandidates"]
+    assert data["radioZoneCandidates"][1][0]["group"] == 0x09
+    assert data["radioZoneCandidates"][1][0]["instance"] == 1
+    assert client.calls == [QUERY_RADIO_DEVICES]
+
+
+def test_radio_query_uses_stale_grace_cycles_for_disconnected_slot() -> None:
+    client = _ScriptedClient(
+        [
+            {
+                "radioDevices": [
+                    {
+                        "group": 0x09,
+                        "instance": 1,
+                        "deviceConnected": True,
+                        "deviceClassAddress": 0x15,
+                    }
+                ]
+            }
+        ]
+    )
+    coordinator = _build_radio_coordinator(client)
+    first = asyncio.run(coordinator._async_update_data())
+    assert len(first["radioDevices"]) == 1
+    coordinator.apply_radio_update(
+        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+    )
+    assert coordinator.data["radioDevices"][0]["staleCycles"] == 1  # type: ignore[index]
+    coordinator.apply_radio_update(
+        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+    )
+    assert coordinator.data["radioDevices"][0]["staleCycles"] == 2  # type: ignore[index]
+    coordinator.apply_radio_update(
+        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+    )
+    assert coordinator.data["radioDevices"][0]["staleCycles"] == 3  # type: ignore[index]

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -4,6 +4,7 @@ from custom_components.helianthus.device_ids import (
     adapter_identifier,
     boiler_burner_identifier,
     boiler_hydraulics_identifier,
+    build_radio_bus_key,
     bus_identifier,
     build_bus_device_key,
     circuit_identifier,
@@ -11,6 +12,7 @@ from custom_components.helianthus.device_ids import (
     dhw_identifier,
     energy_identifier,
     managing_device_identifier,
+    radio_device_identifier,
     resolve_boiler_physical_device_id,
     resolve_boiler_via_device_id,
     resolve_bus_address,
@@ -97,6 +99,8 @@ def test_identifier_helpers_are_deterministic() -> None:
     assert bus_identifier("entry-1", "BASV2-sn-ABC123") == ("helianthus", "entry-1-bus-BASV2-sn-ABC123")
     assert zone_identifier("entry-1", "1") == ("helianthus", "entry-1-zone-1")
     assert circuit_identifier("entry-1", 0) == ("helianthus", "entry-1-circuit-0")
+    assert build_radio_bus_key(0x09, 1) == "g09-i01"
+    assert radio_device_identifier("entry-1", "g09-i01") == ("helianthus", "entry-1-radio-g09-i01")
     assert dhw_identifier("entry-1") == ("helianthus", "entry-1-dhw")
     assert energy_identifier("entry-1") == ("helianthus", "entry-1-energy")
 

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -1,0 +1,338 @@
+"""Tests for HA-11 remote-slot radio coordinator and entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+            PRESSURE = "pressure"
+            HUMIDITY = "humidity"
+            DURATION = "duration"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+            TOTAL_INCREASING = "total_increasing"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    binary_sensor_module = sys.modules.setdefault(
+        "homeassistant.components.binary_sensor",
+        types.ModuleType("homeassistant.components.binary_sensor"),
+    )
+    if not hasattr(binary_sensor_module, "BinarySensorEntity"):
+        class _BinarySensorEntity:
+            pass
+
+        binary_sensor_module.BinarySensorEntity = _BinarySensorEntity
+    if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
+        class _BinarySensorDeviceClass:
+            RUNNING = "running"
+            PROBLEM = "problem"
+
+        binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+    aiohttp_module = sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
+    if not hasattr(aiohttp_module, "WSMsgType"):
+        class _WSMsgType:
+            TEXT = "TEXT"
+            CLOSE = "CLOSE"
+            ERROR = "ERROR"
+
+        aiohttp_module.WSMsgType = _WSMsgType
+    if not hasattr(aiohttp_module, "ClientSession"):
+        class _ClientSession:
+            pass
+
+        aiohttp_module.ClientSession = _ClientSession
+    if not hasattr(aiohttp_module, "ClientWebSocketResponse"):
+        class _ClientWebSocketResponse:
+            pass
+
+        aiohttp_module.ClientWebSocketResponse = _ClientWebSocketResponse
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import binary_sensor as binary_sensor_platform
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus import subscriptions
+from custom_components.helianthus.const import DOMAIN
+from custom_components.helianthus.coordinator import HelianthusRadioDeviceCoordinator
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+    def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+        self.data = payload
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _base_payload(radio_devices: list[dict]) -> dict:
+    return {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
+        "energy_coordinator": None,
+        "circuit_coordinator": None,
+        "radio_coordinator": _FakeCoordinator(
+            {"radioDevices": radio_devices, "radioZoneCandidates": {}}
+        ),
+        "system_coordinator": None,
+        "boiler_coordinator": None,
+        "boiler_device_id": None,
+        "graphql_client": None,
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_radio_sensor_entities_cover_room_and_inventory_devices() -> None:
+    radio_devices = [
+        {
+            "group": 0x09,
+            "instance": 1,
+            "radioBusKey": "g09-i01",
+            "deviceClassAddress": 0x15,
+            "deviceConnected": True,
+            "receptionStrength": 84,
+            "roomTemperatureC": 21.5,
+            "roomHumidityPct": 45.0,
+            "staleCycles": 0,
+        },
+        {
+            "group": 0x0C,
+            "instance": 2,
+            "radioBusKey": "g0c-i02",
+            "deviceClassAddress": 0x99,
+            "deviceConnected": False,
+            "hardwareIdentifier": 0x2233,
+            "remoteControlAddress": 17,
+            "zoneAssignment": 0,
+            "staleCycles": 0,
+        },
+    ]
+    hass = _FakeHass(_base_payload(radio_devices))
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    radio_entities = [
+        entity for entity in entities if isinstance(entity, sensor_platform.HelianthusRadioSensor)
+    ]
+    unique_ids = {entity._attr_unique_id for entity in radio_entities}
+    assert "entry-1-radio-09-01-sensor-roomTemperatureC" in unique_ids
+    assert "entry-1-radio-09-01-sensor-roomHumidityPct" in unique_ids
+    assert "entry-1-radio-09-01-sensor-receptionStrength" in unique_ids
+    assert "entry-1-radio-0c-02-sensor-deviceClassAddress" in unique_ids
+    assert "entry-1-radio-0c-02-sensor-hardwareIdentifier" in unique_ids
+
+
+def test_radio_connected_entity_becomes_unavailable_after_third_stale_cycle() -> None:
+    radio_devices = [
+        {
+            "group": 0x09,
+            "instance": 1,
+            "radioBusKey": "g09-i01",
+            "deviceClassAddress": 0x15,
+            "deviceConnected": True,
+            "staleCycles": 0,
+        }
+    ]
+    payload = _base_payload(radio_devices)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    connected_entity = next(
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusRadioConnectedBinarySensor)
+    )
+    assert connected_entity.available is True
+    assert connected_entity.is_on is True
+
+    payload["radio_coordinator"].data = {
+        "radioDevices": [{**radio_devices[0], "deviceConnected": False, "staleCycles": 2}],
+        "radioZoneCandidates": {},
+    }
+    assert connected_entity.available is True
+    assert connected_entity.is_on is False
+
+    payload["radio_coordinator"].data = {
+        "radioDevices": [{**radio_devices[0], "deviceConnected": False, "staleCycles": 3}],
+        "radioZoneCandidates": {},
+    }
+    assert connected_entity.available is False
+
+
+def test_subscription_dispatches_radio_updates_to_radio_coordinator() -> None:
+    class _FakeRadioCoordinator:
+        def __init__(self) -> None:
+            self.seen: list | None = None
+
+        def apply_radio_update(self, payload) -> None:  # noqa: ANN001
+            self.seen = payload
+
+    fake = _FakeRadioCoordinator()
+    message = {
+        "type": "next",
+        "payload": {
+            "data": {
+                "radioDevicesUpdate": [
+                    {"group": 0x09, "instance": 1, "deviceConnected": True}
+                ]
+            }
+        },
+    }
+
+    asyncio.run(
+        subscriptions._handle_message(
+            message,
+            semantic_coordinator=None,
+            energy_coordinator=None,
+            boiler_coordinator=None,
+            radio_coordinator=fake,
+        )
+    )
+
+    assert isinstance(fake.seen, list)
+    assert fake.seen[0]["group"] == 0x09
+
+
+def test_radio_zone_candidates_update_on_reassignment() -> None:
+    coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
+    coordinator._last_by_slot = {}
+    coordinator._stale_cycles = {}
+    coordinator.async_set_updated_data = lambda payload: setattr(coordinator, "data", payload)
+    coordinator.data = {}
+
+    coordinator.apply_radio_update(
+        [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "deviceConnected": True,
+                "deviceClassAddress": 0x15,
+                "zoneAssignment": 1,
+                "remoteControlAddress": 0,
+            }
+        ]
+    )
+    assert 0 in coordinator.data["radioZoneCandidates"]
+
+    coordinator.apply_radio_update(
+        [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "deviceConnected": True,
+                "deviceClassAddress": 0x15,
+                "zoneAssignment": 2,
+                "remoteControlAddress": 0,
+            }
+        ]
+    )
+    assert 1 in coordinator.data["radioZoneCandidates"]
+    assert 0 not in coordinator.data["radioZoneCandidates"]


### PR DESCRIPTION
## What
- add `HelianthusRadioDeviceCoordinator` with remote-slot polling and deterministic `radioZoneCandidates` index
- implement pair/inventory gating:
  - 0x09/0x0A slots are active only when `deviceConnected=true`
  - 0x0C inventory slots are admitted via identity evidence even when disconnected
- add stale grace handling for disappearing slots (entities become unavailable after 3 cycles)
- register remote-slot physical devices under BASV2 (or adapter root fallback) with firmware/hardware versions
- add radio sensors and connected binary sensor entities
- wire GraphQL subscription flow for `radioDevicesUpdate` into radio coordinator
- expose coordinator in integration runtime data for downstream zone parent resolver usage

## Testing
- `pytest tests/test_radio_device.py tests/test_coordinator.py tests/test_device_ids.py`
- `pytest tests/`
- `./scripts/ci_local.sh`

Fixes #121