### PR TITLE
fix: radio sensor icon AttributeError on None icon

### DIFF
--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -1258,8 +1258,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = state_class
         if entity_category is not None:
             self._attr_entity_category = entity_category
-        if icon is not None:
-            self._attr_icon = icon
+        self._attr_icon = icon
         self._attr_entity_registry_enabled_default = self._device_value_present()
 
     def _device(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: 'HelianthusRadioSensor' object has no attribute '_attr_icon'` on radio sensors with `icon=None`
- The dynamic `icon` property falls through to `return self._attr_icon` but `_attr_icon` was only set conditionally when `icon is not None`
- Fix: always set `self._attr_icon = icon` (can be None, which is fine for HA)

## Test plan
- [x] 54 icon gate tests pass
- [x] Deployed to live HA — no errors in logs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)