### PR TITLE
Fix calendar events to use timezone-aware datetimes

### DIFF
--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .device_ids import zone_identifier, dhw_identifier
@@ -148,7 +149,7 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
         if program is None:
             return None
 
-        now = datetime.now()
+        now = dt_util.now()
         today = now.date()
         weekday_index = today.weekday()
         slots = self._get_day_slots(program, weekday_index)
@@ -156,23 +157,9 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
         for slot in slots:
             if not isinstance(slot, dict):
                 continue
-            start_h = slot.get("startHour", 0)
-            start_m = slot.get("startMinute", 0)
-            end_h = slot.get("endHour", 0)
-            end_m = slot.get("endMinute", 0)
-
-            start_dt = datetime.combine(today, datetime.min.time().replace(
-                hour=min(start_h, 23), minute=min(start_m, 59)
-            ))
-            if end_h >= 24:
-                end_dt = datetime.combine(today + timedelta(days=1), datetime.min.time())
-            else:
-                end_dt = datetime.combine(today, datetime.min.time().replace(
-                    hour=min(end_h, 23), minute=min(end_m, 59)
-                ))
-
-            if start_dt <= now < end_dt:
-                return self._make_event(slot, today)
+            ev = self._make_event(slot, today)
+            if ev is not None and ev.start <= now < ev.end:
+                return ev
 
         return None
 
@@ -215,15 +202,18 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
         end_m = slot.get("endMinute", 0)
         temp_c = slot.get("temperatureC")
 
+        tz = dt_util.DEFAULT_TIME_ZONE
         start_dt = datetime.combine(day, datetime.min.time().replace(
             hour=min(start_h, 23), minute=min(start_m, 59)
-        ))
+        ), tzinfo=tz)
         if end_h >= 24:
-            end_dt = datetime.combine(day + timedelta(days=1), datetime.min.time())
+            end_dt = datetime.combine(
+                day + timedelta(days=1), datetime.min.time(), tzinfo=tz
+            )
         else:
             end_dt = datetime.combine(day, datetime.min.time().replace(
                 hour=min(end_h, 23), minute=min(end_m, 59)
-            ))
+            ), tzinfo=tz)
 
         if start_dt >= end_dt:
             return None

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import types
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 
 # Stub homeassistant modules before importing calendar.py
 ha = types.ModuleType("homeassistant")
@@ -57,10 +57,17 @@ ha_config_entries.ConfigEntry = _ConfigEntry
 ha_core.HomeAssistant = _HomeAssistant
 ha_helpers_entity_platform.AddEntitiesCallback = type(None)
 
+ha_util = types.ModuleType("homeassistant.util")
+ha_util_dt = types.ModuleType("homeassistant.util.dt")
+ha_util_dt.DEFAULT_TIME_ZONE = timezone.utc
+ha_util_dt.now = lambda: datetime.now(timezone.utc)
+ha_util.dt = ha_util_dt
+
 ha.core = ha_core
 ha.helpers = ha_helpers
 ha.config_entries = ha_config_entries
 ha.components = ha_components
+ha.util = ha_util
 ha_helpers.update_coordinator = ha_helpers_update_coordinator
 ha_helpers.entity_platform = ha_helpers_entity_platform
 ha_helpers.device_registry = ha_helpers_device_registry
@@ -75,6 +82,8 @@ sys.modules.setdefault("homeassistant.helpers.entity_platform", ha_helpers_entit
 sys.modules.setdefault("homeassistant.helpers.device_registry", ha_helpers_device_registry)
 sys.modules.setdefault("homeassistant.components", ha_components)
 sys.modules.setdefault("homeassistant.components.calendar", ha_calendar)
+sys.modules.setdefault("homeassistant.util", ha_util)
+sys.modules.setdefault("homeassistant.util.dt", ha_util_dt)
 
 from custom_components.helianthus.calendar import HelianthusScheduleCalendar
 
@@ -156,8 +165,8 @@ def test_make_event_with_temperature() -> None:
 
     assert event is not None
     assert event.summary == "Heating 22.5°C"
-    assert event.start == datetime(2026, 3, 9, 6, 0)
-    assert event.end == datetime(2026, 3, 9, 22, 0)
+    assert event.start == datetime(2026, 3, 9, 6, 0, tzinfo=timezone.utc)
+    assert event.end == datetime(2026, 3, 9, 22, 0, tzinfo=timezone.utc)
 
 
 def test_make_event_24h_end() -> None:
@@ -170,8 +179,8 @@ def test_make_event_24h_end() -> None:
 
     assert event is not None
     assert event.summary == "DHW"
-    assert event.start == datetime(2026, 3, 9, 0, 0)
-    assert event.end == datetime(2026, 3, 10, 0, 0)
+    assert event.start == datetime(2026, 3, 9, 0, 0, tzinfo=timezone.utc)
+    assert event.end == datetime(2026, 3, 10, 0, 0, tzinfo=timezone.utc)
 
 
 def test_make_event_zero_duration_returns_none() -> None:


### PR DESCRIPTION
## Summary
- HA `CalendarEvent` validation requires timezone-aware datetimes
- `_make_event` now uses `dt_util.DEFAULT_TIME_ZONE` via `datetime.combine(..., tzinfo=tz)`
- `event` property uses `dt_util.now()` for timezone-aware current time
- Simplifies active-event check by reusing `_make_event` instead of duplicating datetime logic

Closes #153

## Test plan
- [x] All 136 tests pass locally
- [x] Calendar tests updated with `timezone.utc` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)