### PR TITLE
HA-10: add FM5 interpreted solar and cylinder entities

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -143,6 +143,8 @@ def _identifier_belongs_to_entry(token: str, entry_id: str) -> bool:
         or token.startswith(f"{entry_id}-zone-")
         or token.startswith(f"{entry_id}-circuit-")
         or token.startswith(f"{entry_id}-radio-")
+        or token.startswith(f"{entry_id}-cylinder-")
+        or token == f"{entry_id}-solar"
     )
 
 
@@ -211,6 +213,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HelianthusCircuitCoordinator,
         HelianthusCoordinator,
         HelianthusEnergyCoordinator,
+        HelianthusFM5Coordinator,
         HelianthusRadioDeviceCoordinator,
         HelianthusSemanticCoordinator,
         HelianthusSystemCoordinator,
@@ -330,6 +333,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     energy_coordinator = HelianthusEnergyCoordinator(hass, client, scan_interval)
     circuit_coordinator = HelianthusCircuitCoordinator(hass, client, scan_interval)
     radio_coordinator = HelianthusRadioDeviceCoordinator(hass, client, scan_interval)
+    fm5_coordinator = HelianthusFM5Coordinator(hass, client, scan_interval)
     system_coordinator = HelianthusSystemCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
@@ -338,6 +342,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await energy_coordinator.async_config_entry_first_refresh()
     await circuit_coordinator.async_config_entry_first_refresh()
     await radio_coordinator.async_config_entry_first_refresh()
+    await fm5_coordinator.async_config_entry_first_refresh()
     await system_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
 
@@ -588,6 +593,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_kwargs["via_device"] = managing_device
         device_registry.async_get_or_create(**device_kwargs)
 
+    fm5_payload = fm5_coordinator.data or {}
+    known_fm5_mode = str(fm5_payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    known_cylinder_indexes: set[int] = set()
+    for cylinder in fm5_payload.get("cylinders", []) or []:
+        if not isinstance(cylinder, dict):
+            continue
+        index = parse_optional_int(cylinder.get("index"))
+        if index is not None and index >= 0:
+            known_cylinder_indexes.add(index)
+
     daemon_data = status_coordinator.data.get("daemon", {}) if status_coordinator.data else {}
     daemon_source_addr = _parse_bus_address(daemon_data.get("initiatorAddress"))
 
@@ -723,11 +738,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if current_keys - known_radio_bus_keys:
             schedule_reload("radio inventory became available")
 
+    def handle_fm5_update() -> None:
+        payload = fm5_coordinator.data or {}
+        mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+        current_indexes: set[int] = set()
+        for cylinder in payload.get("cylinders", []) or []:
+            if not isinstance(cylinder, dict):
+                continue
+            index = parse_optional_int(cylinder.get("index"))
+            if index is not None and index >= 0:
+                current_indexes.add(index)
+        if mode != known_fm5_mode:
+            if "INTERPRETED" in {mode, known_fm5_mode}:
+                schedule_reload("fm5 semantic mode changed")
+                return
+        if mode == "INTERPRETED" and (current_indexes - known_cylinder_indexes):
+            schedule_reload("cylinder inventory became available")
+
     unsub_listeners: list[Callable[[], None]] = []
     unsub_listeners.append(device_coordinator.async_add_listener(handle_device_update))
     unsub_listeners.append(semantic_coordinator.async_add_listener(handle_semantic_update))
     unsub_listeners.append(circuit_coordinator.async_add_listener(handle_circuit_update))
     unsub_listeners.append(radio_coordinator.async_add_listener(handle_radio_update))
+    unsub_listeners.append(fm5_coordinator.async_add_listener(handle_fm5_update))
 
     for zone_id, helper_entity in zone_schedule_helpers.items():
         @callback
@@ -792,6 +825,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "energy_coordinator": energy_coordinator,
         "circuit_coordinator": circuit_coordinator,
         "radio_coordinator": radio_coordinator,
+        "fm5_coordinator": fm5_coordinator,
         "system_coordinator": system_coordinator,
         "boiler_coordinator": boiler_coordinator,
         "graphql_client": client,

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -296,6 +296,28 @@ query RadioDevices {
 }
 """
 
+QUERY_FM5 = """
+query FM5Semantic {
+  fm5SemanticMode
+  solar {
+    collectorTemperatureC
+    returnTemperatureC
+    pumpActive
+    currentYield
+    pumpHours
+    solarEnabled
+    functionMode
+  }
+  cylinders {
+    index
+    temperatureC
+    maxSetpointC
+    chargeHysteresisC
+    chargeOffsetC
+  }
+}
+"""
+
 QUERY_SYSTEM = """
 query System {
   system {
@@ -718,6 +740,88 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {
             "radioDevices": radio_devices,
             "radioZoneCandidates": candidates,
+        }
+
+
+class HelianthusFM5Coordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator fetching FM5 mode plus interpreted solar/cylinder semantics."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_fm5",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+        self._client = client
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        empty = {
+            "fm5SemanticMode": "ABSENT",
+            "solar": None,
+            "cylinders": [],
+        }
+        missing_fields = [
+            "fm5SemanticMode",
+            "solar",
+            "cylinders",
+            "collectorTemperatureC",
+            "returnTemperatureC",
+            "pumpActive",
+            "currentYield",
+            "pumpHours",
+            "solarEnabled",
+            "functionMode",
+            "index",
+            "temperatureC",
+            "maxSetpointC",
+            "chargeHysteresisC",
+            "chargeOffsetC",
+        ]
+        try:
+            payload = await self._client.execute(QUERY_FM5)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, missing_fields):
+                return empty
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            return empty
+
+        mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+        if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
+            mode = "ABSENT"
+
+        if mode != "INTERPRETED":
+            return {
+                "fm5SemanticMode": mode,
+                "solar": None,
+                "cylinders": [],
+            }
+
+        solar = payload.get("solar")
+        if not isinstance(solar, dict):
+            solar = None
+        cylinders = payload.get("cylinders")
+        normalized_cylinders: list[dict[str, Any]] = []
+        if isinstance(cylinders, list):
+            for cylinder in cylinders:
+                if not isinstance(cylinder, dict):
+                    continue
+                index = _parse_optional_int(cylinder.get("index"))
+                if index is None or index < 0:
+                    continue
+                normalized = dict(cylinder)
+                normalized["index"] = index
+                normalized_cylinders.append(normalized)
+        normalized_cylinders.sort(key=lambda item: int(item.get("index") or 0))
+
+        return {
+            "fm5SemanticMode": mode,
+            "solar": solar,
+            "cylinders": normalized_cylinders,
         }
 
 

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -145,6 +145,16 @@ def radio_device_identifier(config_entry_id: str, radio_bus_key: str) -> DeviceI
     return (DOMAIN, f"{_token(config_entry_id)}-radio-{_token(radio_bus_key)}")
 
 
+def solar_identifier(config_entry_id: str) -> DeviceIdentifier:
+    return (DOMAIN, f"{_token(config_entry_id)}-solar")
+
+
+def cylinder_identifier(config_entry_id: str, cylinder_index: object) -> DeviceIdentifier:
+    index = _parse_circuit_index(cylinder_index)
+    token = str(index) if index is not None else _token(cylinder_index)
+    return (DOMAIN, f"{_token(config_entry_id)}-cylinder-{token}")
+
+
 def dhw_identifier(config_entry_id: str) -> tuple[str, str]:
     return (DOMAIN, f"{_token(config_entry_id)}-dhw")
 

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier
+from .device_ids import circuit_identifier, solar_identifier
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -17,6 +17,8 @@ _CIRCUIT_TYPE_LABELS = {
     "dhw": "DHW",
     "return_increase": "Return Increase",
 }
+
+_FM5_MODE_INTERPRETED = "INTERPRETED"
 
 
 def _parse_circuit_index(value: object | None) -> int | None:
@@ -37,30 +39,52 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     return f"Circuit {index + 1} ({label})"
 
 
+def _fm5_mode(payload: dict[str, Any] | None) -> str:
+    if not isinstance(payload, dict):
+        return "ABSENT"
+    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
+        return "ABSENT"
+    return mode
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
+    fm5_coordinator = data.get("fm5_coordinator")
+    vr71_device_id = data.get("vr71_device_id") or data.get("regulator_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
-    if coordinator is None or not coordinator.data:
-        async_add_entities([])
-        return
 
-    entities: list[HelianthusCircuitPumpFan] = []
-    for circuit in coordinator.data.get("circuits", []) or []:
-        if not isinstance(circuit, dict):
-            continue
-        index = _parse_circuit_index(circuit.get("index"))
-        if index is None:
-            continue
-        entities.append(
-            HelianthusCircuitPumpFan(
-                coordinator=coordinator,
-                entry_id=entry.entry_id,
-                manufacturer=manufacturer,
-                circuit_index=index,
-                initial_name=_circuit_name(circuit, index),
+    entities: list[FanEntity] = []
+    if coordinator and coordinator.data:
+        for circuit in coordinator.data.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            index = _parse_circuit_index(circuit.get("index"))
+            if index is None:
+                continue
+            entities.append(
+                HelianthusCircuitPumpFan(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    circuit_index=index,
+                    initial_name=_circuit_name(circuit, index),
+                )
             )
-        )
+
+    if fm5_coordinator and fm5_coordinator.data and _fm5_mode(fm5_coordinator.data) == _FM5_MODE_INTERPRETED:
+        solar = fm5_coordinator.data.get("solar")
+        if isinstance(solar, dict):
+            entities.append(
+                HelianthusSolarPumpFan(
+                    coordinator=fm5_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    solar_device_id=solar_identifier(entry.entry_id),
+                    parent_device_id=vr71_device_id,
+                )
+            )
     async_add_entities(entities)
 
 
@@ -120,6 +144,68 @@ class HelianthusCircuitPumpFan(CoordinatorEntity, FanEntity):
         circuit = self._circuit()
         state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
         value = state.get("pumpActive")
+        if isinstance(value, bool):
+            return value
+        return None
+
+    @property
+    def percentage(self) -> int | None:
+        is_on = self.is_on
+        if is_on is None:
+            return None
+        return 100 if is_on else 0
+
+    @property
+    def speed_count(self) -> int:
+        return 1
+
+
+class HelianthusSolarPumpFan(CoordinatorEntity, FanEntity):
+    """Read-only solar pump state."""
+
+    _attr_icon = "mdi:pump"
+    _attr_supported_features = 0
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        solar_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._solar_device_id = solar_device_id
+        self._parent_device_id = parent_device_id
+        self._attr_name = "Solar Pump"
+        self._attr_unique_id = f"{entry_id}-solar-pump"
+
+    @property
+    def available(self) -> bool:
+        payload = self.coordinator.data if isinstance(self.coordinator.data, dict) else None
+        return _fm5_mode(payload) == _FM5_MODE_INTERPRETED
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._solar_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Solar Circuit",
+            "name": "Solar Circuit",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def is_on(self) -> bool | None:
+        payload = self.coordinator.data or {}
+        solar = payload.get("solar") if isinstance(payload, dict) else None
+        if not isinstance(solar, dict):
+            return None
+        value = solar.get("pumpActive")
         if isinstance(value, bool):
             return value
         return None

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier
+from .device_ids import circuit_identifier, cylinder_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
@@ -40,6 +40,8 @@ _CIRCUIT_TYPE_LABELS = {
     "return_increase": "Return Increase",
 }
 
+_FM5_MODE_INTERPRETED = "INTERPRETED"
+
 
 @dataclass(frozen=True)
 class CircuitNumberField:
@@ -61,6 +63,16 @@ class SystemNumberField:
     step: float
     unit: str | None = None
     cast_int: bool = False
+
+
+@dataclass(frozen=True)
+class CylinderNumberField:
+    key: str
+    label: str
+    minimum: float
+    maximum: float
+    step: float
+    unit: str | None = None
 
 
 _CIRCUIT_NUMBER_FIELDS = [
@@ -148,6 +160,33 @@ _SYSTEM_NUMBER_FIELDS = [
     ),
 ]
 
+_CYLINDER_NUMBER_FIELDS = [
+    CylinderNumberField(
+        key="maxSetpointC",
+        label="Max Setpoint",
+        minimum=20.0,
+        maximum=80.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    CylinderNumberField(
+        key="chargeHysteresisC",
+        label="Charge Hysteresis",
+        minimum=0.0,
+        maximum=30.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    CylinderNumberField(
+        key="chargeOffsetC",
+        label="Charge Offset",
+        minimum=-20.0,
+        maximum=20.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+]
+
 
 def _parse_circuit_index(value: object | None) -> int | None:
     if isinstance(value, bool):
@@ -167,13 +206,24 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     return f"Circuit {index + 1} ({label})"
 
 
+def _fm5_mode(payload: dict[str, Any] | None) -> str:
+    if not isinstance(payload, dict):
+        return "ABSENT"
+    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
+        return "ABSENT"
+    return mode
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
     system_coordinator = data.get("system_coordinator")
+    fm5_coordinator = data.get("fm5_coordinator")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
     regulator_device_id = data.get("regulator_device_id")
+    vr71_device_id = data.get("vr71_device_id") or regulator_device_id
 
     entities: list[NumberEntity] = []
     if coordinator and coordinator.data:
@@ -209,6 +259,26 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     field=field,
                 )
             )
+
+    if fm5_coordinator and fm5_coordinator.data and vr71_device_id:
+        if _fm5_mode(fm5_coordinator.data) == _FM5_MODE_INTERPRETED:
+            for cylinder in fm5_coordinator.data.get("cylinders", []) or []:
+                if not isinstance(cylinder, dict):
+                    continue
+                index = _parse_circuit_index(cylinder.get("index"))
+                if index is None:
+                    continue
+                for field in _CYLINDER_NUMBER_FIELDS:
+                    entities.append(
+                        HelianthusCylinderConfigNumber(
+                            coordinator=fm5_coordinator,
+                            entry_id=entry.entry_id,
+                            manufacturer=manufacturer,
+                            parent_device_id=vr71_device_id,
+                            cylinder_index=index,
+                            field=field,
+                        )
+                    )
 
     async_add_entities(entities)
 
@@ -394,3 +464,73 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
             error = str(result.get("error") or "")
         message = error or "unknown error"
         raise HomeAssistantError(f"Helianthus write failed: {message}")
+
+
+class HelianthusCylinderConfigNumber(CoordinatorEntity, NumberEntity):
+    """Read-only interpreted cylinder configuration number."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        parent_device_id: tuple[str, str] | None,
+        cylinder_index: int,
+        field: CylinderNumberField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._parent_device_id = parent_device_id
+        self._cylinder_index = cylinder_index
+        self._field = field
+        self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-number-{field.key}"
+        self._attr_name = f"Cylinder {cylinder_index + 1} {field.label}"
+        self._attr_native_min_value = field.minimum
+        self._attr_native_max_value = field.maximum
+        self._attr_native_step = field.step
+        if field.unit is not None:
+            self._attr_native_unit_of_measurement = field.unit
+
+    def _cylinder(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for cylinder in payload.get("cylinders", []) if isinstance(payload, dict) else []:
+            if not isinstance(cylinder, dict):
+                continue
+            index = _parse_circuit_index(cylinder.get("index"))
+            if index == self._cylinder_index:
+                return cylinder
+        return {}
+
+    @property
+    def available(self) -> bool:
+        payload = self.coordinator.data if isinstance(self.coordinator.data, dict) else None
+        return _fm5_mode(payload) == _FM5_MODE_INTERPRETED
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {cylinder_identifier(self._entry_id, self._cylinder_index)},
+            "manufacturer": self._manufacturer,
+            "model": "Cylinder",
+            "name": f"Cylinder {self._cylinder_index + 1}",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def native_value(self) -> float | None:
+        value = self._cylinder().get(self._field.key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        raise HomeAssistantError("Helianthus cylinder config numbers are read-only in this profile")

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -14,12 +14,14 @@ from .const import DOMAIN
 from .device_ids import (
     build_radio_bus_key,
     build_bus_device_key,
+    cylinder_identifier,
     bus_identifier,
     circuit_identifier,
     dhw_identifier,
     energy_identifier,
     radio_device_identifier,
     resolve_bus_address,
+    solar_identifier,
     zone_identifier,
 )
 from .energy import compute_total
@@ -86,6 +88,7 @@ _SENSOR_DEVICE_CLASS_PRESSURE = getattr(SensorDeviceClass, "PRESSURE", None)
 _SENSOR_STATE_CLASS_TOTAL_INCREASING = getattr(SensorStateClass, "TOTAL_INCREASING", None)
 _RADIO_ROOM_CLASSES = {0x15, 0x35}
 _RADIO_STALE_GRACE_CYCLES = 3
+_FM5_MODE_INTERPRETED = "INTERPRETED"
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -275,6 +278,15 @@ def _radio_model_name(device: dict[str, Any]) -> str:
     return "Unknown Radio"
 
 
+def _fm5_mode(payload: dict[str, Any] | None) -> str:
+    if not isinstance(payload, dict):
+        return "ABSENT"
+    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
+        return "ABSENT"
+    return mode
+
+
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     token = str(circuit.get("circuitType") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
@@ -289,10 +301,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     energy_coordinator = data.get("energy_coordinator")
     circuit_coordinator = data.get("circuit_coordinator")
     radio_coordinator = data.get("radio_coordinator")
+    fm5_coordinator = data.get("fm5_coordinator")
     system_coordinator = data.get("system_coordinator")
     boiler_coordinator = data.get("boiler_coordinator")
     boiler_device_id = data.get("boiler_device_id")
     regulator_device_id = data.get("regulator_device_id")
+    vr71_device_id = data.get("vr71_device_id")
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
@@ -474,6 +488,72 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                             cast_int=True,
                         )
                     )
+
+    if fm5_coordinator and fm5_coordinator.data:
+        fm5_payload = fm5_coordinator.data
+        mode = _fm5_mode(fm5_payload)
+        marker_device_id = vr71_device_id or regulator_device_id
+        if marker_device_id:
+            sensors.append(
+                HelianthusFM5ModeSensor(
+                    coordinator=fm5_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    parent_device_id=marker_device_id,
+                )
+            )
+        if mode == _FM5_MODE_INTERPRETED:
+            solar = fm5_payload.get("solar")
+            if isinstance(solar, dict):
+                solar_device_id = solar_identifier(entry.entry_id)
+                for key, label, device_class, unit, state_class in [
+                    (
+                        "collectorTemperatureC",
+                        "Collector Temperature",
+                        SensorDeviceClass.TEMPERATURE,
+                        UnitOfTemperature.CELSIUS,
+                        SensorStateClass.MEASUREMENT,
+                    ),
+                    (
+                        "returnTemperatureC",
+                        "Return Temperature",
+                        SensorDeviceClass.TEMPERATURE,
+                        UnitOfTemperature.CELSIUS,
+                        SensorStateClass.MEASUREMENT,
+                    ),
+                    ("currentYield", "Current Yield", None, None, None),
+                    ("pumpHours", "Pump Hours", _SENSOR_DEVICE_CLASS_DURATION, "h", _SENSOR_STATE_CLASS_TOTAL_INCREASING),
+                ]:
+                    sensors.append(
+                        HelianthusSolarSensor(
+                            coordinator=fm5_coordinator,
+                            entry_id=entry.entry_id,
+                            manufacturer=manufacturer,
+                            solar_device_id=solar_device_id,
+                            parent_device_id=vr71_device_id or regulator_device_id,
+                            key=key,
+                            label=label,
+                            device_class=device_class,
+                            native_unit=unit,
+                            state_class=state_class,
+                        )
+                    )
+
+            for cylinder in fm5_payload.get("cylinders", []) or []:
+                if not isinstance(cylinder, dict):
+                    continue
+                index = _parse_optional_int(cylinder.get("index"))
+                if index is None or index < 0:
+                    continue
+                sensors.append(
+                    HelianthusCylinderSensor(
+                        coordinator=fm5_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        cylinder_index=index,
+                        parent_device_id=vr71_device_id or regulator_device_id,
+                    )
+                )
 
     if semantic_coordinator and semantic_coordinator.data:
         zones = semantic_coordinator.data.get("zones", []) or []
@@ -857,6 +937,162 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
         if isinstance(value, (bool, int, float, str)):
             return value
         return None
+
+
+class HelianthusFM5ModeSensor(CoordinatorEntity, SensorEntity):
+    """FM5 semantic mode marker."""
+
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        parent_device_id: tuple[str, str],
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._parent_device_id = parent_device_id
+        self._attr_name = "FM5 Semantic Mode"
+        self._attr_unique_id = f"{entry_id}-fm5-mode"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._parent_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def native_value(self) -> Any:
+        return _fm5_mode(self.coordinator.data if isinstance(self.coordinator.data, dict) else None)
+
+
+class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
+    """Solar semantic sensor values (interpreted mode only)."""
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        solar_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+        key: str,
+        label: str,
+        device_class: str | None,
+        native_unit: str | None,
+        state_class: str | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._solar_device_id = solar_device_id
+        self._parent_device_id = parent_device_id
+        self._key = key
+        self._attr_name = f"Solar {label}"
+        self._attr_unique_id = f"{entry_id}-solar-sensor-{key}"
+        if device_class is not None:
+            self._attr_device_class = device_class
+        if native_unit is not None:
+            self._attr_native_unit_of_measurement = native_unit
+        if state_class is not None:
+            self._attr_state_class = state_class
+
+    @property
+    def available(self) -> bool:
+        payload = self.coordinator.data or {}
+        return _fm5_mode(payload if isinstance(payload, dict) else None) == _FM5_MODE_INTERPRETED
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._solar_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Solar Circuit",
+            "name": "Solar Circuit",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def native_value(self) -> Any:
+        payload = self.coordinator.data or {}
+        solar = payload.get("solar") if isinstance(payload, dict) else None
+        if not isinstance(solar, dict):
+            return None
+        value = solar.get(self._key)
+        if value is None:
+            return None
+        if isinstance(value, (bool, int, float, str)):
+            return value
+        return None
+
+
+class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
+    """Cylinder temperature sensor (interpreted mode only)."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        cylinder_index: int,
+        parent_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._cylinder_index = cylinder_index
+        self._parent_device_id = parent_device_id
+        self._attr_name = f"Cylinder {cylinder_index + 1} Temperature"
+        self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-temperature"
+
+    def _cylinder(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for cylinder in payload.get("cylinders", []) if isinstance(payload, dict) else []:
+            if not isinstance(cylinder, dict):
+                continue
+            index = _parse_optional_int(cylinder.get("index"))
+            if index == self._cylinder_index:
+                return cylinder
+        return {}
+
+    @property
+    def available(self) -> bool:
+        payload = self.coordinator.data or {}
+        return _fm5_mode(payload if isinstance(payload, dict) else None) == _FM5_MODE_INTERPRETED
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = cylinder_identifier(self._entry_id, self._cylinder_index)
+        info = {
+            "identifiers": {identifier},
+            "manufacturer": self._manufacturer,
+            "model": "Cylinder",
+            "name": f"Cylinder {self._cylinder_index + 1}",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def native_value(self) -> Any:
+        value = self._cylinder().get("temperatureC")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
 
 class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier
+from .device_ids import circuit_identifier, solar_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
@@ -29,6 +29,8 @@ _CIRCUIT_TYPE_LABELS = {
     "dhw": "DHW",
     "return_increase": "Return Increase",
 }
+
+_FM5_MODE_INTERPRETED = "INTERPRETED"
 
 
 def _parse_circuit_index(value: object | None) -> int | None:
@@ -49,32 +51,60 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
     return f"Circuit {index + 1} ({label})"
 
 
+def _fm5_mode(payload: dict[str, Any] | None) -> str:
+    if not isinstance(payload, dict):
+        return "ABSENT"
+    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
+        return "ABSENT"
+    return mode
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
+    fm5_coordinator = data.get("fm5_coordinator")
+    vr71_device_id = data.get("vr71_device_id") or data.get("regulator_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
-    if coordinator is None or not coordinator.data:
-        async_add_entities([])
-        return
 
-    entities: list[HelianthusCircuitCoolingEnabledSwitch] = []
-    for circuit in coordinator.data.get("circuits", []) or []:
-        if not isinstance(circuit, dict):
-            continue
-        index = _parse_circuit_index(circuit.get("index"))
-        if index is None:
-            continue
-        entities.append(
-            HelianthusCircuitCoolingEnabledSwitch(
-                coordinator=coordinator,
-                entry_id=entry.entry_id,
-                manufacturer=manufacturer,
-                client=client,
-                circuit_index=index,
-                initial_name=_circuit_name(circuit, index),
+    entities: list[SwitchEntity] = []
+    if coordinator and coordinator.data:
+        for circuit in coordinator.data.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            index = _parse_circuit_index(circuit.get("index"))
+            if index is None:
+                continue
+            entities.append(
+                HelianthusCircuitCoolingEnabledSwitch(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    client=client,
+                    circuit_index=index,
+                    initial_name=_circuit_name(circuit, index),
+                )
             )
-        )
+
+    if fm5_coordinator and fm5_coordinator.data and _fm5_mode(fm5_coordinator.data) == _FM5_MODE_INTERPRETED:
+        solar = fm5_coordinator.data.get("solar")
+        if isinstance(solar, dict):
+            for key, label in [
+                ("solarEnabled", "Solar Enabled"),
+                ("functionMode", "Function Mode"),
+            ]:
+                entities.append(
+                    HelianthusSolarSwitch(
+                        coordinator=fm5_coordinator,
+                        entry_id=entry.entry_id,
+                        manufacturer=manufacturer,
+                        solar_device_id=solar_identifier(entry.entry_id),
+                        parent_device_id=vr71_device_id,
+                        key=key,
+                        label=label,
+                    )
+                )
     async_add_entities(entities)
 
 
@@ -170,3 +200,62 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self._write(False)
+
+
+class HelianthusSolarSwitch(CoordinatorEntity, SwitchEntity):
+    """Read-only interpreted solar config switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        solar_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+        key: str,
+        label: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._solar_device_id = solar_device_id
+        self._parent_device_id = parent_device_id
+        self._key = key
+        self._attr_name = f"Solar {label}"
+        self._attr_unique_id = f"{entry_id}-solar-switch-{key}"
+
+    @property
+    def available(self) -> bool:
+        payload = self.coordinator.data if isinstance(self.coordinator.data, dict) else None
+        return _fm5_mode(payload) == _FM5_MODE_INTERPRETED
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._solar_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Solar Circuit",
+            "name": "Solar Circuit",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def is_on(self) -> bool | None:
+        payload = self.coordinator.data or {}
+        solar = payload.get("solar") if isinstance(payload, dict) else None
+        if not isinstance(solar, dict):
+            return None
+        value = solar.get(self._key)
+        if isinstance(value, bool):
+            return value
+        return None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        raise HomeAssistantError("Helianthus solar switches are read-only in this profile")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        raise HomeAssistantError("Helianthus solar switches are read-only in this profile")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -39,6 +39,7 @@ from custom_components.helianthus.coordinator import (
     QUERY_EXTENDED_V3,
     QUERY_EXTENDED_V3_NO_ADDRESSES,
     QUERY_EXTENDED_V3_NO_PART,
+    QUERY_FM5,
     QUERY_RADIO_DEVICES,
     QUERY_STATUS,
     QUERY_STATUS_LEGACY,
@@ -47,6 +48,7 @@ from custom_components.helianthus.coordinator import (
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
     HelianthusCoordinator,
+    HelianthusFM5Coordinator,
     HelianthusRadioDeviceCoordinator,
     HelianthusSystemCoordinator,
     HelianthusStatusCoordinator,
@@ -105,6 +107,12 @@ def _build_radio_coordinator(client: _ScriptedClient) -> HelianthusRadioDeviceCo
     coordinator._stale_cycles = {}  # type: ignore[attr-defined]
     coordinator.data = {}  # type: ignore[attr-defined]
     coordinator.async_set_updated_data = lambda payload: setattr(coordinator, "data", payload)  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_fm5_coordinator(client: _ScriptedClient) -> HelianthusFM5Coordinator:
+    coordinator = object.__new__(HelianthusFM5Coordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -475,3 +483,42 @@ def test_radio_query_uses_stale_grace_cycles_for_disconnected_slot() -> None:
         [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
     )
     assert coordinator.data["radioDevices"][0]["staleCycles"] == 3  # type: ignore[index]
+
+
+def test_fm5_query_suppresses_interpreted_payload_when_gpio_only() -> None:
+    client = _ScriptedClient(
+        [
+            {
+                "fm5SemanticMode": "GPIO_ONLY",
+                "solar": {"collectorTemperatureC": 70.0},
+                "cylinders": [{"index": 0, "temperatureC": 48.0}],
+            }
+        ]
+    )
+    coordinator = _build_fm5_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["fm5SemanticMode"] == "GPIO_ONLY"
+    assert data["solar"] is None
+    assert data["cylinders"] == []
+    assert client.calls == [QUERY_FM5]
+
+
+def test_fm5_query_returns_interpreted_payload() -> None:
+    client = _ScriptedClient(
+        [
+            {
+                "fm5SemanticMode": "INTERPRETED",
+                "solar": {"collectorTemperatureC": 70.0},
+                "cylinders": [{"index": 0, "temperatureC": 48.0}],
+            }
+        ]
+    )
+    coordinator = _build_fm5_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["fm5SemanticMode"] == "INTERPRETED"
+    assert data["solar"]["collectorTemperatureC"] == 70.0
+    assert data["cylinders"][0]["index"] == 0

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -7,6 +7,7 @@ from custom_components.helianthus.device_ids import (
     build_radio_bus_key,
     bus_identifier,
     build_bus_device_key,
+    cylinder_identifier,
     circuit_identifier,
     daemon_identifier,
     dhw_identifier,
@@ -16,6 +17,7 @@ from custom_components.helianthus.device_ids import (
     resolve_boiler_physical_device_id,
     resolve_boiler_via_device_id,
     resolve_bus_address,
+    solar_identifier,
     zone_identifier,
 )
 
@@ -101,6 +103,8 @@ def test_identifier_helpers_are_deterministic() -> None:
     assert circuit_identifier("entry-1", 0) == ("helianthus", "entry-1-circuit-0")
     assert build_radio_bus_key(0x09, 1) == "g09-i01"
     assert radio_device_identifier("entry-1", "g09-i01") == ("helianthus", "entry-1-radio-g09-i01")
+    assert solar_identifier("entry-1") == ("helianthus", "entry-1-solar")
+    assert cylinder_identifier("entry-1", 0) == ("helianthus", "entry-1-cylinder-0")
     assert dhw_identifier("entry-1") == ("helianthus", "entry-1-dhw")
     assert energy_identifier("entry-1") == ("helianthus", "entry-1-energy")
 

--- a/tests/test_solar_cylinder.py
+++ b/tests/test_solar_cylinder.py
@@ -1,0 +1,284 @@
+"""Tests for HA-10 solar/cylinder interpreted entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    fan_module = sys.modules.setdefault(
+        "homeassistant.components.fan",
+        types.ModuleType("homeassistant.components.fan"),
+    )
+    if not hasattr(fan_module, "FanEntity"):
+        class _FanEntity:
+            pass
+
+        fan_module.FanEntity = _FanEntity
+
+    switch_module = sys.modules.setdefault(
+        "homeassistant.components.switch",
+        types.ModuleType("homeassistant.components.switch"),
+    )
+    if not hasattr(switch_module, "SwitchEntity"):
+        class _SwitchEntity:
+            pass
+
+        switch_module.SwitchEntity = _SwitchEntity
+
+    number_module = sys.modules.setdefault(
+        "homeassistant.components.number",
+        types.ModuleType("homeassistant.components.number"),
+    )
+    if not hasattr(number_module, "NumberEntity"):
+        class _NumberEntity:
+            pass
+
+        number_module.NumberEntity = _NumberEntity
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+    if not hasattr(sensor_module, "SensorDeviceClass"):
+        class _SensorDeviceClass:
+            ENERGY = "energy"
+            TEMPERATURE = "temperature"
+            PRESSURE = "pressure"
+            HUMIDITY = "humidity"
+            DURATION = "duration"
+
+        sensor_module.SensorDeviceClass = _SensorDeviceClass
+    if not hasattr(sensor_module, "SensorStateClass"):
+        class _SensorStateClass:
+            TOTAL = "total"
+            MEASUREMENT = "measurement"
+            TOTAL_INCREASING = "total_increasing"
+
+        sensor_module.SensorStateClass = _SensorStateClass
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfEnergy"):
+        class _UnitOfEnergy:
+            KILO_WATT_HOUR = "kWh"
+
+        const_module.UnitOfEnergy = _UnitOfEnergy
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import fan as fan_platform
+from custom_components.helianthus import number as number_platform
+from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus import switch as switch_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+        self.refresh_requests = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refresh_requests += 1
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _payload(mode: str) -> dict:
+    return {
+        "device_coordinator": _FakeCoordinator([]),
+        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
+        "energy_coordinator": None,
+        "circuit_coordinator": _FakeCoordinator({"circuits": []}),
+        "radio_coordinator": None,
+        "fm5_coordinator": _FakeCoordinator(
+            {
+                "fm5SemanticMode": mode,
+                "solar": {
+                    "collectorTemperatureC": 72.0,
+                    "returnTemperatureC": 41.0,
+                    "pumpActive": True,
+                    "currentYield": 1.2,
+                    "pumpHours": 123.0,
+                    "solarEnabled": True,
+                    "functionMode": False,
+                },
+                "cylinders": [
+                    {
+                        "index": 0,
+                        "temperatureC": 49.0,
+                        "maxSetpointC": 62.0,
+                        "chargeHysteresisC": 6.0,
+                        "chargeOffsetC": 3.0,
+                    }
+                ],
+            }
+        ),
+        "system_coordinator": _FakeCoordinator({"state": {}, "config": {}, "properties": {}}),
+        "boiler_coordinator": None,
+        "boiler_device_id": None,
+        "graphql_client": None,
+        "daemon_device_id": ("helianthus", "daemon-entry-1"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "vr71_device_id": ("helianthus", "entry-1-bus-VR_71-26"),
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_interpreted_mode_creates_solar_and_cylinder_entities() -> None:
+    payload = _payload("INTERPRETED")
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    fan_entities: list = []
+    switch_entities: list = []
+    number_entities: list = []
+    sensor_entities: list = []
+
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, fan_entities.extend))
+    asyncio.run(switch_platform.async_setup_entry(hass, entry, switch_entities.extend))
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, sensor_entities.extend))
+
+    assert any(isinstance(entity, fan_platform.HelianthusSolarPumpFan) for entity in fan_entities)
+    assert len(
+        [entity for entity in switch_entities if isinstance(entity, switch_platform.HelianthusSolarSwitch)]
+    ) == 2
+    assert len(
+        [
+            entity
+            for entity in number_entities
+            if isinstance(entity, number_platform.HelianthusCylinderConfigNumber)
+        ]
+    ) == 3
+    assert any(
+        isinstance(entity, sensor_platform.HelianthusCylinderSensor)
+        for entity in sensor_entities
+    )
+    assert any(
+        isinstance(entity, sensor_platform.HelianthusSolarSensor)
+        for entity in sensor_entities
+    )
+    assert any(
+        isinstance(entity, sensor_platform.HelianthusFM5ModeSensor)
+        for entity in sensor_entities
+    )
+
+
+def test_gpio_only_mode_suppresses_interpreted_entities_and_keeps_fm5_marker() -> None:
+    payload = _payload("GPIO_ONLY")
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    fan_entities: list = []
+    switch_entities: list = []
+    number_entities: list = []
+    sensor_entities: list = []
+
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, fan_entities.extend))
+    asyncio.run(switch_platform.async_setup_entry(hass, entry, switch_entities.extend))
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, sensor_entities.extend))
+
+    assert not any(isinstance(entity, fan_platform.HelianthusSolarPumpFan) for entity in fan_entities)
+    assert not any(isinstance(entity, switch_platform.HelianthusSolarSwitch) for entity in switch_entities)
+    assert not any(
+        isinstance(entity, number_platform.HelianthusCylinderConfigNumber)
+        for entity in number_entities
+    )
+    assert not any(isinstance(entity, sensor_platform.HelianthusSolarSensor) for entity in sensor_entities)
+    assert not any(isinstance(entity, sensor_platform.HelianthusCylinderSensor) for entity in sensor_entities)
+
+    markers = [
+        entity for entity in sensor_entities if isinstance(entity, sensor_platform.HelianthusFM5ModeSensor)
+    ]
+    assert len(markers) == 1
+    assert markers[0].native_value == "GPIO_ONLY"


### PR DESCRIPTION
## Summary
- add FM5 coordinator query (`fm5SemanticMode`, `solar`, `cylinders`) and mode-aware suppression
- expose interpreted-mode entities for solar pump/status/config and cylinder telemetry/config
- wire FM5 coordinator into setup/reload flow and extend stale cleanup identifiers
- add deterministic IDs for solar/cylinder and full coverage tests

## Validation
- `pytest tests/`
- `./scripts/ci_local.sh`

Fixes #122
