### PR TITLE
HA-9: add DHW HWC status sensor entity

### DIFF
--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -501,6 +501,14 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     ("dhw", None),
                 )
             )
+            sensors.append(
+                HelianthusDHWStatusSensor(
+                    semantic_coordinator,
+                    entry.entry_id,
+                    via_device,
+                    manufacturer,
+                )
+            )
 
     if energy_coordinator and energy_coordinator.data:
         sensors.extend(
@@ -919,6 +927,48 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
         dhw = self.coordinator.data.get("dhw") or {}
         state = dhw.get("state") or {}
         return state.get("heatingDemandPct")
+
+
+class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
+    """DHW charging/status sensor."""
+
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        via_device: tuple[str, str] | None,
+        manufacturer: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._via_device = via_device
+        self._manufacturer = manufacturer
+        self._attr_name = "Domestic Hot Water HWC Status"
+        self._attr_unique_id = f"{entry_id}-dhw-hwc-status"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={dhw_identifier(self._entry_id)},
+            manufacturer=self._manufacturer,
+            model="Virtual DHW",
+            name="Domestic Hot Water",
+            via_device=self._via_device,
+        )
+
+    @property
+    def native_value(self) -> Any:
+        payload = self.coordinator.data or {}
+        dhw = payload.get("dhw") or {}
+        state = dhw.get("state") if isinstance(dhw.get("state"), dict) else {}
+        value = state.get("specialFunction")
+        if value is None:
+            return None
+        if isinstance(value, (bool, int, float, str)):
+            return value
+        return str(value)
 
 
 class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_dhw_status.py
+++ b/tests/test_dhw_status.py
@@ -1,0 +1,171 @@
+"""Tests for HA-9 DHW status sensor."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+            PRESSURE = "pressure"
+            HUMIDITY = "humidity"
+            DURATION = "duration"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+            TOTAL_INCREASING = "total_increasing"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def test_sensor_platform_adds_dhw_status_sensor() -> None:
+    payload = {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": _FakeCoordinator(
+            {
+                "zones": [],
+                "dhw": {
+                    "state": {
+                        "currentTempC": 48.1,
+                        "specialFunction": "charging",
+                        "heatingDemandPct": 67,
+                    },
+                    "config": {
+                        "operatingMode": "auto",
+                        "preset": "schedule",
+                        "targetTempC": 50.0,
+                    },
+                },
+            }
+        ),
+        "energy_coordinator": None,
+        "circuit_coordinator": None,
+        "radio_coordinator": None,
+        "system_coordinator": None,
+        "boiler_coordinator": None,
+        "boiler_device_id": None,
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
+        "regulator_manufacturer": "Vaillant",
+    }
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    dhw_status = [
+        entity
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusDHWStatusSensor)
+    ]
+    assert len(dhw_status) == 1
+    assert dhw_status[0]._attr_unique_id == "entry-1-dhw-hwc-status"
+    assert dhw_status[0].native_value == "charging"


### PR DESCRIPTION
## What
- add `HelianthusDHWStatusSensor` on the DHW virtual device
- source sensor value from `dhw.state.specialFunction` to expose HWC charging/status state
- keep circulation pump out of DHW scope per R7 authority model
- add unit test coverage for DHW status sensor creation and value mapping

## Testing
- `pytest tests/test_dhw_status.py tests/test_sensor.py`
- `pytest tests/`
- `./scripts/ci_local.sh`

Fixes #120