### PR TITLE
Add adapter diagnostic sensors and device enrichment

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -333,6 +333,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
     from .graphql import GraphQLClient, build_graphql_url
     from .coordinator import (
+        HelianthusAdapterInfoCoordinator,
         HelianthusBoilerCoordinator,
         HelianthusCircuitCoordinator,
         HelianthusCoordinator,
@@ -446,6 +447,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     system_coordinator = HelianthusSystemCoordinator(hass, client, scan_interval)
     boiler_coordinator = HelianthusBoilerCoordinator(hass, client, scan_interval)
     schedule_coordinator = HelianthusScheduleCoordinator(hass, client, scan_interval)
+    adapter_info_coordinator = HelianthusAdapterInfoCoordinator(hass, client, scan_interval)
     await device_coordinator.async_config_entry_first_refresh()
     await status_coordinator.async_config_entry_first_refresh()
     await semantic_coordinator.async_config_entry_first_refresh()
@@ -456,6 +458,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await system_coordinator.async_config_entry_first_refresh()
     await boiler_coordinator.async_config_entry_first_refresh()
     await schedule_coordinator.async_config_entry_first_refresh()
+    await adapter_info_coordinator.async_config_entry_first_refresh()
+
+    adapter_hw = adapter_info_coordinator.data
+    if isinstance(adapter_hw, dict) and adapter_hw.get("firmwareVersion"):
+        hw_id = adapter_hw.get("hardwareID") or None
+        device_registry.async_update_device(
+            adapter_device_entry.id,
+            sw_version=adapter_hw["firmwareVersion"],
+            hw_version=hw_id,
+            serial_number=hw_id,
+        )
 
     devices = device_coordinator.data or []
     reload_scheduled = False
@@ -1259,6 +1272,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "system_coordinator": system_coordinator,
         "boiler_coordinator": boiler_coordinator,
         "schedule_coordinator": schedule_coordinator,
+        "adapter_info_coordinator": adapter_info_coordinator,
         "graphql_client": client,
         "subscription_task": subscription_task,
         "unsub_listeners": unsub_listeners,

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1343,3 +1343,88 @@ def _normalize_energy_totals_payload(payload: Any) -> dict[str, Any] | None:
             if "today" not in series or "yearly" not in series:
                 return None
     return totals
+
+
+QUERY_ADAPTER_HARDWARE_INFO = """
+query AdapterHardwareInfo {
+  adapterHardwareInfo {
+    firmwareVersion
+    firmwareChecksum
+    bootloaderVersion
+    bootloaderChecksum
+    hardwareID
+    hardwareConfig
+    features
+    jumpers
+    jumperFlags
+    isWifi
+    isEthernet
+    temperatureC
+    supplyVoltageMv
+    busVoltageMaxDv
+    busVoltageMinDv
+    resetCause
+    resetCauseCode
+    restartCount
+    wifiRssiDbm
+    lastIdentityQuery
+    lastTelemetryQuery
+    versionResponseLen
+    infoSupported
+  }
+}
+"""
+
+QUERY_ADAPTER_HARDWARE_INFO_MINIMAL = """
+query AdapterHardwareInfo {
+  adapterHardwareInfo {
+    firmwareVersion
+    isWifi
+    isEthernet
+    infoSupported
+    versionResponseLen
+  }
+}
+"""
+
+
+class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
+    """Coordinator fetching adapter hardware telemetry via GraphQL."""
+
+    def __init__(self, hass, client: GraphQLClient, scan_interval: int) -> None:
+        super().__init__(
+            hass,
+            logger=logging.getLogger(__name__),
+            name="helianthus_adapter_info",
+            update_interval=timedelta(seconds=max(scan_interval, 60)),
+        )
+        self._client = client
+        self._use_minimal = False
+
+    async def _async_update_data(self) -> dict[str, Any] | None:
+        query = QUERY_ADAPTER_HARDWARE_INFO_MINIMAL if self._use_minimal else QUERY_ADAPTER_HARDWARE_INFO
+        try:
+            payload = await self._client.execute(query)
+        except GraphQLResponseError as exc:
+            if _is_missing_field_error(exc.errors, ["adapterHardwareInfo"]):
+                self._use_minimal = True
+                return None
+            if not self._use_minimal:
+                self._use_minimal = True
+                try:
+                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
+                except (GraphQLClientError, GraphQLResponseError):
+                    return None
+            else:
+                raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+        if not isinstance(payload, dict):
+            return None
+
+        info = payload.get("adapterHardwareInfo")
+        if not isinstance(info, dict):
+            return None
+
+        return info

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -865,6 +865,82 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             ]
         )
 
+    adapter_info_coordinator = data.get("adapter_info_coordinator")
+    adapter_device_id = data.get("adapter_device_id")
+    if adapter_info_coordinator and adapter_device_id:
+        adapter_hw = adapter_info_coordinator.data
+        is_wifi = isinstance(adapter_hw, dict) and adapter_hw.get("isWifi") is True
+        has_reset = isinstance(adapter_hw, dict) and adapter_hw.get("resetCause") is not None
+        sensors.append(
+            HelianthusAdapterInfoSensor(
+                adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                key="temperatureC", label="Adapter Temperature",
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit=UnitOfTemperature.CELSIUS,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:thermometer",
+            )
+        )
+        sensors.append(
+            HelianthusAdapterInfoSensor(
+                adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                key="supplyVoltageMv", label="Adapter Supply Voltage",
+                device_class=SensorDeviceClass.VOLTAGE,
+                native_unit="mV",
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:flash",
+            )
+        )
+        sensors.append(
+            HelianthusAdapterInfoSensor(
+                adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                key="busVoltageMaxDv", label="eBUS Voltage Max",
+                device_class=SensorDeviceClass.VOLTAGE,
+                native_unit="V",
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:sine-wave",
+                scale=0.1,
+            )
+        )
+        sensors.append(
+            HelianthusAdapterInfoSensor(
+                adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                key="busVoltageMinDv", label="eBUS Voltage Min",
+                device_class=SensorDeviceClass.VOLTAGE,
+                native_unit="V",
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:sine-wave",
+                scale=0.1,
+            )
+        )
+        sensors.append(
+            HelianthusAdapterInfoSensor(
+                adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                key="restartCount", label="Adapter Restart Count",
+                state_class=_SENSOR_STATE_CLASS_TOTAL_INCREASING,
+                icon="mdi:counter",
+            )
+        )
+        if has_reset:
+            sensors.append(
+                HelianthusAdapterInfoSensor(
+                    adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                    key="resetCause", label="Adapter Reset Cause",
+                    icon="mdi:alert-circle-outline",
+                )
+            )
+        if is_wifi:
+            sensors.append(
+                HelianthusAdapterInfoSensor(
+                    adapter_info_coordinator, entry.entry_id, adapter_device_id,
+                    key="wifiRssiDbm", label="Adapter WiFi Signal",
+                    device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                    native_unit="dBm",
+                    state_class=SensorStateClass.MEASUREMENT,
+                    icon="mdi:wifi",
+                )
+            )
+
     async_add_entities(sensors)
 
 
@@ -1798,3 +1874,57 @@ class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
         yearly = series.get("yearly") if isinstance(series.get("yearly"), list) else None
         today = series.get("today")
         return compute_total(yearly, today)
+
+
+class HelianthusAdapterInfoSensor(CoordinatorEntity, SensorEntity):
+    """Adapter hardware telemetry diagnostic sensor."""
+
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        adapter_device_id: tuple[str, str],
+        *,
+        key: str,
+        label: str,
+        device_class: str | None = None,
+        native_unit: str | None = None,
+        state_class: str | None = None,
+        icon: str | None = None,
+        scale: float | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._adapter_device_id = adapter_device_id
+        self._key = key
+        self._scale = scale
+        self._attr_name = label
+        self._attr_unique_id = f"{entry_id}-adapter-hw-{key}"
+        if device_class is not None:
+            self._attr_device_class = device_class
+        if native_unit is not None:
+            self._attr_native_unit_of_measurement = native_unit
+        if state_class is not None:
+            self._attr_state_class = state_class
+        if icon is not None:
+            self._attr_icon = icon
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={self._adapter_device_id})
+
+    @property
+    def native_value(self) -> Any:
+        info = self.coordinator.data
+        if not isinstance(info, dict):
+            return None
+        value = info.get(self._key)
+        if value is None:
+            return None
+        if self._scale is not None:
+            try:
+                return round(float(value) * self._scale, 1)
+            except (TypeError, ValueError):
+                return None
+        return value


### PR DESCRIPTION
## Summary
- `HelianthusAdapterInfoCoordinator` with GraphQL query and schema fallback (60s interval)
- 5-7 diagnostic sensors: temperature, supply voltage, bus voltage max/min, restart count
- Version-gated: WiFi RSSI (only if isWifi), reset cause (only if present)
- Adapter device enriched with `sw_version` and `hw_version` from adapter info

## Test plan
- [x] Python syntax check passes
- [x] 217 existing tests pass
- [ ] Live verification with adapter connected

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)