### PR TITLE
[HVAC-Blueprint] HA-3: boiler diverter valve entity

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -404,6 +404,7 @@ query BoilerStatus {
       externalPumpActive
       circulationPumpActive
       storageLoadPumpPct
+      diverterValvePositionPct
     }
     diagnostics {
       heatingStatusRaw
@@ -969,6 +970,7 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "externalPumpActive",
                     "circulationPumpActive",
                     "storageLoadPumpPct",
+                    "diverterValvePositionPct",
                     "heatingStatusRaw",
                 ],
             ):

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -193,6 +194,7 @@ class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
     """Read-only burner state exposed as a fan."""
 
     _attr_icon = "mdi:fire"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -255,6 +257,7 @@ class HelianthusBoilerPumpFan(HelianthusReadOnlyFan):
     """Read-only boiler pump state under the Hydraulics sub-device."""
 
     _attr_icon = "mdi:pump"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.valve import ValveEntity
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import circuit_identifier, zone_identifier
+from .device_ids import boiler_hydraulics_identifier, circuit_identifier, zone_identifier
+
+try:
+    from homeassistant.components.valve import ValveEntityFeature
+except ImportError:  # pragma: no cover - test stub fallback
+    class ValveEntityFeature(int):
+        """Fallback feature wrapper for test environments without HA valve flags."""
+
+        def __new__(cls, value: int = 0):
+            return int.__new__(cls, value)
 
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
@@ -65,8 +76,22 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data.get("circuit_coordinator")
     semantic_coordinator = data.get("semantic_coordinator")
+    boiler_coordinator = data.get("boiler_coordinator")
+    boiler_device_id = data.get("boiler_device_id")
+    boiler_via_device_id = data.get("boiler_via_device_id") or boiler_device_id
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     entities: list[ValveEntity] = []
+
+    if boiler_coordinator and boiler_device_id:
+        entities.append(
+            HelianthusBoilerDiverterValve(
+                coordinator=boiler_coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                hydraulics_device_id=boiler_hydraulics_identifier(entry.entry_id),
+                parent_device_id=boiler_via_device_id,
+            )
+        )
 
     if coordinator and coordinator.data:
         for circuit in coordinator.data.get("circuits", []) or []:
@@ -106,11 +131,102 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities(entities)
 
 
-class HelianthusCircuitMixingValve(CoordinatorEntity, ValveEntity):
+class HelianthusReadOnlyValve(CoordinatorEntity, ValveEntity):
+    """Base read-only valve entity."""
+
+    _attr_supported_features = ValveEntityFeature(0)
+    _attr_reports_position = True
+
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        raise HomeAssistantError("Helianthus valve entities are read-only")
+
+    async def async_close_valve(self, **kwargs: Any) -> None:
+        raise HomeAssistantError("Helianthus valve entities are read-only")
+
+    async def async_set_valve_position(self, position: int) -> None:
+        raise HomeAssistantError("Helianthus valve entities are read-only")
+
+
+def _coerce_position(value: object | None) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return 0
+    if parsed >= 100:
+        return 100
+    return int(round(parsed))
+
+
+def _boiler_state(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    boiler_status = payload.get("boilerStatus")
+    if not isinstance(boiler_status, dict):
+        return {}
+    state = boiler_status.get("state")
+    if not isinstance(state, dict):
+        return {}
+    return state
+
+
+class HelianthusBoilerDiverterValve(HelianthusReadOnlyValve):
+    """Read-only diverter valve position under the Hydraulics sub-device."""
+
+    _attr_icon = "mdi:valve"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        hydraulics_device_id: tuple[str, str],
+        parent_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._hydraulics_device_id = hydraulics_device_id
+        self._parent_device_id = parent_device_id
+        self._attr_name = "Diverter Valve"
+        self._attr_unique_id = f"{entry_id}-boiler-diverter-valve"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = {
+            "identifiers": {self._hydraulics_device_id},
+            "manufacturer": self._manufacturer,
+            "model": "Hydraulics",
+            "name": "Hydraulics",
+        }
+        if self._parent_device_id is not None:
+            info["via_device"] = self._parent_device_id
+        return DeviceInfo(**info)
+
+    @property
+    def current_valve_position(self) -> int | None:
+        return _coerce_position(_boiler_state(self.coordinator.data).get("diverterValvePositionPct"))
+
+    @property
+    def is_closed(self) -> bool | None:
+        position = self.current_valve_position
+        if position is None:
+            return None
+        return position == 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        return {"position_meaning": "0%=CH, 100%=DHW"}
+
+
+class HelianthusCircuitMixingValve(HelianthusReadOnlyValve):
     """Read-only circuit mixing valve position."""
 
     _attr_icon = "mdi:valve"
-    _attr_reports_position = True
 
     def __init__(
         self,
@@ -161,25 +277,13 @@ class HelianthusCircuitMixingValve(CoordinatorEntity, ValveEntity):
     def current_valve_position(self) -> int | None:
         circuit = self._circuit()
         state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
-        value = state.get("mixerPositionPct")
-        if value is None:
-            return None
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            return None
-        if parsed < 0:
-            parsed = 0
-        if parsed > 100:
-            parsed = 100
-        return int(round(parsed))
+        return _coerce_position(state.get("mixerPositionPct"))
 
 
-class HelianthusZoneValve(CoordinatorEntity, ValveEntity):
+class HelianthusZoneValve(HelianthusReadOnlyValve):
     """Read-only zone valve status (0/100)."""
 
     _attr_icon = "mdi:valve"
-    _attr_reports_position = True
 
     def __init__(
         self,
@@ -226,15 +330,4 @@ class HelianthusZoneValve(CoordinatorEntity, ValveEntity):
     def current_valve_position(self) -> int | None:
         zone = self._zone()
         state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
-        value = state.get("valvePositionPct")
-        if value is None:
-            return None
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            return None
-        if parsed <= 0:
-            return 0
-        if parsed >= 100:
-            return 100
-        return int(round(parsed))
+        return _coerce_position(state.get("valvePositionPct"))

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -17,6 +17,13 @@ def _ensure_homeassistant_stubs() -> None:
     setattr(homeassistant_module, "components", components_module)
     helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
     setattr(homeassistant_module, "helpers", helpers_module)
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
 
     fan_module = sys.modules.setdefault(
         "homeassistant.components.fan",

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,0 +1,166 @@
+"""Tests for HA-3 boiler diverter valve entity."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from enum import IntFlag
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+
+    valve_module = sys.modules.setdefault(
+        "homeassistant.components.valve",
+        types.ModuleType("homeassistant.components.valve"),
+    )
+    if not hasattr(valve_module, "ValveEntity"):
+        class _ValveEntity:
+            pass
+
+        valve_module.ValveEntity = _ValveEntity
+    if not hasattr(valve_module, "ValveEntityFeature"):
+        class _ValveEntityFeature(IntFlag):
+            OPEN = 1
+            CLOSE = 2
+            SET_POSITION = 4
+
+        valve_module.ValveEntityFeature = _ValveEntityFeature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.helianthus import valve as valve_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _payload(*, boiler_device_id: tuple[str, str] | None, position: float | None) -> dict:
+    return {
+        "circuit_coordinator": None,
+        "semantic_coordinator": None,
+        "boiler_coordinator": _FakeCoordinator(
+            {"boilerStatus": {"state": {"diverterValvePositionPct": position}}}
+        ),
+        "boiler_device_id": boiler_device_id,
+        "boiler_via_device_id": boiler_device_id,
+        "regulator_manufacturer": "Vaillant",
+    }
+
+
+def test_async_setup_entry_adds_boiler_diverter_valve() -> None:
+    payload = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"), position=73.4)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(valve_platform.async_setup_entry(hass, entry, entities.extend))
+
+    diverter = next(entity for entity in entities if isinstance(entity, valve_platform.HelianthusBoilerDiverterValve))
+    assert diverter._attr_supported_features == valve_platform.ValveEntityFeature(0)
+    assert diverter.current_valve_position == 73
+    assert diverter.is_closed is False
+    assert diverter.device_info["identifiers"] == {("helianthus", "entry-1-boiler-hydraulics")}
+    assert diverter.device_info["via_device"] == ("helianthus", "entry-1-bus-BAI00-08")
+    assert diverter.extra_state_attributes == {"position_meaning": "0%=CH, 100%=DHW"}
+
+
+def test_async_setup_entry_skips_boiler_diverter_without_physical_bai00() -> None:
+    payload = _payload(boiler_device_id=None, position=50.0)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(valve_platform.async_setup_entry(hass, entry, entities.extend))
+
+    assert not any(isinstance(entity, valve_platform.HelianthusBoilerDiverterValve) for entity in entities)
+
+
+def test_boiler_diverter_valve_is_read_only_and_reports_closed_state() -> None:
+    payload = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"), position=0.0)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    entities: list = []
+    asyncio.run(valve_platform.async_setup_entry(hass, entry, entities.extend))
+
+    diverter = next(entity for entity in entities if isinstance(entity, valve_platform.HelianthusBoilerDiverterValve))
+    assert diverter.current_valve_position == 0
+    assert diverter.is_closed is True
+
+    for operation in (
+        diverter.async_open_valve(),
+        diverter.async_close_valve(),
+        diverter.async_set_valve_position(20),
+    ):
+        try:
+            asyncio.run(operation)
+        except HomeAssistantError:
+            pass
+        else:
+            raise AssertionError("expected HomeAssistantError")


### PR DESCRIPTION
## What
Implements HA-3 by adding the read-only boiler diverter valve entity under the Hydraulics sub-device and wiring the required boiler query field.

## Why
The boiler hierarchy was still incomplete after HA-2; the Hydraulics device needs the diverter valve state to match the blueprint device tree.

## Validation
- `./scripts/ci_local.sh`
- `pytest tests/test_valve.py tests/test_zone_valve.py tests/test_circuit.py tests/test_coordinator.py`
- Runtime validation on Home Assistant 2026.2.3: `Hydraulics` now exposes `Diverter Valve` in the device UI.

Closes #114