### PR TITLE
HA: consume explicit circuit ownership contract (#143)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -544,15 +544,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_kwargs["hw_version"] = f"0x{hardware_identifier:04X}"
         device_registry.async_get_or_create(**device_kwargs)
 
-    system_payload = system_coordinator.data or {}
-    system_properties = system_payload.get("properties")
-    if not isinstance(system_properties, dict):
-        system_properties = {}
-    fm5_raw = parse_optional_int(system_properties.get("moduleConfigurationVR71"))
-    fm5_config = fm5_raw if fm5_raw is not None and fm5_raw >= 0 else None
-    vr71_start_raw = parse_optional_int(system_properties.get("vr71CircuitStartIndex"))
-    vr71_circuit_start = vr71_start_raw if vr71_start_raw is not None and vr71_start_raw >= 0 else -1
-
     circuits_payload = circuit_coordinator.data or {}
     circuits = circuits_payload.get("circuits", []) or []
     known_circuit_indexes: set[int] = set()
@@ -570,8 +561,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             regulator_device_id=regulator_device,
             vr71_device_id=vr71_device,
             adapter_device_id=adapter_device_id,
-            fm5_config=fm5_config,
-            vr71_circuit_start=vr71_circuit_start,
+            managing_device=circuit.get("managingDevice"),
         )
         circuit_device_id = circuit_identifier(entry.entry_id, index)
         device_kwargs: dict[str, object] = {
@@ -1054,8 +1044,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "regulator_manufacturer": regulator_manufacturer,
         "regulator_bus_address": regulator_bus_address,
         "daemon_source_address": daemon_source_addr,
-        "fm5_config": fm5_config,
-        "vr71_circuit_start": vr71_circuit_start,
         "boiler_physical_device_id": boiler_physical_device_id,
         "boiler_via_device_id": boiler_via_device_id,
         "boiler_burner_device_id": boiler_burner_device_id,

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -251,6 +251,11 @@ query Circuits {
     index
     circuitType
     hasMixer
+    managingDevice {
+      role
+      deviceId
+      address
+    }
     state {
       pumpActive
       mixerPositionPct
@@ -320,35 +325,6 @@ query FM5Semantic {
 """
 
 QUERY_SYSTEM = """
-query System {
-  system {
-    state {
-      systemWaterPressure
-      systemFlowTemperature
-      outdoorTemperature
-      outdoorTemperatureAvg24h
-      maintenanceDue
-      hwcCylinderTemperatureTop
-      hwcCylinderTemperatureBottom
-    }
-    config {
-      adaptiveHeatingCurve
-      heatingCircuitBivalencePoint
-      dhwBivalencePoint
-      hcEmergencyTemperature
-      hwcMaxFlowTempDesired
-      maxRoomHumidity
-    }
-    properties {
-      systemScheme
-      moduleConfigurationVR71
-      vr71CircuitStartIndex
-    }
-  }
-}
-"""
-
-QUERY_SYSTEM_LEGACY = """
 query System {
   system {
     state {
@@ -876,19 +852,9 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             payload = await self._client.execute(QUERY_SYSTEM)
         except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["vr71CircuitStartIndex"]):
-                try:
-                    payload = await self._client.execute(QUERY_SYSTEM_LEGACY)
-                except GraphQLResponseError as nested:
-                    if _is_missing_field_error(nested.errors, missing_fields):
-                        return empty
-                    raise UpdateFailed(str(nested)) from nested
-                except GraphQLClientError as nested:
-                    raise UpdateFailed(str(nested)) from nested
-            elif _is_missing_field_error(exc.errors, missing_fields):
+            if _is_missing_field_error(exc.errors, missing_fields):
                 return empty
-            else:
-                raise UpdateFailed(str(exc)) from exc
+            raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -201,21 +201,32 @@ def managing_device_identifier(
     regulator_device_id: DeviceIdentifier | None,
     vr71_device_id: DeviceIdentifier | None,
     adapter_device_id: DeviceIdentifier | None = None,
-    fm5_config: int | None = None,
-    vr71_circuit_start: int = -1,
+    managing_device: dict[str, object] | None = None,
 ) -> DeviceIdentifier | None:
     """Resolve the physical manager device for a semantic sub-device.
 
     R6 rules:
-    - solar/cylinder groups use VR_71 when FM5 is present;
-    - circuits can use VR_71 starting from `vr71_circuit_start`;
-    - otherwise use controller/regulator, then adapter fallback.
+    - circuits use the explicit semantic `managingDevice` contract;
+    - `UNKNOWN` ownership does not fall back to a guessed physical parent;
+    - non-circuit groups keep the controller/adapter fallback.
     """
 
-    if group in (0x04, 0x05) and vr71_device_id and fm5_config is not None:
-        if 1 <= int(fm5_config) <= 2:
-            return vr71_device_id
-    if group == 0x02 and vr71_device_id and vr71_circuit_start >= 0:
-        if instance >= vr71_circuit_start:
-            return vr71_device_id
+    del instance
+
+    if group == 0x02:
+        role = str((managing_device or {}).get("role") or "").strip().upper()
+        if role == "REGULATOR":
+            return regulator_device_id
+        if role == "FUNCTION_MODULE":
+            device_id = _clean((managing_device or {}).get("deviceId"))
+            if device_id is None:
+                device_id = _clean((managing_device or {}).get("device_id"))
+            address = _parse_bus_address((managing_device or {}).get("address"))
+            if vr71_device_id and (device_id == "VR_71" or address == 0x26):
+                return vr71_device_id
+            return None
+        if role == "UNKNOWN":
+            return None
+        return None
+
     return regulator_device_id or adapter_device_id or vr71_device_id

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -366,6 +366,11 @@ def test_circuit_query_returns_circuit_payload() -> None:
                 "index": 0,
                 "circuitType": "heating",
                 "hasMixer": True,
+                "managingDevice": {
+                    "role": "FUNCTION_MODULE",
+                    "deviceId": "VR_71",
+                    "address": 0x26,
+                },
                 "state": {"pumpActive": True},
                 "config": {"coolingEnabled": False},
             }

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -132,7 +132,7 @@ def test_boiler_device_contract_helpers_fall_back_to_regulator_or_adapter() -> N
     assert resolve_boiler_via_device_id(None, None, adapter) == adapter
 
 
-def test_managing_device_identifier_prefers_regulator_for_circuits_by_default() -> None:
+def test_managing_device_identifier_routes_to_regulator_from_explicit_role() -> None:
     regulator = ("helianthus", "entry-1-bus-BASV-15")
     vr71 = ("helianthus", "entry-1-bus-VR_71-26")
     adapter = ("helianthus", "adapter-entry-1")
@@ -144,14 +144,13 @@ def test_managing_device_identifier_prefers_regulator_for_circuits_by_default() 
             regulator_device_id=regulator,
             vr71_device_id=vr71,
             adapter_device_id=adapter,
-            fm5_config=None,
-            vr71_circuit_start=-1,
+            managing_device={"role": "REGULATOR", "deviceId": "BASV2", "address": 0x15},
         )
         == regulator
     )
 
 
-def test_managing_device_identifier_routes_to_vr71_when_circuit_is_fm5_managed() -> None:
+def test_managing_device_identifier_routes_to_vr71_from_explicit_function_module() -> None:
     regulator = ("helianthus", "entry-1-bus-BASV-15")
     vr71 = ("helianthus", "entry-1-bus-VR_71-26")
     adapter = ("helianthus", "adapter-entry-1")
@@ -163,8 +162,25 @@ def test_managing_device_identifier_routes_to_vr71_when_circuit_is_fm5_managed()
             regulator_device_id=regulator,
             vr71_device_id=vr71,
             adapter_device_id=adapter,
-            fm5_config=1,
-            vr71_circuit_start=2,
+            managing_device={"role": "FUNCTION_MODULE", "deviceId": "VR_71", "address": 0x26},
         )
         == vr71
+    )
+
+
+def test_managing_device_identifier_returns_none_for_unknown_circuit_ownership() -> None:
+    regulator = ("helianthus", "entry-1-bus-BASV-15")
+    vr71 = ("helianthus", "entry-1-bus-VR_71-26")
+    adapter = ("helianthus", "adapter-entry-1")
+
+    assert (
+        managing_device_identifier(
+            group=0x02,
+            instance=0,
+            regulator_device_id=regulator,
+            vr71_device_id=vr71,
+            adapter_device_id=adapter,
+            managing_device={"role": "UNKNOWN"},
+        )
+        is None
     )


### PR DESCRIPTION
## What
- stop querying and consuming `vr71CircuitStartIndex`
- parent circuit devices from `circuits[].managingDevice` only
- treat `UNKNOWN` ownership as unparented rather than guessed

## Why
Circuit parenting should consume the canonical gateway contract instead of the old threshold heuristic.

## Validation
- `python3 -m pytest -q`
- `./scripts/ci_local.sh`

## Dependencies
- blocked by gateway contract PR Project-Helianthus/helianthus-ebusgateway#304
- docs companion: Project-Helianthus/helianthus-docs-ebus#184

Closes #143
