### PR TITLE
fix: map B555 zone indices to semantic zone IDs in calendar entities

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -719,6 +719,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
     def cleanup_obsolete_devices(reason: str) -> None:
+        # Remove stale calendar entities with old zone_N unique_id format
+        # (pre-fix: B555 zone indices were used directly instead of semantic zone IDs).
+        _stale_schedule_re = re.compile(
+            rf"^{re.escape(entry.entry_id)}-schedule-zone_\d+-"
+        )
+        stale_removed = 0
+        for entity_entry in tuple(_entry_entities()):
+            uid = str(entity_entry.unique_id or "")
+            if _stale_schedule_re.match(uid):
+                entity_registry.async_remove(entity_entry.entity_id)
+                stale_removed += 1
+        if stale_removed:
+            _LOGGER.info(
+                "Helianthus cleanup removed %d stale schedule entities for entry %s (%s)",
+                stale_removed,
+                entry.entry_id,
+                reason,
+            )
+
         removed = 0
         for device_entry in tuple(dr.async_entries_for_config_entry(device_registry, entry.entry_id)):
             identifier_pairs = _iter_identifier_pairs(device_entry.identifiers)

--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
         if zone == 255:
             target_device_id = dhw_identifier(entry.entry_id)
         else:
-            zone_id = str(zone)
+            zone_id = f"zone-{zone + 1}"
             target_device_id = zone_parent_device_ids.get(
                 zone_id, zone_identifier(entry.entry_id, zone_id)
             )
@@ -106,8 +106,8 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
             self._attr_name = f"{hc_label} Schedule"
             zone_tag = "dhw"
         else:
-            self._attr_name = f"Zone {zone} {hc_label} Schedule"
-            zone_tag = f"zone_{zone}"
+            self._attr_name = f"Zone {zone + 1} {hc_label} Schedule"
+            zone_tag = f"zone-{zone + 1}"
 
         self._attr_unique_id = (
             f"{entry_id}-schedule-{zone_tag}-{hc}"

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -117,7 +117,7 @@ def _make_calendar(program, zone=0, hc="heating"):
 def test_unique_id_zone() -> None:
     program = _make_program(zone=0, hc="heating")
     cal = _make_calendar(program, zone=0, hc="heating")
-    assert cal._attr_unique_id == "test-entry-schedule-zone_0-heating"
+    assert cal._attr_unique_id == "test-entry-schedule-zone-1-heating"
 
 
 def test_unique_id_dhw() -> None:
@@ -129,7 +129,7 @@ def test_unique_id_dhw() -> None:
 def test_name_zone() -> None:
     program = _make_program(zone=1, hc="cooling")
     cal = _make_calendar(program, zone=1, hc="cooling")
-    assert cal._attr_name == "Zone 1 Cooling Schedule"
+    assert cal._attr_name == "Zone 2 Cooling Schedule"
 
 
 def test_name_dhw() -> None:


### PR DESCRIPTION
## Summary
- Fix B555 zone index → semantic zone ID mapping in calendar entity setup (`zone_id = f"zone-{zone + 1}"` instead of `str(zone)`)
- Fix display names (`Zone 1` / `Zone 2` instead of `Zone 0` / `Zone 1`)
- Fix unique_id zone tags (`zone-1` / `zone-2` instead of `zone_0` / `zone_1`)
- Add stale entity cleanup in `cleanup_obsolete_devices()` to remove calendar entities with old `zone_N` format unique_ids, allowing orphan devices to be garbage-collected

## Test plan
- [x] All 151 tests pass (`python3 -m pytest tests/ -v`)
- [x] Deployed to HA, core restarted
- [x] Both orphan "Unnamed device" entries removed automatically
- [x] "Zone 1 Heating Schedule" calendar on VRC720 device (Parter)
- [x] "Zone 2 Heating Schedule" calendar on VR92 device (Etaj)
- [x] 16 devices, 151 entities — clean

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)