### PR TITLE
Add calendar entities for B555 timer schedules

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -32,6 +32,7 @@ PLATFORMS: list[str] = [
     "number",
     "select",
     "switch",
+    "calendar",
 ]
 
 if TYPE_CHECKING:
@@ -227,6 +228,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HelianthusEnergyCoordinator,
         HelianthusFM5Coordinator,
         HelianthusRadioDeviceCoordinator,
+        HelianthusScheduleCoordinator,
         HelianthusSemanticCoordinator,
         HelianthusSystemCoordinator,
         HelianthusStatusCoordinator,
@@ -328,6 +330,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     fm5_coordinator = HelianthusFM5Coordinator(hass, client, scan_interval)
     system_coordinator = HelianthusSystemCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
+    schedule_coordinator = HelianthusScheduleCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
     await status_coordinator.async_config_entry_first_refresh()
     await semantic_coordinator.async_config_entry_first_refresh()
@@ -337,6 +340,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await fm5_coordinator.async_config_entry_first_refresh()
     await system_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
+    await schedule_coordinator.async_config_entry_first_refresh()
 
     devices = device_coordinator.data or []
     reload_scheduled = False
@@ -1033,6 +1037,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "fm5_coordinator": fm5_coordinator,
         "system_coordinator": system_coordinator,
         "boiler_coordinator": boiler_coordinator,
+        "schedule_coordinator": schedule_coordinator,
         "graphql_client": client,
         "subscription_task": subscription_task,
         "unsub_listeners": unsub_listeners,

--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -1,0 +1,240 @@
+"""Calendar platform for Helianthus B555 timer schedules."""
+
+from __future__ import annotations
+
+from datetime import datetime, date, timedelta
+from typing import Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .device_ids import zone_identifier, dhw_identifier
+
+_WEEKDAY_INDEX = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+_HC_LABELS = {
+    "heating": "Heating",
+    "cooling": "Cooling",
+    "dhw": "DHW",
+    "circulation": "Circulation",
+    "silent": "Silent",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Helianthus schedule calendar entities."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    schedule_coordinator = data.get("schedule_coordinator")
+    if schedule_coordinator is None:
+        return
+
+    zone_parent_device_ids = data.get("zone_parent_device_ids") or {}
+    regulator_device_id = data.get("regulator_device_id")
+
+    programs = (schedule_coordinator.data or {}).get("programs") or []
+    entities: list[CalendarEntity] = []
+
+    for program in programs:
+        if not isinstance(program, dict):
+            continue
+        zone = program.get("zone")
+        hc = program.get("hc")
+        if zone is None or hc is None:
+            continue
+
+        if zone == 255:
+            target_device_id = dhw_identifier(entry.entry_id)
+        else:
+            zone_id = str(zone)
+            target_device_id = zone_parent_device_ids.get(
+                zone_id, zone_identifier(entry.entry_id, zone_id)
+            )
+
+        entities.append(
+            HelianthusScheduleCalendar(
+                coordinator=schedule_coordinator,
+                entry_id=entry.entry_id,
+                zone=zone,
+                hc=hc,
+                target_device_id=target_device_id,
+                regulator_device_id=regulator_device_id,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
+    """Calendar entity representing a B555 timer schedule program."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        zone: int,
+        hc: str,
+        target_device_id: tuple[str, str] | None,
+        regulator_device_id: tuple[str, str] | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._zone = zone
+        self._hc = hc
+        self._entry_id = entry_id
+        self._target_device_id = target_device_id or regulator_device_id
+
+        hc_label = _HC_LABELS.get(hc, hc)
+        if zone == 255:
+            self._attr_name = f"{hc_label} Schedule"
+            zone_tag = "dhw"
+        else:
+            self._attr_name = f"Zone {zone} {hc_label} Schedule"
+            zone_tag = f"zone_{zone}"
+
+        self._attr_unique_id = (
+            f"{entry_id}-schedule-{zone_tag}-{hc}"
+        )
+        self._hc_label = hc_label
+
+    @property
+    def device_info(self):
+        if self._target_device_id is None:
+            return None
+        from homeassistant.helpers.device_registry import DeviceInfo
+        return DeviceInfo(identifiers={self._target_device_id})
+
+    def _find_program(self) -> dict[str, Any] | None:
+        programs = (self.coordinator.data or {}).get("programs") or []
+        for prog in programs:
+            if not isinstance(prog, dict):
+                continue
+            if prog.get("zone") == self._zone and prog.get("hc") == self._hc:
+                return prog
+        return None
+
+    def _get_day_slots(
+        self, program: dict[str, Any], weekday_index: int
+    ) -> list[dict[str, Any]]:
+        days = program.get("days") or []
+        for day in days:
+            if not isinstance(day, dict):
+                continue
+            wd = _WEEKDAY_INDEX.get(str(day.get("weekday", "")).lower())
+            if wd == weekday_index:
+                return day.get("slots") or []
+        return []
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the currently active event."""
+        program = self._find_program()
+        if program is None:
+            return None
+
+        now = datetime.now()
+        today = now.date()
+        weekday_index = today.weekday()
+        slots = self._get_day_slots(program, weekday_index)
+
+        for slot in slots:
+            if not isinstance(slot, dict):
+                continue
+            start_h = slot.get("startHour", 0)
+            start_m = slot.get("startMinute", 0)
+            end_h = slot.get("endHour", 0)
+            end_m = slot.get("endMinute", 0)
+
+            start_dt = datetime.combine(today, datetime.min.time().replace(
+                hour=min(start_h, 23), minute=min(start_m, 59)
+            ))
+            if end_h >= 24:
+                end_dt = datetime.combine(today + timedelta(days=1), datetime.min.time())
+            else:
+                end_dt = datetime.combine(today, datetime.min.time().replace(
+                    hour=min(end_h, 23), minute=min(end_m, 59)
+                ))
+
+            if start_dt <= now < end_dt:
+                return self._make_event(slot, today)
+
+        return None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return events in the requested date range."""
+        program = self._find_program()
+        if program is None:
+            return []
+
+        events: list[CalendarEvent] = []
+        current = start_date.date() if isinstance(start_date, datetime) else start_date
+        end = end_date.date() if isinstance(end_date, datetime) else end_date
+
+        while current <= end:
+            weekday_index = current.weekday()
+            slots = self._get_day_slots(program, weekday_index)
+
+            for slot in slots:
+                if not isinstance(slot, dict):
+                    continue
+                ev = self._make_event(slot, current)
+                if ev is not None:
+                    events.append(ev)
+
+            current += timedelta(days=1)
+
+        return events
+
+    def _make_event(
+        self, slot: dict[str, Any], day: date
+    ) -> CalendarEvent | None:
+        start_h = slot.get("startHour", 0)
+        start_m = slot.get("startMinute", 0)
+        end_h = slot.get("endHour", 0)
+        end_m = slot.get("endMinute", 0)
+        temp_c = slot.get("temperatureC")
+
+        start_dt = datetime.combine(day, datetime.min.time().replace(
+            hour=min(start_h, 23), minute=min(start_m, 59)
+        ))
+        if end_h >= 24:
+            end_dt = datetime.combine(day + timedelta(days=1), datetime.min.time())
+        else:
+            end_dt = datetime.combine(day, datetime.min.time().replace(
+                hour=min(end_h, 23), minute=min(end_m, 59)
+            ))
+
+        if start_dt >= end_dt:
+            return None
+
+        if temp_c is not None:
+            summary = f"{self._hc_label} {temp_c}°C"
+        else:
+            summary = self._hc_label
+
+        return CalendarEvent(
+            summary=summary,
+            start=start_dt,
+            end=end_dt,
+        )

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1002,6 +1002,80 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {"boilerStatus": payload.get("boilerStatus")}
 
 
+QUERY_SCHEDULES = """
+query Schedules {
+  schedules {
+    programs {
+      zone
+      hc
+      config {
+        maxSlots
+        timeResolution
+        minDuration
+        hasTemperature
+        tempSlots
+        minTempC
+        maxTempC
+      }
+      slotsUsed
+      days {
+        weekday
+        slots {
+          startHour
+          startMinute
+          endHour
+          endMinute
+          temperatureC
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class HelianthusScheduleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator fetching B555 timer schedule data."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_schedule",
+            update_interval=timedelta(seconds=max(scan_interval, 300)),
+        )
+        self._client = client
+        self.schedule_supported = True
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        empty: dict[str, Any] = {"programs": []}
+        if not self.schedule_supported:
+            return empty
+
+        try:
+            payload = await self._client.execute(QUERY_SCHEDULES)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, ["schedules", "programs"]):
+                self.schedule_supported = False
+                return empty
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            return empty
+
+        schedules = payload.get("schedules")
+        if not isinstance(schedules, dict):
+            return empty
+
+        programs = schedules.get("programs")
+        if not isinstance(programs, list):
+            return empty
+
+        return {"programs": programs}
+
+
 def _parse_optional_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,211 @@
+"""Tests for Helianthus schedule calendar entities."""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, date, timedelta
+
+# Stub homeassistant modules before importing calendar.py
+ha = types.ModuleType("homeassistant")
+ha_core = types.ModuleType("homeassistant.core")
+ha_config_entries = types.ModuleType("homeassistant.config_entries")
+ha_helpers = types.ModuleType("homeassistant.helpers")
+ha_helpers_entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+ha_helpers_update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
+ha_helpers_device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+ha_components = types.ModuleType("homeassistant.components")
+ha_calendar = types.ModuleType("homeassistant.components.calendar")
+
+
+class _CalendarEntity:
+    pass
+
+
+class _CalendarEvent:
+    def __init__(self, *, summary: str, start, end, **kwargs):
+        self.summary = summary
+        self.start = start
+        self.end = end
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+class _ConfigEntry:
+    pass
+
+
+class _DeviceInfo:
+    def __init__(self, **kwargs):
+        self.identifiers = kwargs.get("identifiers")
+
+
+class _HomeAssistant:
+    pass
+
+
+ha_calendar.CalendarEntity = _CalendarEntity
+ha_calendar.CalendarEvent = _CalendarEvent
+ha_helpers_update_coordinator.CoordinatorEntity = _CoordinatorEntity
+ha_helpers_update_coordinator.DataUpdateCoordinator = type("DataUpdateCoordinator", (), {"__class_getitem__": classmethod(lambda cls, _: cls)})
+ha_helpers_update_coordinator.UpdateFailed = Exception
+ha_helpers_device_registry.DeviceInfo = _DeviceInfo
+ha_config_entries.ConfigEntry = _ConfigEntry
+ha_core.HomeAssistant = _HomeAssistant
+ha_helpers_entity_platform.AddEntitiesCallback = type(None)
+
+ha.core = ha_core
+ha.helpers = ha_helpers
+ha.config_entries = ha_config_entries
+ha.components = ha_components
+ha_helpers.update_coordinator = ha_helpers_update_coordinator
+ha_helpers.entity_platform = ha_helpers_entity_platform
+ha_helpers.device_registry = ha_helpers_device_registry
+ha_components.calendar = ha_calendar
+
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.core", ha_core)
+sys.modules.setdefault("homeassistant.config_entries", ha_config_entries)
+sys.modules.setdefault("homeassistant.helpers", ha_helpers)
+sys.modules.setdefault("homeassistant.helpers.update_coordinator", ha_helpers_update_coordinator)
+sys.modules.setdefault("homeassistant.helpers.entity_platform", ha_helpers_entity_platform)
+sys.modules.setdefault("homeassistant.helpers.device_registry", ha_helpers_device_registry)
+sys.modules.setdefault("homeassistant.components", ha_components)
+sys.modules.setdefault("homeassistant.components.calendar", ha_calendar)
+
+from custom_components.helianthus.calendar import HelianthusScheduleCalendar
+
+
+class _FakeCoordinator:
+    def __init__(self, data):
+        self.data = data
+
+
+def _make_program(zone=0, hc="heating", days=None, config=None):
+    return {
+        "zone": zone,
+        "hc": hc,
+        "config": config or {"maxSlots": 3, "hasTemperature": True},
+        "days": days or [],
+    }
+
+
+def _make_calendar(program, zone=0, hc="heating"):
+    coordinator = _FakeCoordinator({"programs": [program]})
+    return HelianthusScheduleCalendar(
+        coordinator=coordinator,
+        entry_id="test-entry",
+        zone=zone,
+        hc=hc,
+        target_device_id=("helianthus", "test-device"),
+        regulator_device_id=None,
+    )
+
+
+def test_unique_id_zone() -> None:
+    program = _make_program(zone=0, hc="heating")
+    cal = _make_calendar(program, zone=0, hc="heating")
+    assert cal._attr_unique_id == "test-entry-schedule-zone_0-heating"
+
+
+def test_unique_id_dhw() -> None:
+    program = _make_program(zone=255, hc="dhw")
+    cal = _make_calendar(program, zone=255, hc="dhw")
+    assert cal._attr_unique_id == "test-entry-schedule-dhw-dhw"
+
+
+def test_name_zone() -> None:
+    program = _make_program(zone=1, hc="cooling")
+    cal = _make_calendar(program, zone=1, hc="cooling")
+    assert cal._attr_name == "Zone 1 Cooling Schedule"
+
+
+def test_name_dhw() -> None:
+    program = _make_program(zone=255, hc="circulation")
+    cal = _make_calendar(program, zone=255, hc="circulation")
+    assert cal._attr_name == "Circulation Schedule"
+
+
+def test_event_returns_none_when_no_program() -> None:
+    coordinator = _FakeCoordinator({"programs": []})
+    cal = HelianthusScheduleCalendar(
+        coordinator=coordinator,
+        entry_id="test-entry",
+        zone=0,
+        hc="heating",
+        target_device_id=None,
+        regulator_device_id=None,
+    )
+    assert cal.event is None
+
+
+def test_make_event_with_temperature() -> None:
+    slot = {"startHour": 6, "startMinute": 0, "endHour": 22, "endMinute": 0, "temperatureC": 22.5}
+    program = _make_program(
+        zone=0,
+        hc="heating",
+        days=[{"weekday": "monday", "slots": [slot]}],
+    )
+    cal = _make_calendar(program)
+    today = date(2026, 3, 9)  # Monday
+
+    event = cal._make_event(slot, today)
+
+    assert event is not None
+    assert event.summary == "Heating 22.5°C"
+    assert event.start == datetime(2026, 3, 9, 6, 0)
+    assert event.end == datetime(2026, 3, 9, 22, 0)
+
+
+def test_make_event_24h_end() -> None:
+    slot = {"startHour": 0, "startMinute": 0, "endHour": 24, "endMinute": 0}
+    program = _make_program(zone=255, hc="dhw")
+    cal = _make_calendar(program, zone=255, hc="dhw")
+    today = date(2026, 3, 9)
+
+    event = cal._make_event(slot, today)
+
+    assert event is not None
+    assert event.summary == "DHW"
+    assert event.start == datetime(2026, 3, 9, 0, 0)
+    assert event.end == datetime(2026, 3, 10, 0, 0)
+
+
+def test_make_event_zero_duration_returns_none() -> None:
+    slot = {"startHour": 10, "startMinute": 0, "endHour": 10, "endMinute": 0}
+    program = _make_program()
+    cal = _make_calendar(program)
+
+    event = cal._make_event(slot, date(2026, 3, 9))
+
+    assert event is None
+
+
+def test_get_day_slots_matches_weekday() -> None:
+    slot = {"startHour": 6, "startMinute": 0, "endHour": 22, "endMinute": 0}
+    program = _make_program(
+        days=[
+            {"weekday": "monday", "slots": [slot]},
+            {"weekday": "tuesday", "slots": []},
+        ],
+    )
+    cal = _make_calendar(program)
+
+    monday_slots = cal._get_day_slots(program, 0)
+    tuesday_slots = cal._get_day_slots(program, 1)
+    wednesday_slots = cal._get_day_slots(program, 2)
+
+    assert len(monday_slots) == 1
+    assert len(tuesday_slots) == 0
+    assert len(wednesday_slots) == 0
+
+
+def test_device_info_not_none() -> None:
+    program = _make_program()
+    cal = _make_calendar(program)
+
+    info = cal.device_info
+    assert info is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -53,8 +53,10 @@ from custom_components.helianthus.coordinator import (
     HelianthusEnergyCoordinator,
     HelianthusFM5Coordinator,
     HelianthusRadioDeviceCoordinator,
+    HelianthusScheduleCoordinator,
     HelianthusSystemCoordinator,
     HelianthusStatusCoordinator,
+    QUERY_SCHEDULES,
 )
 from custom_components.helianthus.graphql import GraphQLClientError, GraphQLResponseError
 
@@ -611,3 +613,59 @@ def test_energy_query_falls_back_to_legacy_when_monthly_unsupported() -> None:
     assert second["energyTotals"]["gas"]["dhw"]["today"] == 6.0
     assert client.calls == [QUERY_ENERGY, QUERY_ENERGY_LEGACY, QUERY_ENERGY_LEGACY]
     assert coordinator._monthly_supported is False
+
+
+def _build_schedule_coordinator(client: _ScriptedClient) -> HelianthusScheduleCoordinator:
+    coordinator = object.__new__(HelianthusScheduleCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
+    coordinator.schedule_supported = True  # type: ignore[attr-defined]
+    return coordinator
+
+
+def test_schedule_coordinator_returns_programs() -> None:
+    payload = {
+        "schedules": {
+            "programs": [
+                {
+                    "zone": 0,
+                    "hc": "heating",
+                    "config": {"maxSlots": 12, "hasTemperature": True},
+                    "days": [
+                        {"weekday": "monday", "slots": [{"startHour": 6, "endHour": 22}]}
+                    ],
+                }
+            ]
+        }
+    }
+    client = _ScriptedClient([payload])
+    coordinator = _build_schedule_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert len(result["programs"]) == 1
+    assert result["programs"][0]["zone"] == 0
+    assert result["programs"][0]["hc"] == "heating"
+    assert client.calls == [QUERY_SCHEDULES]
+
+
+def test_schedule_coordinator_returns_empty_on_missing_field() -> None:
+    client = _ScriptedClient([
+        GraphQLResponseError(
+            [{"message": 'Cannot query field "schedules" on type "Query".'}]
+        ),
+    ])
+    coordinator = _build_schedule_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result == {"programs": []}
+    assert coordinator.schedule_supported is False
+
+
+def test_schedule_coordinator_returns_empty_on_null_schedules() -> None:
+    client = _ScriptedClient([{"schedules": None}])
+    coordinator = _build_schedule_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result == {"programs": []}


### PR DESCRIPTION
## Summary
- Add `HelianthusScheduleCoordinator` with `QUERY_SCHEDULES` GraphQL query
- Add `calendar.py` platform with `HelianthusScheduleCalendar` entities
- One calendar entity per (zone, HC) program: heating, cooling, DHW, circulation
- Events generated from weekly schedule slots with temperature setpoints
- Read-only — shows current active event and supports date range queries
- Calendar entities attach to zone/DHW parent devices

Fixes #151

## Test plan
- [x] All 136 tests pass (13 new: 3 coordinator + 10 calendar)
- [x] Calendar unique IDs, names, event generation, weekday matching tested
- [x] Coordinator handles null/missing schedules gracefully
- [x] Zero-duration slots filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)