### PR TITLE
HA-8: add zone valve entities and R8 radio-based zone parentage

### DIFF
--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import zone_identifier
+from .device_ids import build_radio_bus_key, radio_device_identifier, zone_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 from .semantic_tokens import normalize_allowed_mode_tokens, normalize_preset_token
 
@@ -53,6 +53,107 @@ _ZONE_WRITABLE_REGISTERS: dict[int, str] = {
     _ZONE_TARGET_TEMP_DESIRED_ADDR: "configuration.heating.desired_setpoint",
     _ZONE_TARGET_TEMP_ADDR: "configuration.heating.manual_mode_setpoint",
 }
+
+_ROOM_TEMPERATURE_ZONE_MAPPING_TEXT = {
+    0: "none",
+    1: "regulator",
+    2: "thermostat_1",
+    3: "thermostat_2",
+    4: "thermostat_3",
+}
+
+
+def _parse_optional_int(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_radio_slot_candidate(candidate: dict[str, Any]) -> dict[str, Any] | None:
+    group = _parse_optional_int(candidate.get("group"))
+    instance = _parse_optional_int(candidate.get("instance"))
+    if group is None or instance is None:
+        return None
+    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
+        return None
+    return {
+        "group": group,
+        "instance": instance,
+        "remote_control_address": _parse_optional_int(candidate.get("remote_control_address")),
+    }
+
+
+def _select_zone_radio_candidate(
+    zone_instance: int,
+    room_temperature_zone_mapping: int | None,
+    radio_zone_candidates: dict[int, list[dict[str, Any]]],
+) -> dict[str, Any] | None:
+    candidates = list(radio_zone_candidates.get(zone_instance, []) or [])
+
+    def pick(group: int, remote_addr: int | None = None) -> dict[str, Any] | None:
+        for candidate in candidates:
+            if candidate.get("group") != group:
+                continue
+            if remote_addr is not None and candidate.get("remote_control_address") != remote_addr:
+                continue
+            return candidate
+        return None
+
+    def pick_thermostat_fallback(target_remote_addr: int) -> dict[str, Any] | None:
+        ranked = sorted(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.get("group") == 0x0A
+            ),
+            key=lambda candidate: (
+                abs(
+                    (
+                        candidate.get("remote_control_address")
+                        if isinstance(candidate.get("remote_control_address"), int)
+                        else 255
+                    )
+                    - target_remote_addr
+                ),
+                int(candidate.get("instance") or 0),
+            ),
+        )
+        return ranked[0] if ranked else None
+
+    if room_temperature_zone_mapping == 1:
+        return pick(0x09, 0) or pick(0x09)
+    if room_temperature_zone_mapping in (2, 3, 4):
+        remote_addr = room_temperature_zone_mapping - 1
+        return pick(0x0A, remote_addr) or pick_thermostat_fallback(remote_addr) or pick(0x09)
+    if room_temperature_zone_mapping == 0:
+        return None
+    return pick(0x0A) or pick(0x09)
+
+
+def zone_via_device(
+    zone_instance: int,
+    room_temperature_zone_mapping: int | None,
+    radio_zone_candidates: dict[int, list[dict[str, Any]]],
+    radio_device_ids: dict[tuple[int, int], tuple[str, str]],
+    regulator_device_id: tuple[str, str] | None,
+) -> tuple[str, str] | None:
+    candidate = _select_zone_radio_candidate(
+        zone_instance,
+        room_temperature_zone_mapping,
+        radio_zone_candidates,
+    )
+    if candidate is not None:
+        slot = (
+            int(candidate.get("group") or 0),
+            int(candidate.get("instance") or 0),
+        )
+        radio_id = radio_device_ids.get(slot)
+        if radio_id is not None:
+            return radio_id
+    return regulator_device_id
 
 
 def _normalize_zone_id(zone_id: object | None) -> str | None:
@@ -98,7 +199,8 @@ def _zone_default_name(zone_id: object | None) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["semantic_coordinator"]
-    via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
+    radio_coordinator = data.get("radio_coordinator")
+    regulator_device_id = data.get("regulator_device_id") or data.get("adapter_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
     regulator_bus_address = data.get("regulator_bus_address")
@@ -109,7 +211,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         HelianthusZoneClimate(
             entry.entry_id,
             coordinator,
-            via_device,
+            radio_coordinator,
+            regulator_device_id,
             manufacturer,
             client,
             regulator_bus_address,
@@ -134,7 +237,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         self,
         entry_id: str,
         coordinator,
-        via_device: tuple[str, str] | None,
+        radio_coordinator,
+        regulator_device_id: tuple[str, str] | None,
         manufacturer: str,
         client: GraphQLClient | None,
         regulator_bus_address: int | None,
@@ -144,7 +248,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
-        self._via_device = via_device
+        self._radio_coordinator = radio_coordinator
+        self._regulator_device_id = regulator_device_id
         self._manufacturer = manufacturer
         self._client = client
         self._regulator_bus_address = regulator_bus_address
@@ -177,7 +282,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     @property
     def device_info(self) -> DeviceInfo:
         identifier = zone_identifier(self._entry_id, str(self._zone_id))
-        via = self._via_device
+        via = self._resolved_via_device()
         return DeviceInfo(
             identifiers={identifier},
             manufacturer=self._manufacturer,
@@ -191,6 +296,97 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
     def _zone_config(self) -> dict[str, Any]:
         return self._zone().get("config") or {}
+
+    def _room_temperature_zone_mapping(self) -> int | None:
+        return _parse_optional_int(self._zone_config().get("roomTemperatureZoneMapping"))
+
+    def _radio_zone_candidates(self) -> dict[int, list[dict[str, Any]]]:
+        if self._radio_coordinator is None or not isinstance(self._radio_coordinator.data, dict):
+            return {}
+        raw_candidates = self._radio_coordinator.data.get("radioZoneCandidates")
+        if not isinstance(raw_candidates, dict):
+            return {}
+        out: dict[int, list[dict[str, Any]]] = {}
+        for raw_zone_instance, raw_items in raw_candidates.items():
+            zone_instance = _parse_optional_int(raw_zone_instance)
+            if zone_instance is None:
+                continue
+            if not isinstance(raw_items, list):
+                continue
+            normalized_items: list[dict[str, Any]] = []
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+                normalized = _normalize_radio_slot_candidate(item)
+                if normalized is not None:
+                    normalized_items.append(normalized)
+            if normalized_items:
+                out[zone_instance] = normalized_items
+        return out
+
+    def _radio_devices(self) -> list[dict[str, Any]]:
+        if self._radio_coordinator is None or not isinstance(self._radio_coordinator.data, dict):
+            return []
+        items = self._radio_coordinator.data.get("radioDevices")
+        if not isinstance(items, list):
+            return []
+        return [item for item in items if isinstance(item, dict)]
+
+    def _radio_device_ids(self) -> dict[tuple[int, int], tuple[str, str]]:
+        out: dict[tuple[int, int], tuple[str, str]] = {}
+        for device in self._radio_devices():
+            group = _parse_optional_int(device.get("group"))
+            instance = _parse_optional_int(device.get("instance"))
+            if group is None or instance is None:
+                continue
+            bus_key = str(device.get("radioBusKey") or "").strip()
+            if not bus_key:
+                bus_key = build_radio_bus_key(group, instance)
+            out[(group, instance)] = radio_device_identifier(self._entry_id, bus_key)
+        return out
+
+    def _radio_device_labels(self) -> dict[tuple[int, int], str]:
+        out: dict[tuple[int, int], str] = {}
+        for device in self._radio_devices():
+            group = _parse_optional_int(device.get("group"))
+            instance = _parse_optional_int(device.get("instance"))
+            if group is None or instance is None:
+                continue
+            model = str(device.get("deviceModel") or "").strip()
+            class_address = _parse_optional_int(device.get("deviceClassAddress"))
+            if not model:
+                if class_address == 0x15:
+                    model = "VRC720f/2"
+                elif class_address == 0x35:
+                    model = "VR92f"
+                elif class_address == 0x26:
+                    model = "VR71/FM5"
+                elif class_address is not None and class_address >= 0:
+                    model = f"Unknown Radio (0x{class_address:02X})"
+                else:
+                    model = "Unknown Radio"
+            out[(group, instance)] = model
+        return out
+
+    def _selected_radio_candidate(self) -> dict[str, Any] | None:
+        if self._zone_instance is None:
+            return None
+        return _select_zone_radio_candidate(
+            self._zone_instance,
+            self._room_temperature_zone_mapping(),
+            self._radio_zone_candidates(),
+        )
+
+    def _resolved_via_device(self) -> tuple[str, str] | None:
+        if self._zone_instance is None:
+            return self._regulator_device_id
+        return zone_via_device(
+            self._zone_instance,
+            self._room_temperature_zone_mapping(),
+            self._radio_zone_candidates(),
+            self._radio_device_ids(),
+            self._regulator_device_id,
+        )
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -238,6 +434,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         attrs: dict[str, Any] = {}
         state = self._zone_state()
         config = self._zone_config()
+        mapping = self._room_temperature_zone_mapping()
         demand = state.get("heatingDemandPct")
         if demand is not None:
             attrs["heating_demand_pct"] = demand
@@ -251,6 +448,28 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
             value = source.get(key)
             if value is not None and str(value).strip() != "":
                 attrs[field] = value
+
+        attrs["room_temperature_zone_mapping"] = mapping
+        attrs["room_temperature_zone_mapping_text"] = (
+            _ROOM_TEMPERATURE_ZONE_MAPPING_TEXT.get(mapping, "unknown")
+            if mapping is not None
+            else None
+        )
+
+        selected = self._selected_radio_candidate()
+        if selected is not None:
+            slot = (
+                int(selected.get("group") or 0),
+                int(selected.get("instance") or 0),
+            )
+            labels = self._radio_device_labels()
+            attrs["radio_device"] = labels.get(slot)
+            attrs["radio_device_group"] = f"0x{slot[0]:02X}"
+            attrs["radio_device_instance"] = slot[1]
+        else:
+            attrs["radio_device"] = None
+            attrs["radio_device_group"] = None
+            attrs["radio_device_instance"] = None
         return attrs
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -189,6 +189,44 @@ query Semantic {
       allowedModes
       circuitType
       associatedCircuit
+      roomTemperatureZoneMapping
+    }
+  }
+  dhw {
+    state {
+      currentTempC
+      specialFunction
+      heatingDemandPct
+    }
+    config {
+      operatingMode
+      preset
+      targetTempC
+    }
+  }
+}
+"""
+
+QUERY_SEMANTIC_LEGACY = """
+query Semantic {
+  zones {
+    id
+    name
+    state {
+      currentTempC
+      currentHumidityPct
+      hvacAction
+      specialFunction
+      heatingDemandPct
+      valvePositionPct
+    }
+    config {
+      operatingMode
+      preset
+      targetTempC
+      allowedModes
+      circuitType
+      associatedCircuit
     }
   }
   dhw {
@@ -477,9 +515,19 @@ class HelianthusSemanticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             payload = await self._client.execute(QUERY_SEMANTIC)
         except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["zones", "dhw"]):
+            if _is_missing_field_error(exc.errors, ["roomTemperatureZoneMapping"]):
+                try:
+                    payload = await self._client.execute(QUERY_SEMANTIC_LEGACY)
+                except GraphQLResponseError as nested:
+                    if _is_missing_field_error(nested.errors, ["zones", "dhw"]):
+                        return {"zones": [], "dhw": None}
+                    raise UpdateFailed(str(nested)) from nested
+                except GraphQLClientError as nested:
+                    raise UpdateFailed(str(nested)) from nested
+            elif _is_missing_field_error(exc.errors, ["zones", "dhw"]):
                 return {"zones": [], "dhw": None}
-            raise UpdateFailed(str(exc)) from exc
+            else:
+                raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -32,6 +32,7 @@ SUBSCRIPTIONS = {
           allowedModes
           circuitType
           associatedCircuit
+          roomTemperatureZoneMapping
         }
       }
     }

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier
+from .device_ids import circuit_identifier, zone_identifier
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -37,32 +37,72 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     return f"Circuit {index + 1} ({label})"
 
 
+def _normalize_zone_id(zone_id: object | None) -> str | None:
+    if zone_id is None:
+        return None
+    token = str(zone_id).strip().lower()
+    if not token:
+        return None
+    if token.startswith("zone-"):
+        suffix = token[5:]
+    else:
+        suffix = token
+    if suffix.isdigit():
+        value = int(suffix, 10)
+        if value > 0:
+            return f"zone-{value}"
+    return token
+
+
+def _zone_default_name(zone_id: object | None) -> str:
+    normalized = _normalize_zone_id(zone_id)
+    if normalized and normalized.startswith("zone-") and normalized[5:].isdigit():
+        return f"Zone {int(normalized[5:])}"
+    return f"Zone {zone_id}"
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
+    semantic_coordinator = data.get("semantic_coordinator")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
-    if coordinator is None or not coordinator.data:
-        async_add_entities([])
-        return
+    entities: list[ValveEntity] = []
 
-    entities: list[HelianthusCircuitMixingValve] = []
-    for circuit in coordinator.data.get("circuits", []) or []:
-        if not isinstance(circuit, dict):
-            continue
-        if not bool(circuit.get("hasMixer")):
-            continue
-        index = _parse_circuit_index(circuit.get("index"))
-        if index is None:
-            continue
-        entities.append(
-            HelianthusCircuitMixingValve(
-                coordinator=coordinator,
-                entry_id=entry.entry_id,
-                manufacturer=manufacturer,
-                circuit_index=index,
-                initial_name=_circuit_name(circuit, index),
+    if coordinator and coordinator.data:
+        for circuit in coordinator.data.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if not bool(circuit.get("hasMixer")):
+                continue
+            index = _parse_circuit_index(circuit.get("index"))
+            if index is None:
+                continue
+            entities.append(
+                HelianthusCircuitMixingValve(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    circuit_index=index,
+                    initial_name=_circuit_name(circuit, index),
+                )
             )
-        )
+
+    if semantic_coordinator and semantic_coordinator.data:
+        for zone in semantic_coordinator.data.get("zones", []) or []:
+            if not isinstance(zone, dict):
+                continue
+            zone_id = _normalize_zone_id(zone.get("id"))
+            if not zone_id:
+                continue
+            entities.append(
+                HelianthusZoneValve(
+                    coordinator=semantic_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    zone_id=zone_id,
+                    initial_name=str(zone.get("name") or _zone_default_name(zone_id)),
+                )
+            )
     async_add_entities(entities)
 
 
@@ -132,4 +172,69 @@ class HelianthusCircuitMixingValve(CoordinatorEntity, ValveEntity):
             parsed = 0
         if parsed > 100:
             parsed = 100
+        return int(round(parsed))
+
+
+class HelianthusZoneValve(CoordinatorEntity, ValveEntity):
+    """Read-only zone valve status (0/100)."""
+
+    _attr_icon = "mdi:valve"
+    _attr_reports_position = True
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        zone_id: str,
+        initial_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._zone_id = zone_id
+        self._initial_name = initial_name
+        self._attr_unique_id = f"{entry_id}-zone-{zone_id}-valve"
+
+    def _zone(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for zone in payload.get("zones", []) or []:
+            if not isinstance(zone, dict):
+                continue
+            if _normalize_zone_id(zone.get("id")) == self._zone_id:
+                return zone
+        return {}
+
+    @property
+    def name(self) -> str | None:
+        zone_name = self._zone().get("name")
+        if zone_name is not None and str(zone_name).strip():
+            return f"{str(zone_name).strip()} Valve"
+        return f"{self._initial_name} Valve"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={zone_identifier(self._entry_id, self._zone_id)},
+            manufacturer=self._manufacturer,
+            model="Virtual Zone",
+            name=self._zone().get("name") or self._initial_name,
+        )
+
+    @property
+    def current_valve_position(self) -> int | None:
+        zone = self._zone()
+        state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
+        value = state.get("valvePositionPct")
+        if value is None:
+            return None
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        if parsed <= 0:
+            return 0
+        if parsed >= 100:
+            return 100
         return int(round(parsed))

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -1,0 +1,257 @@
+"""Tests for HA-8 zone valve and climate radio parentage."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    climate_module = sys.modules.setdefault(
+        "homeassistant.components.climate",
+        types.ModuleType("homeassistant.components.climate"),
+    )
+    if not hasattr(climate_module, "ClimateEntity"):
+        class _ClimateEntity:
+            pass
+
+        climate_module.ClimateEntity = _ClimateEntity
+    if not hasattr(climate_module, "HVACMode"):
+        class _HVACMode:
+            HEAT = "heat"
+            COOL = "cool"
+            HEAT_COOL = "heat_cool"
+            AUTO = "auto"
+            OFF = "off"
+
+        climate_module.HVACMode = _HVACMode
+
+    climate_const_module = sys.modules.setdefault(
+        "homeassistant.components.climate.const",
+        types.ModuleType("homeassistant.components.climate.const"),
+    )
+    if not hasattr(climate_const_module, "ClimateEntityFeature"):
+        class _ClimateEntityFeature:
+            TARGET_TEMPERATURE = 1
+            PRESET_MODE = 2
+
+        climate_const_module.ClimateEntityFeature = _ClimateEntityFeature
+
+    valve_module = sys.modules.setdefault(
+        "homeassistant.components.valve",
+        types.ModuleType("homeassistant.components.valve"),
+    )
+    if not hasattr(valve_module, "ValveEntity"):
+        class _ValveEntity:
+            pass
+
+        valve_module.ValveEntity = _ValveEntity
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "ATTR_TEMPERATURE"):
+        const_module.ATTR_TEMPERATURE = "temperature"
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import climate as climate_platform
+from custom_components.helianthus import valve as valve_platform
+from custom_components.helianthus.const import DOMAIN
+from custom_components.helianthus.device_ids import radio_device_identifier
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+    async def async_request_refresh(self) -> None:
+        return None
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def test_zone_via_device_prefers_expected_radio_candidates() -> None:
+    candidates = {
+        0: [
+            {"group": 0x09, "instance": 1, "remote_control_address": 0},
+            {"group": 0x0A, "instance": 1, "remote_control_address": 1},
+            {"group": 0x0A, "instance": 2, "remote_control_address": 2},
+        ]
+    }
+    radio_ids = {
+        (0x09, 1): ("helianthus", "entry-1-radio-g09-i01"),
+        (0x0A, 1): ("helianthus", "entry-1-radio-g0a-i01"),
+        (0x0A, 2): ("helianthus", "entry-1-radio-g0a-i02"),
+    }
+    regulator = ("helianthus", "entry-1-bus-BASV-15")
+
+    assert climate_platform.zone_via_device(0, 1, candidates, radio_ids, regulator) == radio_ids[(0x09, 1)]
+    assert climate_platform.zone_via_device(0, 2, candidates, radio_ids, regulator) == radio_ids[(0x0A, 1)]
+    assert climate_platform.zone_via_device(0, 3, candidates, radio_ids, regulator) == radio_ids[(0x0A, 2)]
+    assert climate_platform.zone_via_device(0, 0, candidates, radio_ids, regulator) == regulator
+
+
+def test_climate_attributes_include_radio_and_room_mapping_metadata() -> None:
+    semantic_coordinator = _FakeCoordinator(
+        {
+            "zones": [
+                {
+                    "id": "zone-1",
+                    "name": "Living",
+                    "state": {"valvePositionPct": 45.0},
+                    "config": {
+                        "operatingMode": "auto",
+                        "preset": "schedule",
+                        "targetTempC": 21.0,
+                        "allowedModes": ["off", "auto", "heat"],
+                        "circuitType": "heating",
+                        "associatedCircuit": 0,
+                        "roomTemperatureZoneMapping": 2,
+                    },
+                }
+            ],
+            "dhw": None,
+        }
+    )
+    radio_coordinator = _FakeCoordinator(
+        {
+            "radioDevices": [
+                {
+                    "group": 0x0A,
+                    "instance": 1,
+                    "radioBusKey": "g0a-i01",
+                    "deviceModel": "VR92f",
+                }
+            ],
+            "radioZoneCandidates": {
+                0: [{"group": 0x0A, "instance": 1, "remote_control_address": 1}]
+            },
+        }
+    )
+    payload = {
+        "semantic_coordinator": semantic_coordinator,
+        "radio_coordinator": radio_coordinator,
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_manufacturer": "Vaillant",
+        "graphql_client": None,
+        "regulator_bus_address": 0x15,
+        "daemon_source_address": 0x31,
+    }
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(climate_platform.async_setup_entry(hass, entry, entities.extend))
+
+    assert len(entities) == 1
+    climate = entities[0]
+    attrs = climate.extra_state_attributes
+    assert attrs["room_temperature_zone_mapping"] == 2
+    assert attrs["room_temperature_zone_mapping_text"] == "thermostat_1"
+    assert attrs["radio_device"] == "VR92f"
+    assert attrs["radio_device_group"] == "0x0A"
+    assert attrs["radio_device_instance"] == 1
+    assert climate._attr_unique_id == "entry-1-zone-zone-1"
+    assert climate.device_info["via_device"] == radio_device_identifier("entry-1", "g0a-i01")
+
+
+def test_zone_valve_entities_are_created_per_zone() -> None:
+    payload = {
+        "circuit_coordinator": _FakeCoordinator({"circuits": []}),
+        "semantic_coordinator": _FakeCoordinator(
+            {
+                "zones": [
+                    {"id": "zone-1", "name": "Living", "state": {"valvePositionPct": 100}},
+                    {"id": "zone-2", "name": "Bedroom", "state": {"valvePositionPct": 0}},
+                ],
+                "dhw": None,
+            }
+        ),
+        "regulator_manufacturer": "Vaillant",
+    }
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(valve_platform.async_setup_entry(hass, entry, entities.extend))
+
+    zone_valves = [
+        entity for entity in entities if isinstance(entity, valve_platform.HelianthusZoneValve)
+    ]
+    assert len(zone_valves) == 2
+    assert {entity._attr_unique_id for entity in zone_valves} == {
+        "entry-1-zone-zone-1-valve",
+        "entry-1-zone-zone-2-valve",
+    }


### PR DESCRIPTION
## What
- add read-only per-zone valve entities sourced from zone `valvePositionPct`
- add deterministic `zone_via_device()` resolver implementing R8 parentage selection
- update climate zone device parent (`via_device`) to use radio candidates + room temperature mapping
- expose climate attributes:
  - `room_temperature_zone_mapping` + decoded text
  - `radio_device`, `radio_device_group`, `radio_device_instance`
- extend semantic query/subscription with `roomTemperatureZoneMapping` (legacy fallback kept)

## Testing
- `pytest tests/test_zone_valve.py tests/test_coordinator.py tests/test_circuit.py tests/test_radio_device.py`
- `pytest tests/`
- `./scripts/ci_local.sh`

Fixes #119