### PR TITLE
Add zone valve binary sensor (open/closed)

### DIFF
--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -145,6 +145,16 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     schedule_label=schedule_label,
                 )
             )
+        entities.append(
+            HelianthusZoneValveBinarySensor(
+                coordinator=coordinator,
+                entry_id=entry.entry_id,
+                manufacturer=manufacturer,
+                zone_id=str(zone_id),
+                zone_name=zone_name,
+                target_device_id=parent_device_id,
+            )
+        )
 
     dhw = coordinator.data.get("dhw") if coordinator.data else None
     if dhw is not None:
@@ -633,3 +643,58 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
         if isinstance(value, bool):
             return value
         return None
+
+
+class HelianthusZoneValveBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Zone valve open/closed derived from valve_position_pct."""
+
+    _attr_device_class = BinarySensorDeviceClass.OPENING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        zone_id: str,
+        zone_name: str,
+        target_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._zone_id = zone_id
+        self._target_device_id = target_device_id
+        self._attr_name = f"{zone_name} Valve"
+        self._attr_unique_id = f"{entry_id}-zone-{zone_id}-binary-valve"
+
+    def _zone(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        for zone in payload.get("zones", []) or []:
+            if not isinstance(zone, dict):
+                continue
+            if str(zone.get("id")) == self._zone_id:
+                return zone
+        return {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        identifier = self._target_device_id
+        if identifier is None:
+            raise RuntimeError("Zone valve binary sensor created without a physical parent device")
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        zone = self._zone()
+        state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
+        value = state.get("valvePositionPct") if isinstance(state, dict) else None
+        if value is None:
+            return None
+        try:
+            return float(value) > 0
+        except (TypeError, ValueError):
+            return None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -31,6 +31,8 @@ def _ensure_homeassistant_stubs() -> None:
     if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
         class _BinarySensorDeviceClass:
             RUNNING = "running"
+            OPENING = "opening"
+            PROBLEM = "problem"
 
         binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
 
@@ -180,3 +182,76 @@ def test_async_setup_entry_skips_boiler_state_binary_sensors_without_physical_ba
     ]
 
     assert boiler_entities == []
+
+
+def _build_zone_payload(valve_position_pct):
+    return {
+        "semantic_coordinator": _FakeCoordinator({
+            "zones": [
+                {
+                    "id": "zone-1",
+                    "name": "Living Room",
+                    "state": {"valvePositionPct": valve_position_pct},
+                    "config": {"roomTemperatureZoneMapping": None},
+                },
+            ],
+            "dhw": None,
+        }),
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
+        "regulator_manufacturer": "Vaillant",
+        "zone_parent_device_ids": {"zone-1": ("helianthus", "entry-1-bus-BASV2-15")},
+    }
+
+
+def test_zone_valve_binary_sensor_open_when_position_nonzero() -> None:
+    payload = _build_zone_payload(valve_position_pct=50.0)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    valve_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusZoneValveBinarySensor)
+    ]
+    assert len(valve_entities) == 1
+    valve = valve_entities[0]
+    assert valve._attr_unique_id == "entry-1-zone-zone-1-binary-valve"
+    assert valve._attr_name == "Living Room Valve"
+    assert valve.is_on is True
+
+
+def test_zone_valve_binary_sensor_closed_when_position_zero() -> None:
+    payload = _build_zone_payload(valve_position_pct=0)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    valve_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusZoneValveBinarySensor)
+    ]
+    assert len(valve_entities) == 1
+    assert valve_entities[0].is_on is False
+
+
+def test_zone_valve_binary_sensor_none_when_position_absent() -> None:
+    payload = _build_zone_payload(valve_position_pct=None)
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    valve_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, binary_sensor_platform.HelianthusZoneValveBinarySensor)
+    ]
+    assert len(valve_entities) == 1
+    assert valve_entities[0].is_on is None


### PR DESCRIPTION
## Summary

- Add `HelianthusZoneValveBinarySensor` that derives open/closed from `valve_position_pct > 0`
- Uses `BinarySensorDeviceClass.OPENING`, diagnostic category
- Tests for open (position > 0), closed (position == 0), and absent (None) states

Part of META-22 W3-I04 (Valve + Cylinder Entities). All other acceptance criteria verified as already implemented:
- Diverter valve position %: `BOILER_STATE_SENSOR_FIELDS`
- Zone valve position %: `HelianthusZoneValvePositionSensor`
- Cylinder gated on temp evidence: `HelianthusCylinderSensor`
- Solar NOT exposed (DEFERRED per plan)
- `cooling_enabled` NOT exposed (per plan)

Closes #149

## Test plan

- [x] `test_zone_valve_binary_sensor_open_when_position_nonzero`
- [x] `test_zone_valve_binary_sensor_closed_when_position_zero`
- [x] `test_zone_valve_binary_sensor_none_when_position_absent`
- [x] 123 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)