### PR TITLE
Fix HA observability robustness under sparse gateway payloads

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1399,24 +1399,22 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
             update_interval=timedelta(seconds=max(scan_interval, 60)),
         )
         self._client = client
-        self._use_minimal = False
+        self._hardware_info_supported: bool | None = None
 
     async def _async_update_data(self) -> dict[str, Any] | None:
-        query = QUERY_ADAPTER_HARDWARE_INFO_MINIMAL if self._use_minimal else QUERY_ADAPTER_HARDWARE_INFO
+        if self._hardware_info_supported is False:
+            return None
+
         try:
-            payload = await self._client.execute(query)
+            payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO)
         except GraphQLResponseError as exc:
             if _is_missing_field_error(exc.errors, ["adapterHardwareInfo"]):
-                self._use_minimal = True
-                try:
-                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
-                except (GraphQLClientError, GraphQLResponseError) as fallback_exc:
-                    raise UpdateFailed(str(fallback_exc)) from fallback_exc
-            else:
-                try:
-                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
-                except (GraphQLClientError, GraphQLResponseError):
-                    raise UpdateFailed(str(exc)) from exc
+                self._hardware_info_supported = False
+                return None
+            try:
+                payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
+            except (GraphQLClientError, GraphQLResponseError):
+                return None
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1408,15 +1408,15 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         except GraphQLResponseError as exc:
             if _is_missing_field_error(exc.errors, ["adapterHardwareInfo"]):
                 self._use_minimal = True
-                return None
-            if not self._use_minimal:
-                self._use_minimal = True
+                try:
+                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
+                except (GraphQLClientError, GraphQLResponseError) as fallback_exc:
+                    raise UpdateFailed(str(fallback_exc)) from fallback_exc
+            else:
                 try:
                     payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
                 except (GraphQLClientError, GraphQLResponseError):
-                    return None
-            else:
-                raise UpdateFailed(str(exc)) from exc
+                    raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -115,11 +115,39 @@ def _merge_dicts(current: dict[str, Any] | None, update: dict[str, Any] | None) 
 
     for key, value in update.items():
         existing = merged.get(key)
+        if value is None and key in merged:
+            continue
         if isinstance(existing, dict) and isinstance(value, dict):
             merged[key] = _merge_dicts(existing, value)
             continue
         merged[key] = value
     return merged
+
+
+def _merge_zone_update(
+    current_zones: list[Any],
+    zone_update: dict[str, Any],
+) -> list[Any]:
+    zone_id = zone_update.get("id")
+    if zone_id is None:
+        return list(current_zones)
+
+    merged_zones: list[Any] = []
+    merged_existing = False
+    for zone in current_zones:
+        if not isinstance(zone, dict):
+            merged_zones.append(zone)
+            continue
+        if zone.get("id") != zone_id:
+            merged_zones.append(zone)
+            continue
+        merged_zones.append(_merge_dicts(zone, zone_update))
+        merged_existing = True
+
+    if not merged_existing:
+        merged_zones.append(zone_update)
+
+    return merged_zones
 
 
 async def start_subscriptions(
@@ -219,12 +247,14 @@ async def _handle_message(
             zone = {}
         if semantic_coordinator and isinstance(semantic_coordinator.data, dict):
             current = semantic_coordinator.data
-            zones = list(current.get("zones", []) or [])
-            zone_id = zone.get("id")
-            if zone_id:
-                zones = [z for z in zones if z.get("id") != zone_id]
-                zones.append(zone)
-            semantic_coordinator.async_set_updated_data({"zones": zones, "dhw": current.get("dhw")})
+            zones = current.get("zones", [])
+            if isinstance(zones, list):
+                semantic_coordinator.async_set_updated_data(
+                    {
+                        "zones": _merge_zone_update(zones, zone),
+                        "dhw": current.get("dhw"),
+                    }
+                )
 
     if "dhwUpdate" in data:
         dhw = data.get("dhwUpdate")
@@ -232,7 +262,13 @@ async def _handle_message(
             dhw is None or isinstance(dhw, dict)
         ):
             current = semantic_coordinator.data
-            semantic_coordinator.async_set_updated_data({"zones": current.get("zones", []), "dhw": dhw})
+            zones = current.get("zones", [])
+            semantic_coordinator.async_set_updated_data(
+                {
+                    "zones": zones if isinstance(zones, list) else [],
+                    "dhw": dhw if dhw is None or isinstance(dhw, dict) else current.get("dhw"),
+                }
+            )
 
     if "energyUpdate" in data and energy_coordinator:
         energy = data.get("energyUpdate")

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -108,6 +108,20 @@ def _to_ws_url(url: str) -> str:
     return urlunparse(parsed._replace(scheme=scheme, path=path))
 
 
+def _merge_dicts(current: dict[str, Any] | None, update: dict[str, Any] | None) -> dict[str, Any]:
+    merged: dict[str, Any] = dict(current or {})
+    if not isinstance(update, dict):
+        return merged
+
+    for key, value in update.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_dicts(existing, value)
+            continue
+        merged[key] = value
+    return merged
+
+
 async def start_subscriptions(
     session: aiohttp.ClientSession,
     url: str,
@@ -192,14 +206,18 @@ async def _handle_message(
         return
     if message.get("type") != "next":
         return
-    payload = message.get("payload", {})
-    data = payload.get("data", {})
+    payload = message.get("payload")
+    if not isinstance(payload, dict):
+        return
+    data = payload.get("data")
     if not isinstance(data, dict):
         return
 
     if "zoneUpdate" in data:
-        zone = data.get("zoneUpdate") or {}
-        if semantic_coordinator and semantic_coordinator.data is not None:
+        zone = data.get("zoneUpdate")
+        if not isinstance(zone, dict):
+            zone = {}
+        if semantic_coordinator and isinstance(semantic_coordinator.data, dict):
             current = semantic_coordinator.data
             zones = list(current.get("zones", []) or [])
             zone_id = zone.get("id")
@@ -210,17 +228,22 @@ async def _handle_message(
 
     if "dhwUpdate" in data:
         dhw = data.get("dhwUpdate")
-        if semantic_coordinator and semantic_coordinator.data is not None:
+        if semantic_coordinator and isinstance(semantic_coordinator.data, dict) and (
+            dhw is None or isinstance(dhw, dict)
+        ):
             current = semantic_coordinator.data
             semantic_coordinator.async_set_updated_data({"zones": current.get("zones", []), "dhw": dhw})
 
     if "energyUpdate" in data and energy_coordinator:
         energy = data.get("energyUpdate")
-        energy_coordinator.async_set_updated_data({"energyTotals": energy})
+        if isinstance(energy, dict):
+            energy_coordinator.async_set_updated_data({"energyTotals": energy})
 
     if "boilerStatusUpdate" in data and boiler_coordinator:
         boiler = data.get("boilerStatusUpdate")
-        boiler_coordinator.async_set_updated_data({"boilerStatus": boiler})
+        if isinstance(boiler, dict):
+            current = boiler_coordinator.data if isinstance(boiler_coordinator.data, dict) else {}
+            boiler_coordinator.async_set_updated_data(_merge_dicts(current, {"boilerStatus": boiler}))
 
     if "radioDevicesUpdate" in data and radio_coordinator:
         radio_devices = data.get("radioDevicesUpdate")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,6 +32,8 @@ sys.modules.setdefault("homeassistant.helpers", helpers_module)
 sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_coordinator_module)
 
 from custom_components.helianthus.coordinator import (
+    QUERY_ADAPTER_HARDWARE_INFO,
+    QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
     QUERY_BOILER,
     QUERY_CIRCUITS,
     QUERY_ENERGY,
@@ -54,6 +56,7 @@ from custom_components.helianthus.coordinator import (
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
     HelianthusCoordinator,
+    HelianthusAdapterInfoCoordinator,
     HelianthusEnergyCoordinator,
     HelianthusFM5Coordinator,
     HelianthusRadioDeviceCoordinator,
@@ -88,6 +91,13 @@ def _build_coordinator(client: _ScriptedClient) -> HelianthusCoordinator:
 def _build_status_coordinator(client: _ScriptedClient) -> HelianthusStatusCoordinator:
     coordinator = object.__new__(HelianthusStatusCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
+    return coordinator
+
+
+def _build_adapter_info_coordinator(client: _ScriptedClient) -> HelianthusAdapterInfoCoordinator:
+    coordinator = object.__new__(HelianthusAdapterInfoCoordinator)
+    coordinator._client = client  # type: ignore[attr-defined]
+    coordinator._use_minimal = False  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -310,6 +320,62 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     assert data["daemon"]["status"] == "running"
     assert "initiatorAddress" not in data["daemon"]
     assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]
+
+
+def test_adapter_info_query_missing_field_downgrades_to_minimal_queries() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
+            ),
+            {"adapterHardwareInfo": {"firmwareVersion": "1.2.3", "infoSupported": True}},
+            {"adapterHardwareInfo": {"firmwareVersion": "1.2.4", "infoSupported": True}},
+        ]
+    )
+    coordinator = _build_adapter_info_coordinator(client)
+
+    first = asyncio.run(coordinator._async_update_data())
+    second = asyncio.run(coordinator._async_update_data())
+
+    assert first["firmwareVersion"] == "1.2.3"
+    assert second["firmwareVersion"] == "1.2.4"
+    assert coordinator._use_minimal is True  # type: ignore[attr-defined]
+    assert client.calls == [
+        QUERY_ADAPTER_HARDWARE_INFO,
+        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
+        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
+    ]
+
+
+def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError([{"message": 'boom on "adapterStatus"'}]),
+            {"adapterHardwareInfo": {"firmwareVersion": "2.0.0", "infoSupported": True}},
+            {
+                "adapterHardwareInfo": {
+                    "firmwareVersion": "2.0.1",
+                    "infoSupported": True,
+                    "temperatureC": 31.5,
+                }
+            },
+        ]
+    )
+    coordinator = _build_adapter_info_coordinator(client)
+
+    first = asyncio.run(coordinator._async_update_data())
+    second = asyncio.run(coordinator._async_update_data())
+
+    assert first["firmwareVersion"] == "2.0.0"
+    assert "temperatureC" not in first
+    assert second["firmwareVersion"] == "2.0.1"
+    assert second["temperatureC"] == 31.5
+    assert coordinator._use_minimal is False  # type: ignore[attr-defined]
+    assert client.calls == [
+        QUERY_ADAPTER_HARDWARE_INFO,
+        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
+        QUERY_ADAPTER_HARDWARE_INFO,
+    ]
 
 
 def test_boiler_query_returns_status_payload() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -97,7 +97,7 @@ def _build_status_coordinator(client: _ScriptedClient) -> HelianthusStatusCoordi
 def _build_adapter_info_coordinator(client: _ScriptedClient) -> HelianthusAdapterInfoCoordinator:
     coordinator = object.__new__(HelianthusAdapterInfoCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
-    coordinator._use_minimal = False  # type: ignore[attr-defined]
+    coordinator._hardware_info_supported = None  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -322,29 +322,21 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]
 
 
-def test_adapter_info_query_missing_field_downgrades_to_minimal_queries() -> None:
+def test_adapter_info_query_missing_root_field_stays_non_fatal() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
                 [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
             ),
-            {"adapterHardwareInfo": {"firmwareVersion": "1.2.3", "infoSupported": True}},
-            {"adapterHardwareInfo": {"firmwareVersion": "1.2.4", "infoSupported": True}},
         ]
     )
     coordinator = _build_adapter_info_coordinator(client)
 
     first = asyncio.run(coordinator._async_update_data())
-    second = asyncio.run(coordinator._async_update_data())
 
-    assert first["firmwareVersion"] == "1.2.3"
-    assert second["firmwareVersion"] == "1.2.4"
-    assert coordinator._use_minimal is True  # type: ignore[attr-defined]
-    assert client.calls == [
-        QUERY_ADAPTER_HARDWARE_INFO,
-        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
-        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
-    ]
+    assert first is None
+    assert coordinator._hardware_info_supported is False  # type: ignore[attr-defined]
+    assert client.calls == [QUERY_ADAPTER_HARDWARE_INFO]
 
 
 def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
@@ -370,7 +362,7 @@ def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
     assert "temperatureC" not in first
     assert second["firmwareVersion"] == "2.0.1"
     assert second["temperatureC"] == 31.5
-    assert coordinator._use_minimal is False  # type: ignore[attr-defined]
+    assert coordinator._hardware_info_supported is None  # type: ignore[attr-defined]
     assert client.calls == [
         QUERY_ADAPTER_HARDWARE_INFO,
         QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -303,6 +303,79 @@ def test_subscription_dispatches_radio_updates_to_radio_coordinator() -> None:
     assert fake.seen[0]["group"] == 0x09
 
 
+def test_subscription_ignores_null_frames_without_crashing() -> None:
+    class _FakeBoilerCoordinator:
+        def __init__(self) -> None:
+            self.data = {
+                "boilerStatus": {
+                    "state": {"flowTemperatureC": 60.0, "centralHeatingPumpActive": False},
+                    "diagnostics": {"heatingStatusRaw": 1},
+                }
+            }
+
+        def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+            self.data = payload
+
+    boiler = _FakeBoilerCoordinator()
+
+    asyncio.run(
+        subscriptions._handle_message(
+            {"type": "next", "payload": None},
+            semantic_coordinator=None,
+            energy_coordinator=None,
+            boiler_coordinator=boiler,
+            radio_coordinator=None,
+        )
+    )
+
+    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 60.0
+    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
+
+
+def test_subscription_merges_partial_boiler_updates_non_destructively() -> None:
+    class _FakeBoilerCoordinator:
+        def __init__(self) -> None:
+            self.data = {
+                "boilerStatus": {
+                    "state": {
+                        "flowTemperatureC": 60.0,
+                        "returnTemperatureC": 41.5,
+                        "centralHeatingPumpActive": False,
+                    },
+                    "diagnostics": {"heatingStatusRaw": 1},
+                }
+            }
+
+        def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+            self.data = payload
+
+    boiler = _FakeBoilerCoordinator()
+
+    asyncio.run(
+        subscriptions._handle_message(
+            {
+                "type": "next",
+                "payload": {
+                    "data": {
+                        "boilerStatusUpdate": {
+                            "state": {"flowTemperatureC": 63.5},
+                        }
+                    }
+                },
+            },
+            semantic_coordinator=None,
+            energy_coordinator=None,
+            boiler_coordinator=boiler,
+            radio_coordinator=None,
+        )
+    )
+
+    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 63.5
+    assert boiler.data["boilerStatus"]["state"]["returnTemperatureC"] == 41.5
+    assert boiler.data["boilerStatus"]["state"]["centralHeatingPumpActive"] is False
+    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
+
+
 def test_radio_zone_candidates_update_on_reassignment() -> None:
     coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
     coordinator._last_by_slot = {}

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -376,6 +376,106 @@ def test_subscription_merges_partial_boiler_updates_non_destructively() -> None:
     assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
 
 
+def test_subscription_keeps_nested_boiler_diagnostics_on_explicit_null() -> None:
+    class _FakeBoilerCoordinator:
+        def __init__(self) -> None:
+            self.data = {
+                "boilerStatus": {
+                    "state": {
+                        "flowTemperatureC": 60.0,
+                        "centralHeatingPumpActive": False,
+                    },
+                    "diagnostics": {"heatingStatusRaw": 1},
+                }
+            }
+
+        def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+            self.data = payload
+
+    boiler = _FakeBoilerCoordinator()
+
+    asyncio.run(
+        subscriptions._handle_message(
+            {
+                "type": "next",
+                "payload": {
+                    "data": {
+                        "boilerStatusUpdate": {
+                            "diagnostics": None,
+                        }
+                    }
+                },
+            },
+            semantic_coordinator=None,
+            energy_coordinator=None,
+            boiler_coordinator=boiler,
+            radio_coordinator=None,
+        )
+    )
+
+    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
+    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 60.0
+
+
+def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_entries() -> None:
+    class _FakeSemanticCoordinator:
+        def __init__(self) -> None:
+            self.data = {
+                "zones": [
+                    "legacy-slot",
+                    {
+                        "id": "zone-1",
+                        "name": "Living",
+                        "state": {"currentTempC": 20.0},
+                        "config": {
+                            "operatingMode": "auto",
+                            "roomTemperatureZoneMapping": 2,
+                            "targetTempC": 21.0,
+                        },
+                    },
+                    {
+                        "id": "zone-2",
+                        "name": "Etaj",
+                        "state": {"currentTempC": 19.0},
+                        "config": {"roomTemperatureZoneMapping": 3},
+                    },
+                ],
+                "dhw": None,
+            }
+
+        def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+            self.data = payload
+
+    semantic = _FakeSemanticCoordinator()
+
+    asyncio.run(
+        subscriptions._handle_message(
+            {
+                "type": "next",
+                "payload": {
+                    "data": {
+                        "zoneUpdate": {
+                            "id": "zone-1",
+                            "state": {"currentTempC": 21.5},
+                        }
+                    }
+                },
+            },
+            semantic_coordinator=semantic,
+            energy_coordinator=None,
+            boiler_coordinator=None,
+            radio_coordinator=None,
+        )
+    )
+
+    assert semantic.data["zones"][0] == "legacy-slot"
+    merged_zone = semantic.data["zones"][1]
+    assert merged_zone["state"]["currentTempC"] == 21.5
+    assert merged_zone["config"]["roomTemperatureZoneMapping"] == 2
+    assert merged_zone["config"]["targetTempC"] == 21.0
+    assert semantic.data["zones"][2]["id"] == "zone-2"
+
+
 def test_radio_zone_candidates_update_on_reassignment() -> None:
     coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
     coordinator._last_by_slot = {}

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -422,6 +422,85 @@ def test_build_zone_parent_device_ids_flags_mapped_zone_without_physical_parent(
     assert unresolved == ("zone-2",)
 
 
+def test_build_zone_parent_device_ids_recovers_once_live_radio_payload_is_available() -> None:
+    zones = [
+        {
+            "id": "zone-1",
+            "name": "Parter",
+            "config": {"roomTemperatureZoneMapping": 1},
+        },
+        {
+            "id": "zone-2",
+            "name": "Etaj",
+            "config": {"roomTemperatureZoneMapping": 2},
+        },
+    ]
+    regulator = ("helianthus", "entry-1-bus-BASV-15")
+    sparse_payload = {
+        "radioDevices": [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "radioBusKey": "g09-i01",
+                "deviceConnected": False,
+                "remoteControlAddress": 0,
+                "zoneAssignment": 1,
+            },
+            {
+                "group": 0x0A,
+                "instance": 1,
+                "radioBusKey": "g0a-i01",
+                "deviceConnected": False,
+                "remoteControlAddress": 1,
+                "zoneAssignment": 2,
+            },
+        ],
+        "radioZoneCandidates": {},
+    }
+    live_payload = {
+        "radioDevices": [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "radioBusKey": "g09-i01",
+                "deviceConnected": True,
+                "remoteControlAddress": 0,
+                "zoneAssignment": 1,
+            },
+            {
+                "group": 0x0A,
+                "instance": 1,
+                "radioBusKey": "g0a-i01",
+                "deviceConnected": True,
+                "remoteControlAddress": 1,
+                "zoneAssignment": 2,
+            },
+        ],
+        "radioZoneCandidates": {},
+    }
+
+    sparse_parent_ids, sparse_unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        zones,
+        sparse_payload,
+        regulator,
+    )
+    live_parent_ids, live_unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        zones,
+        live_payload,
+        regulator,
+    )
+
+    assert sparse_parent_ids == {}
+    assert sparse_unresolved == ("zone-1", "zone-2")
+    assert live_parent_ids == {
+        "zone-1": radio_device_identifier("entry-1", "g09-i01"),
+        "zone-2": radio_device_identifier("entry-1", "g0a-i01"),
+    }
+    assert live_unresolved == ()
+
+
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
     payload = {
         "semantic_coordinator": _FakeCoordinator(


### PR DESCRIPTION
## Summary
- harden GraphQL subscription handling for sparse/null observability frames
- merge boiler and zone subscription updates non-destructively instead of replacing coordinator state wholesale
- make adapter-info fallback recoverable without turning missing `adapterHardwareInfo` into a setup blocker
- add focused coverage for adapter-info fallback, sparse/null subscription frames, and zone-parent recovery after early sparse payloads

## Validation
- `pytest -q tests/test_coordinator.py`
- `pytest -q tests/test_radio_device.py`
- `pytest -q tests/test_zone_valve.py`
- `pytest -q tests/test_coordinator.py tests/test_radio_device.py tests/test_zone_valve.py`
- `./scripts/ci_local.sh`

Fixes #175
