### PR TITLE
feat: comprehensive semantic icons for all entities (ADR-026 W2)

### DIFF
--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -322,6 +322,14 @@ class HelianthusScheduleBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = f"{target_name} {schedule_label}"
         unique_target = target_id or "dhw"
         self._attr_unique_id = f"{entry_id}-{target_kind}-{unique_target}-schedule-{schedule_key}"
+        _SCHEDULE_ICONS: dict[str, str] = {
+            "schedule": "mdi:calendar-clock",
+            "quickveto": "mdi:timer-alert-outline",
+            "away": "mdi:airplane",
+        }
+        schedule_icon = _SCHEDULE_ICONS.get(schedule_key)
+        if schedule_icon is not None:
+            self._attr_icon = schedule_icon
 
     def _target_payload(self) -> dict[str, Any]:
         if not self.coordinator.data:
@@ -390,6 +398,16 @@ class HelianthusBoilerStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._key = key
         self._attr_name = label
         self._attr_unique_id = f"{entry_id}-boiler-binary-{key}"
+        _BOILER_STATE_ICONS: dict[str, str] = {
+            "flameActive": "mdi:fire",
+            "gasValveActive": "mdi:gas-cylinder",
+            "centralHeatingPumpActive": "mdi:pump",
+            "externalPumpActive": "mdi:pump",
+            "circulationPumpActive": "mdi:pump",
+        }
+        boiler_icon = _BOILER_STATE_ICONS.get(key)
+        if boiler_icon is not None:
+            self._attr_icon = boiler_icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -483,6 +501,14 @@ class HelianthusSolarBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = label
         self._attr_unique_id = f"{entry_id}-solar-binary-{key}"
         self._attr_entity_registry_enabled_default = enabled_by_default
+        _SOLAR_ICONS: dict[str, str] = {
+            "pumpActive": "mdi:pump",
+            "solarEnabled": "mdi:solar-power",
+            "functionMode": "mdi:solar-panel",
+        }
+        solar_icon = _SOLAR_ICONS.get(key)
+        if solar_icon is not None:
+            self._attr_icon = solar_icon
 
     @property
     def available(self) -> bool:
@@ -572,6 +598,12 @@ class HelianthusSystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
             self._attr_device_class = device_class
         if entity_category is not None:
             self._attr_entity_category = entity_category
+        _SYSTEM_BINARY_ICONS: dict[str, str] = {
+            "adaptiveHeatingCurve": "mdi:chart-bell-curve-cumulative",
+        }
+        system_icon = _SYSTEM_BINARY_ICONS.get(key)
+        if system_icon is not None:
+            self._attr_icon = system_icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -596,6 +628,7 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
     """Remote-slot connected-state binary sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:radio-tower"
 
     def __init__(
         self,

--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -85,6 +85,7 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
     """Calendar entity representing a B555 timer schedule program."""
 
     _attr_has_entity_name = True
+    _attr_icon = "mdi:calendar-clock"
 
     def __init__(
         self,

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -60,6 +60,7 @@ class CircuitNumberField:
     maximum: float
     step: float
     unit: str | None = None
+    icon: str | None = None
 
 
 @dataclass(frozen=True)
@@ -72,6 +73,7 @@ class SystemNumberField:
     step: float
     unit: str | None = None
     cast_int: bool = False
+    icon: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +84,7 @@ class CylinderNumberField:
     maximum: float
     step: float
     unit: str | None = None
+    icon: str | None = None
 
 
 @dataclass(frozen=True)
@@ -92,10 +95,11 @@ class BoilerNumberField:
     maximum: float
     step: float
     unit: str | None = None
+    icon: str | None = None
 
 
 _CIRCUIT_NUMBER_FIELDS = [
-    CircuitNumberField("heatingCurve", "Heating Curve", 0.1, 4.0, 0.1),
+    CircuitNumberField("heatingCurve", "Heating Curve", 0.1, 4.0, 0.1, icon="mdi:chart-bell-curve-cumulative"),
     CircuitNumberField(
         "flowTempMaxC",
         "Flow Temperature Maximum",
@@ -103,6 +107,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         80.0,
         1.0,
         UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-chevron-up",
     ),
     CircuitNumberField(
         "flowTempMinC",
@@ -111,6 +116,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         30.0,
         1.0,
         UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-chevron-down",
     ),
     CircuitNumberField(
         "summerLimitC",
@@ -119,6 +125,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         30.0,
         1.0,
         UnitOfTemperature.CELSIUS,
+        icon="mdi:weather-sunny",
     ),
     CircuitNumberField(
         "frostProtC",
@@ -127,6 +134,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         10.0,
         1.0,
         UnitOfTemperature.CELSIUS,
+        icon="mdi:snowflake-thermometer",
     ),
 ]
 
@@ -139,6 +147,7 @@ _SYSTEM_NUMBER_FIELDS = [
         maximum=30.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer",
     ),
     SystemNumberField(
         mutation_field="dhwBivalencePointC",
@@ -148,6 +157,7 @@ _SYSTEM_NUMBER_FIELDS = [
         maximum=50.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer",
     ),
     SystemNumberField(
         mutation_field="hcEmergencyTempC",
@@ -157,6 +167,7 @@ _SYSTEM_NUMBER_FIELDS = [
         maximum=80.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-alert",
     ),
     SystemNumberField(
         mutation_field="hwcMaxFlowTempC",
@@ -166,6 +177,7 @@ _SYSTEM_NUMBER_FIELDS = [
         maximum=80.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-chevron-up",
     ),
     SystemNumberField(
         mutation_field="maxRoomHumidityPct",
@@ -176,6 +188,7 @@ _SYSTEM_NUMBER_FIELDS = [
         step=1.0,
         unit=PERCENTAGE,
         cast_int=True,
+        icon="mdi:water-percent",
     ),
 ]
 
@@ -187,6 +200,7 @@ _CYLINDER_NUMBER_FIELDS = [
         maximum=80.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-high",
     ),
     CylinderNumberField(
         key="chargeHysteresisC",
@@ -195,6 +209,7 @@ _CYLINDER_NUMBER_FIELDS = [
         maximum=30.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer",
     ),
     CylinderNumberField(
         key="chargeOffsetC",
@@ -203,6 +218,7 @@ _CYLINDER_NUMBER_FIELDS = [
         maximum=20.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer",
     ),
 ]
 
@@ -214,6 +230,7 @@ _BOILER_NUMBER_FIELDS = [
         maximum=80.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-chevron-up",
     ),
     BoilerNumberField(
         key="flowsetHwcMaxC",
@@ -222,6 +239,7 @@ _BOILER_NUMBER_FIELDS = [
         maximum=65.0,
         step=1.0,
         unit=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-chevron-up",
     ),
     BoilerNumberField(
         key="partloadHcKW",
@@ -230,6 +248,7 @@ _BOILER_NUMBER_FIELDS = [
         maximum=40.0,
         step=0.1,
         unit="kW",
+        icon="mdi:lightning-bolt",
     ),
     BoilerNumberField(
         key="partloadHwcKW",
@@ -238,6 +257,7 @@ _BOILER_NUMBER_FIELDS = [
         maximum=40.0,
         step=0.1,
         unit="kW",
+        icon="mdi:lightning-bolt",
     ),
 ]
 
@@ -359,6 +379,8 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_step = field.step
         if field.unit is not None:
             self._attr_native_unit_of_measurement = field.unit
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -436,6 +458,8 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_step = field.step
         if field.unit is not None:
             self._attr_native_unit_of_measurement = field.unit
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -535,6 +559,8 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_step = field.step
         if field.unit is not None:
             self._attr_native_unit_of_measurement = field.unit
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -617,6 +643,8 @@ class HelianthusCylinderConfigNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_step = field.step
         if field.unit is not None:
             self._attr_native_unit_of_measurement = field.unit
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     def _cylinder(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -84,6 +84,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_options = _OPTIONS
+    _attr_icon = "mdi:thermostat"
 
     def __init__(
         self,

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -30,6 +30,7 @@ from .energy import compute_total
 class InventoryField:
     key: str
     name: str
+    icon: str | None = None
 
 
 @dataclass(frozen=True)
@@ -61,16 +62,17 @@ class SystemSensorField:
     state_class: str | None = None
     entity_category: str | None = None
     cast_int: bool = False
+    icon: str | None = None
 
 
 STATUS_FIELDS = [
-    InventoryField("status", "Status"),
-    InventoryField("firmwareVersion", "Firmware Version"),
-    InventoryField("updatesAvailable", "Updates Available"),
+    InventoryField("status", "Status", icon="mdi:information-outline"),
+    InventoryField("firmwareVersion", "Firmware Version", icon="mdi:tag-text-outline"),
+    InventoryField("updatesAvailable", "Updates Available", icon="mdi:update"),
 ]
 
 DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
-    InventoryField("initiatorAddress", "eBUS Initiator Address")
+    InventoryField("initiatorAddress", "eBUS Initiator Address", icon="mdi:chip")
 ]
 
 ADAPTER_STATUS_FIELDS = STATUS_FIELDS
@@ -125,11 +127,13 @@ CIRCUIT_SENSOR_FIELDS = [
         native_unit=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:valve",
     ),
     CircuitSensorField(
         key="circuitState",
         label="State",
         include_circuit_attributes=True,
+        icon="mdi:information-outline",
     ),
     CircuitSensorField(
         key="humidity",
@@ -218,6 +222,7 @@ SYSTEM_SENSOR_FIELDS = [
         source="properties",
         entity_category=EntityCategory.DIAGNOSTIC,
         cast_int=True,
+        icon="mdi:sitemap-outline",
     ),
 ]
 
@@ -228,6 +233,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:gas-burner",
     },
     {
         "key": "fanSpeedRpm",
@@ -236,6 +242,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
         "cast_int": True,
+        "icon": "mdi:fan",
     },
     {
         "key": "ionisationVoltageUa",
@@ -244,6 +251,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
         "cast_int": True,
+        "icon": "mdi:flash-triangle-outline",
     },
     {
         "key": "storageLoadPumpPct",
@@ -251,6 +259,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:pump",
     },
     {
         "key": "diverterValvePositionPct",
@@ -258,6 +267,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:valve",
     },
 ]
 
@@ -333,6 +343,7 @@ CYLINDER_CONFIG_SENSOR_FIELDS = [
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:thermometer-high",
     },
     {
         "key": "chargeHysteresisC",
@@ -340,6 +351,7 @@ CYLINDER_CONFIG_SENSOR_FIELDS = [
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:thermometer",
     },
     {
         "key": "chargeOffsetC",
@@ -347,6 +359,7 @@ CYLINDER_CONFIG_SENSOR_FIELDS = [
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:thermometer",
     },
 ]
 
@@ -657,6 +670,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     )
                 )
             elif group == 0x0C:
+                _radio_metadata_icons = {
+                    "deviceClassAddress": "mdi:identifier",
+                    "hardwareIdentifier": "mdi:identifier",
+                    "remoteControlAddress": "mdi:remote",
+                    "zoneAssignment": "mdi:home-map-marker",
+                }
                 for key, label in [
                     ("deviceClassAddress", "Device Class Address"),
                     ("hardwareIdentifier", "Hardware Identifier"),
@@ -678,6 +697,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                             label=label,
                             entity_category=EntityCategory.DIAGNOSTIC,
                             cast_int=True,
+                            icon=_radio_metadata_icons.get(key),
                         )
                     )
 
@@ -698,13 +718,14 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             solar = fm5_payload.get("solar")
             if isinstance(solar, dict):
                 solar_device_id = solar_identifier(entry.entry_id)
-                for key, label, device_class, unit, state_class in [
+                for key, label, device_class, unit, state_class, icon in [
                     (
                         "collectorTemperatureC",
                         "Collector Temperature",
                         SensorDeviceClass.TEMPERATURE,
                         UnitOfTemperature.CELSIUS,
                         SensorStateClass.MEASUREMENT,
+                        None,
                     ),
                     (
                         "returnTemperatureC",
@@ -712,9 +733,10 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         SensorDeviceClass.TEMPERATURE,
                         UnitOfTemperature.CELSIUS,
                         SensorStateClass.MEASUREMENT,
+                        None,
                     ),
-                    ("currentYield", "Current Yield", None, None, None),
-                    ("pumpHours", "Pump Hours", _SENSOR_DEVICE_CLASS_DURATION, "h", _SENSOR_STATE_CLASS_TOTAL_INCREASING),
+                    ("currentYield", "Current Yield", None, None, None, "mdi:solar-power"),
+                    ("pumpHours", "Pump Hours", _SENSOR_DEVICE_CLASS_DURATION, "h", _SENSOR_STATE_CLASS_TOTAL_INCREASING, None),
                 ]:
                     sensors.append(
                         HelianthusSolarSensor(
@@ -728,6 +750,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                             device_class=device_class,
                             native_unit=unit,
                             state_class=state_class,
+                            icon=icon,
                         )
                     )
 
@@ -848,6 +871,7 @@ class HelianthusBusAddressSensor(CoordinatorEntity, SensorEntity):
     """eBUS address sensor for a physical bus device."""
 
     entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
 
     def __init__(
         self,
@@ -889,6 +913,8 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         self._identifier = identifier or (DOMAIN, f"unknown-{target_name.lower()}")
         self._attr_name = f"{target_name} {field.name}"
         self._attr_unique_id = f"{self._identifier[1]}-{field.key}"
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -958,6 +984,8 @@ class HelianthusBoilerStateSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = field["state_class"]
         if field.get("entity_category") is not None:
             self._attr_entity_category = field["entity_category"]
+        if field.get("icon") is not None:
+            self._attr_icon = field["icon"]
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1158,6 +1186,8 @@ class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = field.state_class
         if field.entity_category is not None:
             self._attr_entity_category = field.entity_category
+        if field.icon is not None:
+            self._attr_icon = field.icon
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1208,6 +1238,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
         state_class: str | None = None,
         entity_category: str | None = None,
         cast_int: bool = False,
+        icon: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
@@ -1227,6 +1258,8 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = state_class
         if entity_category is not None:
             self._attr_entity_category = entity_category
+        if icon is not None:
+            self._attr_icon = icon
         self._attr_entity_registry_enabled_default = self._device_value_present()
 
     def _device(self) -> dict[str, Any] | None:
@@ -1260,6 +1293,24 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
         )
 
     @property
+    def icon(self) -> str | None:
+        """Dynamic icon for signal quality (ADR-026); static for others."""
+        if self._key == "receptionStrength":
+            value = self.native_value
+            if value is None:
+                return "mdi:signal-cellular-outline"
+            try:
+                strength = int(value)
+            except (TypeError, ValueError):
+                return "mdi:signal-cellular-outline"
+            if strength < 33:
+                return "mdi:signal-cellular-1"
+            if strength < 67:
+                return "mdi:signal-cellular-2"
+            return "mdi:signal-cellular-3"
+        return self._attr_icon
+
+    @property
     def native_value(self) -> Any:
         device = self._device()
         if not isinstance(device, dict):
@@ -1281,6 +1332,7 @@ class HelianthusFM5ModeSensor(CoordinatorEntity, SensorEntity):
     """FM5 semantic mode marker."""
 
     entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
 
     def __init__(
         self,
@@ -1323,6 +1375,7 @@ class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
         label: str,
         device_class: str | None,
         native_unit: str | None,
+        icon: str | None = None,
         state_class: str | None,
     ) -> None:
         super().__init__(coordinator)
@@ -1338,6 +1391,8 @@ class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_unit_of_measurement = native_unit
         if state_class is not None:
             self._attr_state_class = state_class
+        if icon is not None:
+            self._attr_icon = icon
         self._attr_entity_registry_enabled_default = self._solar_value_present()
 
     @property
@@ -1467,6 +1522,8 @@ class HelianthusCylinderConfigSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = field["state_class"]
         if field.get("entity_category") is not None:
             self._attr_entity_category = field["entity_category"]
+        if field.get("icon") is not None:
+            self._attr_icon = field["icon"]
         self._attr_entity_registry_enabled_default = self._cylinder().get(field["key"]) is not None
 
     def _cylinder(self) -> dict[str, Any]:
@@ -1514,6 +1571,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:valve"
 
     def __init__(
         self,
@@ -1572,6 +1630,7 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
     entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:heat-wave"
 
     def __init__(
         self,
@@ -1643,6 +1702,7 @@ class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
     """DHW charging/status sensor."""
 
     entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:water-boiler"
 
     def __init__(
         self,

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -68,6 +68,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
     """Writable switch for circuit cooling mode."""
 
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:snowflake"
 
     def __init__(
         self,
@@ -162,6 +163,7 @@ class HelianthusSolarSwitch(CoordinatorEntity, SwitchEntity):
     """Read-only interpreted solar config switch."""
 
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:solar-power"
 
     def __init__(
         self,

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     """DHW water heater entity."""
 
+    _attr_icon = "mdi:water-boiler"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
         WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE

--- a/tests/test_entity_icon_gate.py
+++ b/tests/test_entity_icon_gate.py
@@ -25,6 +25,8 @@ def _ensure_homeassistant_stubs() -> None:
         const_module.EntityCategory = _EntityCategory
     if not hasattr(const_module, "PERCENTAGE"):
         const_module.PERCENTAGE = "%"
+    if not hasattr(const_module, "ATTR_TEMPERATURE"):
+        const_module.ATTR_TEMPERATURE = "temperature"
     if not hasattr(const_module, "UnitOfEnergy"):
         class _UnitOfEnergy:
             KILO_WATT_HOUR = "kWh"
@@ -97,6 +99,140 @@ def _ensure_homeassistant_stubs() -> None:
 
         fan_module.FanEntityFeature = _FanEntityFeature
 
+    # Binary sensor stubs
+    binary_sensor_module = sys.modules.setdefault(
+        "homeassistant.components.binary_sensor",
+        types.ModuleType("homeassistant.components.binary_sensor"),
+    )
+    if not hasattr(binary_sensor_module, "BinarySensorEntity"):
+        class _BinarySensorEntity:
+            pass
+
+        binary_sensor_module.BinarySensorEntity = _BinarySensorEntity
+    if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
+        class _BinarySensorDeviceClass:
+            RUNNING = "running"
+            PROBLEM = "problem"
+            OPENING = "opening"
+            CONNECTIVITY = "connectivity"
+
+        binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
+
+    # Number stubs
+    number_module = sys.modules.setdefault(
+        "homeassistant.components.number",
+        types.ModuleType("homeassistant.components.number"),
+    )
+    if not hasattr(number_module, "NumberEntity"):
+        class _NumberEntity:
+            pass
+
+        number_module.NumberEntity = _NumberEntity
+
+    # Select stubs
+    select_module = sys.modules.setdefault(
+        "homeassistant.components.select",
+        types.ModuleType("homeassistant.components.select"),
+    )
+    if not hasattr(select_module, "SelectEntity"):
+        class _SelectEntity:
+            pass
+
+        select_module.SelectEntity = _SelectEntity
+
+    # Switch stubs
+    switch_module = sys.modules.setdefault(
+        "homeassistant.components.switch",
+        types.ModuleType("homeassistant.components.switch"),
+    )
+    if not hasattr(switch_module, "SwitchEntity"):
+        class _SwitchEntity:
+            pass
+
+        switch_module.SwitchEntity = _SwitchEntity
+
+    # Calendar stubs
+    calendar_module = sys.modules.setdefault(
+        "homeassistant.components.calendar",
+        types.ModuleType("homeassistant.components.calendar"),
+    )
+    if not hasattr(calendar_module, "CalendarEntity"):
+        class _CalendarEntity:
+            pass
+
+        calendar_module.CalendarEntity = _CalendarEntity
+    if not hasattr(calendar_module, "CalendarEvent"):
+        class _CalendarEvent:
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        calendar_module.CalendarEvent = _CalendarEvent
+
+    # Water heater stubs
+    water_heater_module = sys.modules.setdefault(
+        "homeassistant.components.water_heater",
+        types.ModuleType("homeassistant.components.water_heater"),
+    )
+    if not hasattr(water_heater_module, "WaterHeaterEntity"):
+        class _WaterHeaterEntity:
+            pass
+
+        water_heater_module.WaterHeaterEntity = _WaterHeaterEntity
+    if not hasattr(water_heater_module, "WaterHeaterEntityFeature"):
+        class _WaterHeaterEntityFeature(IntFlag):
+            TARGET_TEMPERATURE = 1
+            OPERATION_MODE = 2
+
+        water_heater_module.WaterHeaterEntityFeature = _WaterHeaterEntityFeature
+
+    # Config entries stubs
+    config_entries_module = sys.modules.setdefault(
+        "homeassistant.config_entries",
+        types.ModuleType("homeassistant.config_entries"),
+    )
+    if not hasattr(config_entries_module, "ConfigEntry"):
+        class _ConfigEntry:
+            pass
+
+        config_entries_module.ConfigEntry = _ConfigEntry
+
+    # Core stubs
+    core_module = sys.modules.setdefault(
+        "homeassistant.core",
+        types.ModuleType("homeassistant.core"),
+    )
+    if not hasattr(core_module, "HomeAssistant"):
+        class _HomeAssistant:
+            pass
+
+        core_module.HomeAssistant = _HomeAssistant
+
+    # Entity platform stubs
+    entity_platform_module = sys.modules.setdefault(
+        "homeassistant.helpers.entity_platform",
+        types.ModuleType("homeassistant.helpers.entity_platform"),
+    )
+    if not hasattr(entity_platform_module, "AddEntitiesCallback"):
+        entity_platform_module.AddEntitiesCallback = None
+
+    # Util stubs
+    util_module = sys.modules.setdefault(
+        "homeassistant.util",
+        types.ModuleType("homeassistant.util"),
+    )
+    dt_module = sys.modules.setdefault(
+        "homeassistant.util.dt",
+        types.ModuleType("homeassistant.util.dt"),
+    )
+    setattr(util_module, "dt", dt_module)
+    if not hasattr(dt_module, "DEFAULT_TIME_ZONE"):
+        import datetime as _dt
+        dt_module.DEFAULT_TIME_ZONE = _dt.timezone.utc
+    if not hasattr(dt_module, "now"):
+        import datetime as _dt
+        dt_module.now = _dt.datetime.now
+
     exceptions_module = sys.modules.setdefault(
         "homeassistant.exceptions",
         types.ModuleType("homeassistant.exceptions"),
@@ -156,7 +292,18 @@ from custom_components.helianthus.valve import (
 )
 from custom_components.helianthus.sensor import (
     BOILER_DIAGNOSTICS_SENSOR_FIELDS,
+    BOILER_STATE_SENSOR_FIELDS,
     CIRCUIT_SENSOR_FIELDS,
+    CYLINDER_CONFIG_SENSOR_FIELDS,
+    SYSTEM_SENSOR_FIELDS,
+    STATUS_FIELDS,
+    DAEMON_STATUS_FIELDS,
+    HelianthusBusAddressSensor,
+    HelianthusDemandSensor,
+    HelianthusDHWStatusSensor,
+    HelianthusFM5ModeSensor,
+    HelianthusRadioSensor,
+    HelianthusZoneValvePositionSensor,
 )
 from custom_components.helianthus.fan import (
     HelianthusBoilerBurnerFan,
@@ -164,6 +311,26 @@ from custom_components.helianthus.fan import (
     HelianthusCircuitPumpFan,
     HelianthusSolarPumpFan,
 )
+from custom_components.helianthus.binary_sensor import (
+    HelianthusScheduleBinarySensor,
+    HelianthusBoilerStateBinarySensor,
+    HelianthusSolarBinarySensor,
+    HelianthusSystemBinarySensor,
+    HelianthusRadioConnectedBinarySensor,
+)
+from custom_components.helianthus.number import (
+    _CIRCUIT_NUMBER_FIELDS,
+    _SYSTEM_NUMBER_FIELDS,
+    _CYLINDER_NUMBER_FIELDS,
+    _BOILER_NUMBER_FIELDS,
+)
+from custom_components.helianthus.select import HelianthusCircuitRoomTempControlSelect
+from custom_components.helianthus.switch import (
+    HelianthusCircuitCoolingEnabledSwitch,
+    HelianthusSolarSwitch,
+)
+from custom_components.helianthus.calendar import HelianthusScheduleCalendar
+from custom_components.helianthus.water_heater import HelianthusDhwWaterHeater
 
 
 class _FakeCoordinator:
@@ -285,7 +452,7 @@ def test_boiler_diagnostics_duration_fields_have_no_icon_override() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Circuit sensor counter icon tests (ADR-026)
+# Circuit sensor icon tests (ADR-026 Wave 2)
 # ---------------------------------------------------------------------------
 
 
@@ -304,11 +471,257 @@ def test_circuit_counter_fields_have_icon() -> None:
 
 
 def test_circuit_counter_icon_is_mdi_counter() -> None:
+    """Counter fields (TOTAL_INCREASING, no device_class) must use mdi:counter."""
+    total_increasing = getattr(
+        sys.modules["homeassistant.components.sensor"].SensorStateClass,
+        "TOTAL_INCREASING",
+        "total_increasing",
+    )
     for field in CIRCUIT_SENSOR_FIELDS:
-        if field.icon is not None:
+        if field.device_class is None and field.state_class == total_increasing:
             assert field.icon == "mdi:counter", (
-                f"CIRCUIT_SENSOR_FIELDS[{field.key}] icon must be mdi:counter"
+                f"CIRCUIT_SENSOR_FIELDS[{field.key}] counter icon must be mdi:counter"
             )
+
+
+def test_circuit_mixer_position_has_valve_icon() -> None:
+    for field in CIRCUIT_SENSOR_FIELDS:
+        if field.key == "mixerPositionPct":
+            assert field.icon == "mdi:valve"
+
+
+def test_circuit_state_has_info_icon() -> None:
+    for field in CIRCUIT_SENSOR_FIELDS:
+        if field.key == "circuitState":
+            assert field.icon == "mdi:information-outline"
+
+
+# ---------------------------------------------------------------------------
+# Boiler state sensor icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_boiler_state_fields_have_icons() -> None:
+    """Every BOILER_STATE field must have an icon."""
+    for field in BOILER_STATE_SENSOR_FIELDS:
+        assert field.get("icon") is not None, (
+            f"BOILER_STATE[{field['key']}] missing icon (ADR-026)"
+        )
+
+
+def test_boiler_state_specific_icons() -> None:
+    expected = {
+        "modulationPct": "mdi:gas-burner",
+        "fanSpeedRpm": "mdi:fan",
+        "ionisationVoltageUa": "mdi:flash-triangle-outline",
+        "storageLoadPumpPct": "mdi:pump",
+        "diverterValvePositionPct": "mdi:valve",
+    }
+    for field in BOILER_STATE_SENSOR_FIELDS:
+        key = field["key"]
+        if key in expected:
+            assert field["icon"] == expected[key], (
+                f"BOILER_STATE[{key}] icon should be {expected[key]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Status/inventory sensor icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_status_fields_have_icons() -> None:
+    for field in STATUS_FIELDS:
+        assert field.icon is not None, (
+            f"STATUS_FIELDS[{field.key}] missing icon (ADR-026)"
+        )
+
+
+def test_daemon_status_fields_have_icons() -> None:
+    for field in DAEMON_STATUS_FIELDS:
+        assert field.icon is not None, (
+            f"DAEMON_STATUS_FIELDS[{field.key}] missing icon (ADR-026)"
+        )
+
+
+def test_status_specific_icons() -> None:
+    expected = {
+        "status": "mdi:information-outline",
+        "firmwareVersion": "mdi:tag-text-outline",
+        "updatesAvailable": "mdi:update",
+        "initiatorAddress": "mdi:chip",
+    }
+    for field in DAEMON_STATUS_FIELDS:
+        if field.key in expected:
+            assert field.icon == expected[field.key], (
+                f"STATUS[{field.key}] icon should be {expected[field.key]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# System sensor icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_system_scheme_has_icon() -> None:
+    for field in SYSTEM_SENSOR_FIELDS:
+        if field.key == "systemScheme":
+            assert field.icon == "mdi:sitemap-outline"
+
+
+# ---------------------------------------------------------------------------
+# Cylinder config sensor icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_cylinder_config_fields_have_icons() -> None:
+    for field in CYLINDER_CONFIG_SENSOR_FIELDS:
+        assert field.get("icon") is not None, (
+            f"CYLINDER_CONFIG[{field['key']}] missing icon (ADR-026)"
+        )
+
+
+def test_cylinder_config_specific_icons() -> None:
+    expected = {
+        "maxSetpointC": "mdi:thermometer-high",
+        "chargeHysteresisC": "mdi:thermometer",
+        "chargeOffsetC": "mdi:thermometer",
+    }
+    for field in CYLINDER_CONFIG_SENSOR_FIELDS:
+        key = field["key"]
+        if key in expected:
+            assert field["icon"] == expected[key]
+
+
+# ---------------------------------------------------------------------------
+# Sensor class-level icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_bus_address_sensor_icon() -> None:
+    assert HelianthusBusAddressSensor._attr_icon == "mdi:chip"
+
+
+def test_fm5_mode_sensor_icon() -> None:
+    assert HelianthusFM5ModeSensor._attr_icon == "mdi:chip"
+
+
+def test_zone_valve_position_sensor_icon() -> None:
+    assert HelianthusZoneValvePositionSensor._attr_icon == "mdi:valve"
+
+
+def test_demand_sensor_icon() -> None:
+    assert HelianthusDemandSensor._attr_icon == "mdi:heat-wave"
+
+
+def test_dhw_status_sensor_icon() -> None:
+    assert HelianthusDHWStatusSensor._attr_icon == "mdi:water-boiler"
+
+
+# ---------------------------------------------------------------------------
+# Radio sensor dynamic signal quality icon (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_radio_sensor_has_dynamic_icon_property() -> None:
+    """HelianthusRadioSensor must expose icon as a property for signal quality."""
+    assert isinstance(HelianthusRadioSensor.__dict__.get("icon"), property)
+
+
+def test_radio_signal_icon_low() -> None:
+    coord = _FakeCoordinator({
+        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 15}],
+    })
+    sensor = HelianthusRadioSensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        radio_device_id=("r", "x"),
+        radio_name="Test Radio",
+        group=0x0C,
+        instance=1,
+        key="receptionStrength",
+        label="Signal Quality",
+        icon=None,
+    )
+    assert sensor.icon == "mdi:signal-cellular-1"
+
+
+def test_radio_signal_icon_medium() -> None:
+    coord = _FakeCoordinator({
+        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 50}],
+    })
+    sensor = HelianthusRadioSensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        radio_device_id=("r", "x"),
+        radio_name="Test Radio",
+        group=0x0C,
+        instance=1,
+        key="receptionStrength",
+        label="Signal Quality",
+        icon=None,
+    )
+    assert sensor.icon == "mdi:signal-cellular-2"
+
+
+def test_radio_signal_icon_high() -> None:
+    coord = _FakeCoordinator({
+        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 90}],
+    })
+    sensor = HelianthusRadioSensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        radio_device_id=("r", "x"),
+        radio_name="Test Radio",
+        group=0x0C,
+        instance=1,
+        key="receptionStrength",
+        label="Signal Quality",
+        icon=None,
+    )
+    assert sensor.icon == "mdi:signal-cellular-3"
+
+
+def test_radio_signal_icon_none() -> None:
+    coord = _FakeCoordinator({
+        "radioDevices": [{"group": 0x0C, "instance": 1}],
+    })
+    sensor = HelianthusRadioSensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        radio_device_id=("r", "x"),
+        radio_name="Test Radio",
+        group=0x0C,
+        instance=1,
+        key="receptionStrength",
+        label="Signal Quality",
+        icon=None,
+    )
+    assert sensor.icon == "mdi:signal-cellular-outline"
+
+
+def test_radio_metadata_sensor_static_icon() -> None:
+    """Non-signal radio sensors should use their static icon."""
+    coord = _FakeCoordinator({
+        "radioDevices": [{"group": 0x0C, "instance": 1, "hardwareIdentifier": "ABC123"}],
+    })
+    sensor = HelianthusRadioSensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        radio_device_id=("r", "x"),
+        radio_name="Test Radio",
+        group=0x0C,
+        instance=1,
+        key="hardwareIdentifier",
+        label="Hardware ID",
+        icon="mdi:identifier",
+    )
+    assert sensor.icon == "mdi:identifier"
 
 
 # ---------------------------------------------------------------------------
@@ -324,3 +737,264 @@ def test_fan_pump_icons() -> None:
     assert HelianthusBoilerPumpFan._attr_icon == "mdi:pump"
     assert HelianthusCircuitPumpFan._attr_icon == "mdi:pump"
     assert HelianthusSolarPumpFan._attr_icon == "mdi:pump"
+
+
+# ---------------------------------------------------------------------------
+# Binary sensor icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_binary_sensor_icons() -> None:
+    """Schedule binary sensors must have correct icons by schedule_key."""
+    expected = {
+        "schedule": "mdi:calendar-clock",
+        "quickveto": "mdi:timer-alert-outline",
+        "away": "mdi:airplane",
+    }
+    coord = _FakeCoordinator({"zones": [{"id": "zone-1", "name": "Living", "config": {"preset": "auto"}}]})
+    for sched_key, expected_icon in expected.items():
+        sensor = HelianthusScheduleBinarySensor(
+            coordinator=coord,
+            entry_id="test",
+            manufacturer="V",
+            target_kind="zone",
+            target_id="zone-1",
+            target_name="Living",
+            target_device_id=("d", "x"),
+            schedule_key=sched_key,
+            schedule_label=f"{sched_key} Label",
+        )
+        assert sensor._attr_icon == expected_icon, (
+            f"Schedule[{sched_key}] icon should be {expected_icon}"
+        )
+
+
+def test_boiler_state_binary_sensor_icons() -> None:
+    """Boiler binary sensors must have correct icons by key."""
+    expected = {
+        "flameActive": "mdi:fire",
+        "gasValveActive": "mdi:gas-cylinder",
+        "centralHeatingPumpActive": "mdi:pump",
+        "externalPumpActive": "mdi:pump",
+        "circulationPumpActive": "mdi:pump",
+    }
+    coord = _FakeCoordinator({"boilerStatus": {"state": {}}})
+    for key, expected_icon in expected.items():
+        sensor = HelianthusBoilerStateBinarySensor(
+            coordinator=coord,
+            entry_id="test",
+            manufacturer="V",
+            boiler_device_id=("b", "x"),
+            key=key,
+            label=f"{key} Label",
+        )
+        assert sensor._attr_icon == expected_icon, (
+            f"BoilerBinary[{key}] icon should be {expected_icon}"
+        )
+
+
+def test_solar_binary_sensor_icons() -> None:
+    """Solar binary sensors must have correct icons by key."""
+    expected = {
+        "pumpActive": "mdi:pump",
+        "solarEnabled": "mdi:solar-power",
+        "functionMode": "mdi:solar-panel",
+    }
+    coord = _FakeCoordinator({"fm5SemanticMode": "INTERPRETED", "solar": {}})
+    for key, expected_icon in expected.items():
+        sensor = HelianthusSolarBinarySensor(
+            coordinator=coord,
+            entry_id="test",
+            manufacturer="V",
+            solar_device_id=("s", "x"),
+            parent_device_id=None,
+            key=key,
+            label=f"{key} Label",
+            enabled_by_default=True,
+        )
+        assert sensor._attr_icon == expected_icon, (
+            f"SolarBinary[{key}] icon should be {expected_icon}"
+        )
+
+
+def test_system_binary_adaptive_heating_curve_icon() -> None:
+    coord = _FakeCoordinator({"config": {"adaptiveHeatingCurve": True}})
+    sensor = HelianthusSystemBinarySensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        regulator_device_id=("r", "x"),
+        source="config",
+        key="adaptiveHeatingCurve",
+        label="Adaptive Heating Curve",
+        device_class=None,
+        entity_category="diagnostic",
+    )
+    assert sensor._attr_icon == "mdi:chart-bell-curve-cumulative"
+
+
+def test_system_binary_maintenance_due_no_icon_override() -> None:
+    """maintenanceDue has PROBLEM device_class — should NOT override icon."""
+    coord = _FakeCoordinator({"state": {"maintenanceDue": False}})
+    sensor = HelianthusSystemBinarySensor(
+        coordinator=coord,
+        entry_id="test",
+        manufacturer="V",
+        regulator_device_id=("r", "x"),
+        source="state",
+        key="maintenanceDue",
+        label="Maintenance Due",
+        device_class="problem",
+        entity_category="diagnostic",
+    )
+    assert not hasattr(sensor, "_attr_icon") or sensor._attr_icon is None
+
+
+def test_radio_connected_binary_sensor_icon() -> None:
+    assert HelianthusRadioConnectedBinarySensor._attr_icon == "mdi:radio-tower"
+
+
+# ---------------------------------------------------------------------------
+# Number field icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_number_fields_all_have_icons() -> None:
+    for field in _CIRCUIT_NUMBER_FIELDS:
+        assert field.icon is not None, (
+            f"CircuitNumber[{field.key}] missing icon (ADR-026)"
+        )
+
+
+def test_circuit_number_specific_icons() -> None:
+    expected = {
+        "heatingCurve": "mdi:chart-bell-curve-cumulative",
+        "flowTempMaxC": "mdi:thermometer-chevron-up",
+        "flowTempMinC": "mdi:thermometer-chevron-down",
+        "summerLimitC": "mdi:weather-sunny",
+        "frostProtC": "mdi:snowflake-thermometer",
+    }
+    for field in _CIRCUIT_NUMBER_FIELDS:
+        if field.key in expected:
+            assert field.icon == expected[field.key], (
+                f"CircuitNumber[{field.key}] icon should be {expected[field.key]}"
+            )
+
+
+def test_system_number_fields_all_have_icons() -> None:
+    for field in _SYSTEM_NUMBER_FIELDS:
+        assert field.icon is not None, (
+            f"SystemNumber[{field.mutation_field}] missing icon (ADR-026)"
+        )
+
+
+def test_system_number_specific_icons() -> None:
+    expected = {
+        "hcBivalencePointC": "mdi:thermometer",
+        "dhwBivalencePointC": "mdi:thermometer",
+        "hcEmergencyTempC": "mdi:thermometer-alert",
+        "hwcMaxFlowTempC": "mdi:thermometer-chevron-up",
+        "maxRoomHumidityPct": "mdi:water-percent",
+    }
+    for field in _SYSTEM_NUMBER_FIELDS:
+        if field.mutation_field in expected:
+            assert field.icon == expected[field.mutation_field], (
+                f"SystemNumber[{field.mutation_field}] icon should be {expected[field.mutation_field]}"
+            )
+
+
+def test_cylinder_number_fields_all_have_icons() -> None:
+    for field in _CYLINDER_NUMBER_FIELDS:
+        assert field.icon is not None, (
+            f"CylinderNumber[{field.key}] missing icon (ADR-026)"
+        )
+
+
+def test_boiler_number_fields_all_have_icons() -> None:
+    for field in _BOILER_NUMBER_FIELDS:
+        assert field.icon is not None, (
+            f"BoilerNumber[{field.key}] missing icon (ADR-026)"
+        )
+
+
+def test_boiler_number_specific_icons() -> None:
+    expected = {
+        "flowsetHcMaxC": "mdi:thermometer-chevron-up",
+        "flowsetHwcMaxC": "mdi:thermometer-chevron-up",
+        "partloadHcKW": "mdi:lightning-bolt",
+        "partloadHwcKW": "mdi:lightning-bolt",
+    }
+    for field in _BOILER_NUMBER_FIELDS:
+        if field.key in expected:
+            assert field.icon == expected[field.key], (
+                f"BoilerNumber[{field.key}] icon should be {expected[field.key]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Select, Switch, Calendar, Water Heater icon tests (ADR-026 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+def test_select_room_temp_control_icon() -> None:
+    assert HelianthusCircuitRoomTempControlSelect._attr_icon == "mdi:thermostat"
+
+
+def test_switch_cooling_enabled_icon() -> None:
+    assert HelianthusCircuitCoolingEnabledSwitch._attr_icon == "mdi:snowflake"
+
+
+def test_switch_solar_icon() -> None:
+    assert HelianthusSolarSwitch._attr_icon == "mdi:solar-power"
+
+
+def test_calendar_schedule_icon() -> None:
+    assert HelianthusScheduleCalendar._attr_icon == "mdi:calendar-clock"
+
+
+def test_water_heater_icon() -> None:
+    assert HelianthusDhwWaterHeater._attr_icon == "mdi:water-boiler"
+
+
+# ---------------------------------------------------------------------------
+# Global policy: all icons must start with "mdi:" (ADR-026)
+# ---------------------------------------------------------------------------
+
+
+def test_all_icons_are_mdi_prefixed() -> None:
+    """Every icon string in any field definition must start with 'mdi:'."""
+    all_icons: list[tuple[str, str]] = []
+
+    for field in BOILER_DIAGNOSTICS_SENSOR_FIELDS:
+        if field.get("icon"):
+            all_icons.append((f"BOILER_DIAG[{field['key']}]", field["icon"]))
+    for field in BOILER_STATE_SENSOR_FIELDS:
+        if field.get("icon"):
+            all_icons.append((f"BOILER_STATE[{field['key']}]", field["icon"]))
+    for field in CYLINDER_CONFIG_SENSOR_FIELDS:
+        if field.get("icon"):
+            all_icons.append((f"CYLINDER[{field['key']}]", field["icon"]))
+    for field in CIRCUIT_SENSOR_FIELDS:
+        if field.icon:
+            all_icons.append((f"CIRCUIT[{field.key}]", field.icon))
+    for field in STATUS_FIELDS:
+        if field.icon:
+            all_icons.append((f"STATUS[{field.key}]", field.icon))
+    for field in SYSTEM_SENSOR_FIELDS:
+        if field.icon:
+            all_icons.append((f"SYSTEM[{field.key}]", field.icon))
+    for field in _CIRCUIT_NUMBER_FIELDS:
+        if field.icon:
+            all_icons.append((f"CIRCUIT_NUM[{field.key}]", field.icon))
+    for field in _SYSTEM_NUMBER_FIELDS:
+        if field.icon:
+            all_icons.append((f"SYSTEM_NUM[{field.mutation_field}]", field.icon))
+    for field in _CYLINDER_NUMBER_FIELDS:
+        if field.icon:
+            all_icons.append((f"CYL_NUM[{field.key}]", field.icon))
+    for field in _BOILER_NUMBER_FIELDS:
+        if field.icon:
+            all_icons.append((f"BOILER_NUM[{field.key}]", field.icon))
+
+    for label, icon in all_icons:
+        assert icon.startswith("mdi:"), f"{label} icon '{icon}' must start with 'mdi:'"


### PR DESCRIPTION
## Summary
- Assigns semantically correct MDI icons to all ~65 entities that previously had no icon (Wave 1 only covered 9)
- Adds icons across all 10 platforms: sensor, binary_sensor, number, select, switch, calendar, water_heater (fan/valve/climate already done)
- Implements dynamic signal quality icon (`mdi:signal-cellular-1/2/3`) with strength-based thresholds
- Expands CI icon gate from 14 to 54 tests covering every icon assignment

### Icon highlights
| Platform | Examples |
|----------|----------|
| sensor | `mdi:gas-burner` (burner modulation), `mdi:update` (updates available), `mdi:heat-wave` (demand), `mdi:water-boiler` (DHW status) |
| binary_sensor | `mdi:calendar-clock` (schedule), `mdi:airplane` (away), `mdi:timer-alert-outline` (quick veto), `mdi:fire` (flame), `mdi:pump` (pumps) |
| number | `mdi:chart-bell-curve-cumulative` (heating curve), `mdi:snowflake-thermometer` (frost protection), `mdi:weather-sunny` (summer limit) |
| select/switch | `mdi:thermostat` (room temp control), `mdi:snowflake` (cooling), `mdi:solar-power` (solar) |
| calendar | `mdi:calendar-clock` (schedule calendar) |
| water_heater | `mdi:water-boiler` (DHW) |

### Dynamic icons
- **Signal quality**: `mdi:signal-cellular-1` (<33%), `mdi:signal-cellular-2` (33-66%), `mdi:signal-cellular-3` (≥67%)
- **Valve position**: `mdi:valve-closed` (0%), `mdi:valve` (1-99%), `mdi:valve-open` (100%) — from Wave 1

## Test plan
- [x] `pytest` — 210 tests pass (54 icon gate tests)
- [x] `./scripts/ci_local.sh` — full CI green
- [ ] Live deployment to HA — verify icons render correctly on dashboard
- [ ] Verify signal quality dynamic icon thresholds via MCP snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)