### PR TITLE
Quick veto preset activation and QV-aware temperature routing

### DIFF
--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -375,8 +375,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
         for field, key in [
             ("quick_veto", "quickVeto"),
-            ("quick_veto_setpoint_c", "quickVetoSetpointC"),
-            ("quick_veto_duration_h", "quickVetoDurationH"),
+            ("quick_veto_setpoint_c", "quickVetoSetpoint"),
+            ("quick_veto_duration_h", "quickVetoDuration"),
             ("quick_veto_expiry", "quickVetoExpiry"),
         ]:
             value = config.get(key)
@@ -446,7 +446,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         config = self._zone_config()
         temp = config.get("targetTempC")
         if temp is None:
-            temp = config.get("quickVetoSetpointC")
+            temp = config.get("quickVetoSetpoint")
         if temp is None:
             temp = 20.0
         temp = max(5.0, min(30.0, float(temp)))

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -192,8 +192,8 @@ query Semantic {
       associatedCircuit
       roomTemperatureZoneMapping
       quickVeto
-      quickVetoSetpointC
-      quickVetoDurationH
+      quickVetoSetpoint
+      quickVetoDuration
       quickVetoExpiry
     }
   }
@@ -287,7 +287,7 @@ query Semantic {
 }
 """
 
-_QV_FIELDS = ["quickVeto", "quickVetoSetpointC", "quickVetoDurationH", "quickVetoExpiry"]
+_QV_FIELDS = ["quickVeto", "quickVetoSetpoint", "quickVetoDuration", "quickVetoExpiry"]
 _SEMANTIC_RECOVERABLE_FIELDS = _QV_FIELDS + ["roomTemperatureZoneMapping"]
 
 QUERY_CIRCUITS = """

--- a/tests/test_climate_quickveto.py
+++ b/tests/test_climate_quickveto.py
@@ -156,9 +156,9 @@ def _make_entity(
         "quickVeto": qv_active,
     }
     if qv_setpoint is not None:
-        config["quickVetoSetpointC"] = qv_setpoint
+        config["quickVetoSetpoint"] = qv_setpoint
     if qv_duration is not None:
-        config["quickVetoDurationH"] = qv_duration
+        config["quickVetoDuration"] = qv_duration
     zone_data = {
         "zones": [
             {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -710,7 +710,7 @@ def _semantic_payload(**config_overrides: object) -> dict:
 
 def test_semantic_full_query_succeeds() -> None:
     payload = _semantic_payload(
-        quickVeto=False, quickVetoSetpointC=16.0, quickVetoDurationH=3.0
+        quickVeto=False, quickVetoSetpoint=16.0, quickVetoDuration=3.0
     )
     client = _ScriptedClient([payload])
     coordinator = _build_semantic_coordinator(client)


### PR DESCRIPTION
## Summary
- Add quick veto fields to `QUERY_SEMANTIC` with 3-level fallback cascade (full → no-QV → legacy) for backward compat
- Implement `quickveto` preset in `async_set_preset_mode`: writes current target temp to `0x0008` then default 3h duration to `0x0026`
- Route temperature writes during quickveto to veto register (`0x0008`) instead of normal setpoint registers
- Add quick veto fields to climate `extra_state_attributes`
- 14 new tests (4 coordinator cascade + 10 climate quickveto)

## Test plan
- [x] 150 tests pass locally
- [ ] CI green
- [ ] Deploy to RPi4 and verify quickveto activation via HA climate card
- [ ] Verify temperature adjustment during active quickveto
- [ ] Verify cancellation via schedule/manual preset switch

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)