### PR TITLE
[HVAC-Blueprint] HA-4: boiler config numbers on BAI00

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -406,6 +406,12 @@ query BoilerStatus {
       storageLoadPumpPct
       diverterValvePositionPct
     }
+    config {
+      flowsetHcMaxC
+      flowsetHwcMaxC
+      partloadHcKW
+      partloadHwcKW
+    }
     diagnostics {
       heatingStatusRaw
     }
@@ -951,6 +957,10 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._client = client
         self.boiler_supported = True
 
+    @property
+    def client(self) -> GraphQLClient:
+        return self._client
+
     async def _async_update_data(self) -> dict[str, Any]:
         try:
             payload = await self._client.execute(QUERY_BOILER)
@@ -971,6 +981,10 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "circulationPumpActive",
                     "storageLoadPumpPct",
                     "diverterValvePositionPct",
+                    "flowsetHcMaxC",
+                    "flowsetHwcMaxC",
+                    "partloadHcKW",
+                    "partloadHwcKW",
                     "heatingStatusRaw",
                 ],
             ):

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -33,6 +33,15 @@ mutation SetSystemConfig($field: String!, $value: String!) {
 }
 """
 
+_SET_BOILER_CONFIG_MUTATION = """
+mutation SetBoilerConfig($field: String!, $value: String!) {
+  setBoilerConfig(field: $field, value: $value) {
+    success
+    error
+  }
+}
+"""
+
 _CIRCUIT_TYPE_LABELS = {
     "heating": "Heating",
     "fixed_value": "Fixed Value",
@@ -67,6 +76,16 @@ class SystemNumberField:
 
 @dataclass(frozen=True)
 class CylinderNumberField:
+    key: str
+    label: str
+    minimum: float
+    maximum: float
+    step: float
+    unit: str | None = None
+
+
+@dataclass(frozen=True)
+class BoilerNumberField:
     key: str
     label: str
     minimum: float
@@ -187,6 +206,41 @@ _CYLINDER_NUMBER_FIELDS = [
     ),
 ]
 
+_BOILER_NUMBER_FIELDS = [
+    BoilerNumberField(
+        key="flowsetHcMaxC",
+        label="CH Max Flow Setpoint",
+        minimum=20.0,
+        maximum=80.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    BoilerNumberField(
+        key="flowsetHwcMaxC",
+        label="DHW Max Flow Setpoint",
+        minimum=30.0,
+        maximum=65.0,
+        step=1.0,
+        unit=UnitOfTemperature.CELSIUS,
+    ),
+    BoilerNumberField(
+        key="partloadHcKW",
+        label="CH Partload",
+        minimum=0.0,
+        maximum=40.0,
+        step=0.1,
+        unit="kW",
+    ),
+    BoilerNumberField(
+        key="partloadHwcKW",
+        label="DHW Partload",
+        minimum=0.0,
+        maximum=40.0,
+        step=0.1,
+        unit="kW",
+    ),
+]
+
 
 def _parse_circuit_index(value: object | None) -> int | None:
     if isinstance(value, bool):
@@ -220,12 +274,27 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     coordinator = data.get("circuit_coordinator")
     system_coordinator = data.get("system_coordinator")
     fm5_coordinator = data.get("fm5_coordinator")
+    boiler_coordinator = data.get("boiler_coordinator")
+    boiler_device_id = data.get("boiler_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
     regulator_device_id = data.get("regulator_device_id")
     vr71_device_id = data.get("vr71_device_id") or regulator_device_id
 
     entities: list[NumberEntity] = []
+    if boiler_coordinator and boiler_device_id:
+        for field in _BOILER_NUMBER_FIELDS:
+            entities.append(
+                HelianthusBoilerNumber(
+                    coordinator=boiler_coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                    client=client,
+                    boiler_device_id=boiler_device_id,
+                    field=field,
+                )
+            )
+
     if coordinator and coordinator.data:
         for circuit in coordinator.data.get("circuits", []) or []:
             if not isinstance(circuit, dict):
@@ -281,6 +350,80 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     )
 
     async_add_entities(entities)
+
+
+class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
+    """Writable boiler configuration number on the physical BAI00 device."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        boiler_device_id: tuple[str, str],
+        field: BoilerNumberField,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._client = client
+        self._boiler_device_id = boiler_device_id
+        self._field = field
+        self._attr_unique_id = f"{entry_id}-boiler-number-{field.key}"
+        self._attr_name = field.label
+        self._attr_native_min_value = field.minimum
+        self._attr_native_max_value = field.maximum
+        self._attr_native_step = field.step
+        if field.unit is not None:
+            self._attr_native_unit_of_measurement = field.unit
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={self._boiler_device_id},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        payload = self.coordinator.data or {}
+        boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+        config = boiler_status.get("config") if isinstance(boiler_status, dict) else {}
+        value = config.get(self._field.key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        if value < self._field.minimum or value > self._field.maximum:
+            raise HomeAssistantError(
+                f"Value {value} outside allowed range [{self._field.minimum}, {self._field.maximum}]"
+            )
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        variables = {"field": self._field.key, "value": str(float(value))}
+        try:
+            payload = await self._client.mutation(_SET_BOILER_CONFIG_MUTATION, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = ""
+        if isinstance(result, dict):
+            error = str(result.get("error") or "")
+        message = error or "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {message}")
 
 
 class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,198 @@
+"""Tests for HA-4 boiler config numbers."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    number_module = sys.modules.setdefault(
+        "homeassistant.components.number",
+        types.ModuleType("homeassistant.components.number"),
+    )
+    if not hasattr(number_module, "NumberEntity"):
+        class _NumberEntity:
+            pass
+
+        number_module.NumberEntity = _NumberEntity
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "PERCENTAGE"):
+        const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "UnitOfTemperature"):
+        class _UnitOfTemperature:
+            CELSIUS = "C"
+
+        const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+    if not hasattr(exceptions_module, "HomeAssistantError"):
+        class _HomeAssistantError(Exception):
+            pass
+
+        exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import number as number_platform
+from custom_components.helianthus.const import DOMAIN
+
+
+class _FakeCoordinator:
+    def __init__(self, data) -> None:  # noqa: ANN001
+        self.data = data
+        self.refresh_requests = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refresh_requests += 1
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def mutation(self, query: str, variables: dict):  # noqa: ANN201
+        self.calls.append({"query": query, "variables": variables})
+        return {"setBoilerConfig": {"success": True, "error": None}}
+
+
+class _FakeEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+def _payload(*, boiler_device_id: tuple[str, str] | None):
+    boiler_coordinator = _FakeCoordinator(
+        {
+            "boilerStatus": {
+                "config": {
+                    "flowsetHcMaxC": 70.0,
+                    "flowsetHwcMaxC": 59.0,
+                    "partloadHcKW": 18.5,
+                    "partloadHwcKW": 22.0,
+                }
+            }
+        }
+    )
+    client = _FakeClient()
+    payload = {
+        "circuit_coordinator": None,
+        "system_coordinator": None,
+        "fm5_coordinator": None,
+        "boiler_coordinator": boiler_coordinator,
+        "boiler_device_id": boiler_device_id,
+        "graphql_client": client,
+        "regulator_manufacturer": "Vaillant",
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "vr71_device_id": ("helianthus", "entry-1-bus-VR_71-26"),
+    }
+    return payload, boiler_coordinator, client
+
+
+def test_async_setup_entry_adds_boiler_config_numbers_on_bai00() -> None:
+    payload, _coordinator, _client = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_numbers = [
+        entity for entity in entities if isinstance(entity, number_platform.HelianthusBoilerNumber)
+    ]
+    assert len(boiler_numbers) == 4
+    assert {entity._attr_name for entity in boiler_numbers} == {
+        "CH Max Flow Setpoint",
+        "DHW Max Flow Setpoint",
+        "CH Partload",
+        "DHW Partload",
+    }
+    for entity in boiler_numbers:
+        assert entity._attr_entity_category == number_platform.EntityCategory.CONFIG
+        assert entity.device_info["identifiers"] == {("helianthus", "entry-1-bus-BAI00-08")}
+
+
+def test_async_setup_entry_skips_boiler_config_numbers_without_physical_bai00() -> None:
+    payload, _coordinator, _client = _payload(boiler_device_id=None)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    assert not any(isinstance(entity, number_platform.HelianthusBoilerNumber) for entity in entities)
+
+
+def test_boiler_number_entities_write_set_boiler_config_mutation() -> None:
+    payload, boiler_coordinator, client = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_numbers = [
+        entity for entity in entities if isinstance(entity, number_platform.HelianthusBoilerNumber)
+    ]
+    ch_max = next(entity for entity in boiler_numbers if entity._field.key == "flowsetHcMaxC")
+    dhw_partload = next(entity for entity in boiler_numbers if entity._field.key == "partloadHwcKW")
+
+    asyncio.run(ch_max.async_set_native_value(68.0))
+    asyncio.run(dhw_partload.async_set_native_value(21.5))
+
+    assert [call["variables"]["field"] for call in client.calls] == [
+        "flowsetHcMaxC",
+        "partloadHwcKW",
+    ]
+    assert [call["variables"]["value"] for call in client.calls] == ["68.0", "21.5"]
+    assert boiler_coordinator.refresh_requests == 2


### PR DESCRIPTION
## What
Implements `number.py` boiler config number entities on the physical BAI00 device.

## Why
HA-4 completes the writable boiler config surface needed by the blueprint boiler hierarchy after HA-2 and HA-3.

## Changes
- extends the boiler coordinator query with boiler config fields
- adds `HelianthusBoilerNumber` config entities for CH/DHW flow setpoints and partload limits
- adds regression coverage for entity creation and `setBoilerConfig` writes

## Validation
- `./scripts/ci_local.sh`
- runtime deploy to HA Core override on `192.168.100.4`
- GraphQL smoke write: `setBoilerConfig(field: "flowsetHwcMaxC", value: "59") -> success: true`
- HA UI device page shows the 4 config numbers on `ecoTEC plus`