### PR TITLE
feat: merge B524 function module into physical bus device (ADR-027)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -519,7 +519,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not isinstance(radio_devices_payload, list):
         radio_devices_payload = []
 
-    # ADR-001: Merge B524 function-module enrichment into physical bus devices.
+    # ADR-027: Merge B524 function-module enrichment into physical bus devices.
     # Group 0x0C entries whose deviceClassAddress matches a known bus address
     # are enrichment metadata for that bus device, not standalone devices.
     _B524_FUNCTION_MODULE_GROUP = 0x0C
@@ -561,7 +561,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not bus_key:
             bus_key = build_radio_bus_key(group, instance)
         known_radio_bus_keys.add(bus_key)
-        # ADR-001: skip HA device creation for merged B524 function module slots.
+        # ADR-027: skip HA device creation for merged B524 function module slots.
         if bus_key in b524_merge_targets:
             continue
         radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
@@ -725,7 +725,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return "temperatureC" in live_keys
         return False
 
-    # ADR-001: build set of merged B524 slot prefixes for entity cleanup.
+    # ADR-027: build set of merged B524 slot prefixes for entity cleanup.
     # bus_key format: "g0c-i01" -> unique_id slot format: "0c-01"
     def _bus_key_to_uid_slot(bk: str) -> str:
         return bk.replace("g", "").replace("-i", "-")
@@ -749,7 +749,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 unique_id,
             ):
                 remove_entry = True
-            # ADR-001: remove redundant sensor entities from merged B524 slots.
+            # ADR-027: remove redundant sensor entities from merged B524 slots.
             elif entity_entry.domain == "sensor" and any(
                 unique_id.startswith(prefix) for prefix in _b524_merged_uid_prefixes
             ):
@@ -811,7 +811,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if cylinder_index is not None and cylinder_index not in known_cylinder_indexes:
                     remove_device = True
                     break
-                # ADR-001: remove shadow radio device for merged B524 function modules.
+                # ADR-027: remove shadow radio device for merged B524 function modules.
                 radio_prefix = f"{entry.entry_id}-radio-"
                 if token.startswith(radio_prefix):
                     radio_bus_key = token[len(radio_prefix):]

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -277,7 +277,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             if slot is None or bus_key is None:
                 continue
             group, instance = slot
-            # ADR-001: re-parent to physical bus device for merged B524 slots.
+            # ADR-027: re-parent to physical bus device for merged B524 slots.
             merge_target = b524_merge_targets.get(bus_key)
             target_device_id = merge_target if merge_target is not None else radio_device_identifier(entry.entry_id, bus_key)
             entities.append(

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -600,6 +600,9 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             if slot is None or bus_key is None:
                 continue
             group, instance = slot
+            # ADR-027: skip all sensors for merged B524 function-module slots.
+            if bus_key in b524_merge_targets:
+                continue
             class_address = _parse_optional_int(radio.get("deviceClassAddress"))
             is_room = class_address in _RADIO_ROOM_CLASSES
             radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
@@ -654,9 +657,6 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     )
                 )
             elif group == 0x0C:
-                # ADR-001: suppress redundant sensors for merged B524 function modules.
-                if bus_key in b524_merge_targets:
-                    continue
                 for key, label in [
                     ("deviceClassAddress", "Device Class Address"),
                     ("hardwareIdentifier", "Hardware Identifier"),

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -341,7 +341,7 @@ def test_radio_zone_candidates_update_on_reassignment() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ADR-001: B524 function-module merge predicate tests
+# ADR-027: B524 function-module merge predicate tests
 # ---------------------------------------------------------------------------
 
 _VR71_BUS_DEVICE_ID = ("helianthus", "entry-1-bus-VR_71-26-5904-0100")
@@ -355,8 +355,8 @@ def _merge_payload(radio_devices: list[dict], merge_targets: dict[str, tuple[str
     return p
 
 
-def test_adr001_merged_group_0c_sensor_entities_suppressed() -> None:
-    """ADR-001 CE-positive: group 0x0C with matching bus device -> sensors suppressed."""
+def test_adr027_merged_group_0c_sensor_entities_suppressed() -> None:
+    """ADR-027 CE-positive: group 0x0C with matching bus device -> sensors suppressed."""
     radio_devices = [
         {
             "group": 0x0C,
@@ -384,8 +384,8 @@ def test_adr001_merged_group_0c_sensor_entities_suppressed() -> None:
     assert "entry-1-radio-0c-01-sensor-hardwareIdentifier" not in radio_sensor_uids
 
 
-def test_adr001_unmerged_group_0c_sensor_entities_created() -> None:
-    """ADR-001 CE-3: group 0x0C with NO matching bus device -> sensors created normally."""
+def test_adr027_unmerged_group_0c_sensor_entities_created() -> None:
+    """ADR-027 CE-3: group 0x0C with NO matching bus device -> sensors created normally."""
     radio_devices = [
         {
             "group": 0x0C,
@@ -412,8 +412,8 @@ def test_adr001_unmerged_group_0c_sensor_entities_created() -> None:
     assert "entry-1-radio-0c-02-sensor-hardwareIdentifier" in radio_sensor_uids
 
 
-def test_adr001_merged_binary_sensor_reparented_to_bus_device() -> None:
-    """ADR-001: Device Connected entity for merged group 0x0C -> parented to bus device."""
+def test_adr027_merged_binary_sensor_reparented_to_bus_device() -> None:
+    """ADR-027: Device Connected entity for merged group 0x0C -> parented to bus device."""
     radio_devices = [
         {
             "group": 0x0C,
@@ -443,8 +443,8 @@ def test_adr001_merged_binary_sensor_reparented_to_bus_device() -> None:
     assert entity._attr_name == "B524 Connected"
 
 
-def test_adr001_unmerged_binary_sensor_stays_on_radio_device() -> None:
-    """ADR-001 CE-1: group 0x09 -> binary sensor stays on radio device (no merge)."""
+def test_adr027_unmerged_binary_sensor_stays_on_radio_device() -> None:
+    """ADR-027 CE-1: group 0x09 -> binary sensor stays on radio device (no merge)."""
     radio_devices = [
         {
             "group": 0x09,
@@ -473,8 +473,8 @@ def test_adr001_unmerged_binary_sensor_stays_on_radio_device() -> None:
     assert entity._attr_name == "Device Connected"
 
 
-def test_adr001_idempotency_multiple_runs_same_result() -> None:
-    """ADR-001 A7: running setup twice produces identical entity sets."""
+def test_adr027_idempotency_multiple_runs_same_result() -> None:
+    """ADR-027 A7: running setup twice produces identical entity sets."""
     radio_devices = [
         {
             "group": 0x0C,


### PR DESCRIPTION
## Summary

- **Merge B524 group 0x0C enrichment** into the matched physical bus device instead of creating a shadow radio device
- Formal merge predicate: `group==0x0C AND classAddr!=None AND busDevice exists AND classAddr==busAddr`
- Device Connected entity re-parented as "B524 Connected" on FM5 Control Centre; redundant sensors (deviceClassAddress, hardwareIdentifier) suppressed
- Shadow device auto-removed by `cleanup_obsolete_devices()`
- VRC720 (group 0x09) and VR92 (group 0x0A) radio devices unaffected

Implements **ADR-027** (B524 function-module merge rule). ADR entry: Project-Helianthus/helianthus-docs-ebus.

## What changed

| File | Change |
|------|--------|
| `__init__.py` | Bus address→device ID map, merge predicate computation, shadow device/entity cleanup |
| `binary_sensor.py` | Re-parent Device Connected to bus device with "B524 Connected" label |
| `sensor.py` | Suppress redundant group 0x0C sensors when merged |
| `test_radio_device.py` | 5 new ADR-027 tests (merge, suppress, re-parent, isolation, idempotency) |

## Evidence

- **Before:** 18 devices, VR71/FM5 shadow device with Device Class Address + Device Connected
- **After:** 17 devices, FM5 Control Centre has B524 Connected entity, no shadow device
- 156/156 tests pass, live-validated on RPi4

## Test plan

- [x] ADR-027 merge predicate unit tests (5 tests)
- [x] VRC720/VR92 isolation — not merged (counterexample tests)
- [x] Idempotency — multiple runs produce same result
- [x] Live validation — 17 devices, B524 Connected on FM5 Control Centre
- [x] Full test suite — 156/156 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)