### PR TITLE
Fix adaptive heating curve binary sensor category

### DIFF
--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -145,7 +145,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     key="adaptiveHeatingCurve",
                     label="Adaptive Heating Curve",
                     device_class=None,
-                    entity_category=EntityCategory.CONFIG,
+                    entity_category=EntityCategory.DIAGNOSTIC,
                 ),
             ]
         )

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -283,7 +283,7 @@ def test_system_binary_sensors_expose_maintenance_and_adaptive_flags() -> None:
     assert maintenance.is_on is True
     assert adaptive.is_on is False
     assert maintenance._attr_entity_category == binary_sensor_platform.EntityCategory.DIAGNOSTIC
-    assert adaptive._attr_entity_category == binary_sensor_platform.EntityCategory.CONFIG
+    assert adaptive._attr_entity_category == binary_sensor_platform.EntityCategory.DIAGNOSTIC
     assert maintenance.device_info["identifiers"] == {payload["regulator_device_id"]}
 
 


### PR DESCRIPTION
## Summary
- set `adaptiveHeatingCurve` binary sensor category from `CONFIG` to `DIAGNOSTIC`
- align system test expectation with Home Assistant binary sensor category rules

## Validation
- `pytest tests/test_system.py -q`
- `./scripts/ci_local.sh`

Fixes #132
