### PR TITLE
[HVAC-Blueprint] HA-2: boiler burner and pump fan entities

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -396,6 +396,14 @@ query BoilerStatus {
       flowTemperatureC
       returnTemperatureC
       centralHeatingPumpActive
+      flameActive
+      modulationPct
+      gasValveActive
+      fanSpeedRpm
+      ionisationVoltageUa
+      externalPumpActive
+      circulationPumpActive
+      storageLoadPumpPct
     }
     diagnostics {
       heatingStatusRaw
@@ -953,6 +961,14 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "flowTemperatureC",
                     "returnTemperatureC",
                     "centralHeatingPumpActive",
+                    "flameActive",
+                    "modulationPct",
+                    "gasValveActive",
+                    "fanSpeedRpm",
+                    "ionisationVoltageUa",
+                    "externalPumpActive",
+                    "circulationPumpActive",
+                    "storageLoadPumpPct",
                     "heatingStatusRaw",
                 ],
             ):

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier, solar_identifier
+from .device_ids import (
+    boiler_burner_identifier,
+    boiler_hydraulics_identifier,
+    circuit_identifier,
+    solar_identifier,
+)
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -52,10 +58,62 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
     fm5_coordinator = data.get("fm5_coordinator")
+    boiler_coordinator = data.get("boiler_coordinator")
+    boiler_device_id = data.get("boiler_device_id")
+    boiler_via_device_id = data.get("boiler_via_device_id") or boiler_device_id
     vr71_device_id = data.get("vr71_device_id") or data.get("regulator_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
     entities: list[FanEntity] = []
+    if boiler_coordinator and boiler_device_id:
+        entities.extend(
+            [
+                HelianthusBoilerBurnerFan(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    burner_device_id=boiler_burner_identifier(entry.entry_id),
+                    parent_device_id=boiler_via_device_id,
+                ),
+                HelianthusBoilerPumpFan(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    hydraulics_device_id=boiler_hydraulics_identifier(entry.entry_id),
+                    parent_device_id=boiler_via_device_id,
+                    pump_name="CH Pump",
+                    data_key="centralHeatingPumpActive",
+                ),
+                HelianthusBoilerPumpFan(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    hydraulics_device_id=boiler_hydraulics_identifier(entry.entry_id),
+                    parent_device_id=boiler_via_device_id,
+                    pump_name="External Pump",
+                    data_key="externalPumpActive",
+                ),
+                HelianthusBoilerPumpFan(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    hydraulics_device_id=boiler_hydraulics_identifier(entry.entry_id),
+                    parent_device_id=boiler_via_device_id,
+                    pump_name="Circulation Pump",
+                    data_key="circulationPumpActive",
+                ),
+                HelianthusBoilerPumpFan(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    hydraulics_device_id=boiler_hydraulics_identifier(entry.entry_id),
+                    parent_device_id=boiler_via_device_id,
+                    pump_name="Storage Load Pump",
+                    data_key="storageLoadPumpPct",
+                    pump_has_speed=True,
+                ),
+            ]
+        )
     if coordinator and coordinator.data:
         for circuit in coordinator.data.get("circuits", []) or []:
             if not isinstance(circuit, dict):
@@ -88,11 +146,188 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities(entities)
 
 
-class HelianthusCircuitPumpFan(CoordinatorEntity, FanEntity):
+class HelianthusReadOnlyFan(CoordinatorEntity, FanEntity):
+    """Base read-only fan entity."""
+
+    _attr_supported_features = FanEntityFeature(0)
+
+    async def async_turn_on(
+        self, percentage: int | None = None, preset_mode: str | None = None, **kwargs: Any
+    ) -> None:
+        raise HomeAssistantError("Helianthus fan entities are read-only")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        raise HomeAssistantError("Helianthus fan entities are read-only")
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        raise HomeAssistantError("Helianthus fan entities are read-only")
+
+
+def _boiler_state(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    boiler_status = payload.get("boilerStatus")
+    if not isinstance(boiler_status, dict):
+        return {}
+    state = boiler_status.get("state")
+    if not isinstance(state, dict):
+        return {}
+    return state
+
+
+def _coerce_percentage(value: object | None) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return 0
+    if parsed >= 100:
+        return 100
+    return int(round(parsed))
+
+
+class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
+    """Read-only burner state exposed as a fan."""
+
+    _attr_icon = "mdi:fire"
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        burner_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._burner_device_id = burner_device_id
+        self._parent_device_id = parent_device_id
+        self._attr_name = "Burner"
+        self._attr_unique_id = f"{entry_id}-boiler-burner"
+
+    def _state(self) -> dict[str, Any]:
+        return _boiler_state(self.coordinator.data)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._burner_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Burner",
+            "name": "Burner",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def is_on(self) -> bool | None:
+        value = self._state().get("flameActive")
+        if isinstance(value, bool):
+            return value
+        return None
+
+    @property
+    def percentage(self) -> int | None:
+        return _coerce_percentage(self._state().get("modulationPct"))
+
+    @property
+    def speed_count(self) -> int:
+        return 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        state = self._state()
+        return {
+            "helianthus_role": "modulating_burner",
+            "gas_valve_active": state.get("gasValveActive"),
+            "fan_speed_rpm": state.get("fanSpeedRpm"),
+            "ionisation_ua": state.get("ionisationVoltageUa"),
+        }
+
+
+class HelianthusBoilerPumpFan(HelianthusReadOnlyFan):
+    """Read-only boiler pump state under the Hydraulics sub-device."""
+
+    _attr_icon = "mdi:pump"
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        hydraulics_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+        pump_name: str,
+        data_key: str,
+        pump_has_speed: bool = False,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._hydraulics_device_id = hydraulics_device_id
+        self._parent_device_id = parent_device_id
+        self._pump_name = pump_name
+        self._data_key = data_key
+        self._pump_has_speed = pump_has_speed
+        self._attr_name = pump_name
+        self._attr_unique_id = f"{entry_id}-boiler-{data_key}"
+
+    def _state(self) -> dict[str, Any]:
+        return _boiler_state(self.coordinator.data)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._hydraulics_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Hydraulics",
+            "name": "Hydraulics",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def is_on(self) -> bool | None:
+        value = self._state().get(self._data_key)
+        if self._pump_has_speed:
+            percentage = _coerce_percentage(value)
+            if percentage is None:
+                return None
+            return percentage > 0
+        if isinstance(value, bool):
+            return value
+        return None
+
+    @property
+    def percentage(self) -> int | None:
+        if self._pump_has_speed:
+            return _coerce_percentage(self._state().get(self._data_key))
+        is_on = self.is_on
+        if is_on is None:
+            return None
+        return 100 if is_on else 0
+
+    @property
+    def speed_count(self) -> int:
+        return 0 if self._pump_has_speed else 1
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        pump_type = "percentage" if self._pump_has_speed else "on_off"
+        return {"helianthus_role": "pump", "pump_type": pump_type}
+
+
+class HelianthusCircuitPumpFan(HelianthusReadOnlyFan):
     """Read-only circuit pump state as a fan entity."""
 
     _attr_icon = "mdi:pump"
-    _attr_supported_features = FanEntityFeature(0)
 
     def __init__(
         self,

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,226 @@
+"""Tests for HA-2 boiler fan entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from enum import IntFlag
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    fan_module = sys.modules.setdefault(
+        "homeassistant.components.fan",
+        types.ModuleType("homeassistant.components.fan"),
+    )
+    if not hasattr(fan_module, "FanEntity"):
+        class _FanEntity:
+            pass
+
+        fan_module.FanEntity = _FanEntity
+    if not hasattr(fan_module, "FanEntityFeature"):
+        class _FanEntityFeature(IntFlag):
+            SET_SPEED = 1
+
+        fan_module.FanEntityFeature = _FanEntityFeature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    if not hasattr(update_coordinator_module, "DataUpdateCoordinator"):
+        class _DataUpdateCoordinator:
+            def __class_getitem__(cls, _item):  # noqa: ANN206
+                return cls
+
+            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+                return None
+
+        update_coordinator_module.DataUpdateCoordinator = _DataUpdateCoordinator
+    if not hasattr(update_coordinator_module, "UpdateFailed"):
+        class _UpdateFailed(Exception):
+            pass
+
+        update_coordinator_module.UpdateFailed = _UpdateFailed
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.helianthus import fan as fan_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
+    return {
+        "circuit_coordinator": None,
+        "fm5_coordinator": None,
+        "boiler_coordinator": _FakeCoordinator(
+            {
+                "boilerStatus": {
+                    "state": {
+                        "centralHeatingPumpActive": True,
+                        "externalPumpActive": False,
+                        "circulationPumpActive": True,
+                        "storageLoadPumpPct": 42.4,
+                        "flameActive": True,
+                        "modulationPct": 37.6,
+                        "gasValveActive": True,
+                        "fanSpeedRpm": 1860,
+                        "ionisationVoltageUa": 91,
+                    }
+                }
+            }
+        ),
+        "boiler_device_id": boiler_device_id,
+        "boiler_via_device_id": boiler_device_id,
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_async_setup_entry_adds_boiler_burner_and_hydraulics_fans() -> None:
+    payload = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, (fan_platform.HelianthusBoilerBurnerFan, fan_platform.HelianthusBoilerPumpFan))
+    ]
+    assert len(boiler_entities) == 5
+
+    burner = next(entity for entity in boiler_entities if isinstance(entity, fan_platform.HelianthusBoilerBurnerFan))
+    assert burner._attr_supported_features == fan_platform.FanEntityFeature(0)
+    assert burner.is_on is True
+    assert burner.percentage == 38
+    assert burner.speed_count == 0
+    assert burner.device_info["identifiers"] == {("helianthus", "entry-1-boiler-burner")}
+    assert burner.device_info["via_device"] == ("helianthus", "entry-1-bus-BAI00-08")
+    assert burner.extra_state_attributes == {
+        "helianthus_role": "modulating_burner",
+        "gas_valve_active": True,
+        "fan_speed_rpm": 1860,
+        "ionisation_ua": 91,
+    }
+
+    pumps = {
+        entity._attr_name: entity
+        for entity in boiler_entities
+        if isinstance(entity, fan_platform.HelianthusBoilerPumpFan)
+    }
+    assert set(pumps) == {"CH Pump", "External Pump", "Circulation Pump", "Storage Load Pump"}
+    assert pumps["CH Pump"].is_on is True
+    assert pumps["CH Pump"].percentage == 100
+    assert pumps["CH Pump"].speed_count == 1
+    assert pumps["CH Pump"].device_info["identifiers"] == {("helianthus", "entry-1-boiler-hydraulics")}
+    assert pumps["CH Pump"].device_info["via_device"] == ("helianthus", "entry-1-bus-BAI00-08")
+    assert pumps["CH Pump"].extra_state_attributes == {
+        "helianthus_role": "pump",
+        "pump_type": "on_off",
+    }
+    assert pumps["External Pump"].is_on is False
+    assert pumps["External Pump"].percentage == 0
+    assert pumps["Circulation Pump"].is_on is True
+    assert pumps["Storage Load Pump"].is_on is True
+    assert pumps["Storage Load Pump"].percentage == 42
+    assert pumps["Storage Load Pump"].speed_count == 0
+    assert pumps["Storage Load Pump"].extra_state_attributes == {
+        "helianthus_role": "pump",
+        "pump_type": "percentage",
+    }
+
+
+def test_async_setup_entry_skips_boiler_fans_without_physical_bai00() -> None:
+    payload = _payload(boiler_device_id=None)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, entities.extend))
+
+    assert not any(
+        isinstance(entity, (fan_platform.HelianthusBoilerBurnerFan, fan_platform.HelianthusBoilerPumpFan))
+        for entity in entities
+    )
+
+
+def test_boiler_fans_are_read_only() -> None:
+    payload = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(fan_platform.async_setup_entry(hass, entry, entities.extend))
+
+    burner = next(entity for entity in entities if isinstance(entity, fan_platform.HelianthusBoilerBurnerFan))
+    pump = next(entity for entity in entities if isinstance(entity, fan_platform.HelianthusBoilerPumpFan))
+
+    for operation in (
+        burner.async_turn_on(),
+        burner.async_turn_off(),
+        burner.async_set_percentage(10),
+        pump.async_turn_on(),
+    ):
+        try:
+            asyncio.run(operation)
+        except HomeAssistantError:
+            pass
+        else:
+            raise AssertionError("expected HomeAssistantError")


### PR DESCRIPTION
## What
Implements HA-2 by promoting `fan.py` from the reduced boiler profile to the blueprint contract for burner and pump fan entities.

## Why
The runtime now exposes the full boiler state needed for burner and pump entities, and the physical boiler hierarchy remained incomplete without the Burner and Hydraulics sub-devices.

## Validation
- `./scripts/ci_local.sh`
- `pytest tests/test_fan.py tests/test_coordinator.py`
- Runtime validation on Home Assistant 2026.2.3: `ecoTEC plus` now shows connected devices `Burner` and `Hydraulics`, and the new boiler `fan.*` entities are present.

Closes #113