### PR TITLE
Adapter info coordinator: re-probe root support and persist minimal fallback

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import timedelta
 import logging
+import time
 from typing import Any
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -1387,6 +1388,9 @@ query AdapterHardwareInfo {
 }
 """
 
+_ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S = 300.0
+_ADAPTER_HARDWARE_INFO_REPROBE_MAX_DELAY_S = 3600.0
+
 
 class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
     """Coordinator fetching adapter hardware telemetry via GraphQL."""
@@ -1400,20 +1404,37 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         )
         self._client = client
         self._hardware_info_supported: bool | None = None
+        self._hardware_info_reprobe_at: float | None = None
+        self._hardware_info_reprobe_delay_s = _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S
 
     async def _async_update_data(self) -> dict[str, Any] | None:
-        if self._hardware_info_supported is False:
+        now = time.monotonic()
+        if self._hardware_info_reprobe_at is not None and now < self._hardware_info_reprobe_at:
             return None
 
+        query = (
+            QUERY_ADAPTER_HARDWARE_INFO_MINIMAL
+            if self._hardware_info_supported is False
+            else QUERY_ADAPTER_HARDWARE_INFO
+        )
         try:
-            payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO)
+            payload = await self._client.execute(query)
         except GraphQLResponseError as exc:
             if _is_missing_field_error(exc.errors, ["adapterHardwareInfo"]):
-                self._hardware_info_supported = False
+                self._schedule_hardware_info_reprobe(now)
                 return None
-            try:
-                payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
-            except (GraphQLClientError, GraphQLResponseError):
+            if query == QUERY_ADAPTER_HARDWARE_INFO:
+                self._hardware_info_supported = False
+                try:
+                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
+                except GraphQLResponseError as minimal_exc:
+                    if _is_missing_field_error(minimal_exc.errors, ["adapterHardwareInfo"]):
+                        self._schedule_hardware_info_reprobe(now)
+                    return None
+                except GraphQLClientError:
+                    return None
+                self._reset_hardware_info_reprobe()
+            else:
                 return None
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
@@ -1425,4 +1446,17 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         if not isinstance(info, dict):
             return None
 
+        self._reset_hardware_info_reprobe()
         return info
+
+    def _schedule_hardware_info_reprobe(self, now: float) -> None:
+        delay_s = self._hardware_info_reprobe_delay_s
+        self._hardware_info_reprobe_at = now + delay_s
+        self._hardware_info_reprobe_delay_s = min(
+            delay_s * 2,
+            _ADAPTER_HARDWARE_INFO_REPROBE_MAX_DELAY_S,
+        )
+
+    def _reset_hardware_info_reprobe(self) -> None:
+        self._hardware_info_reprobe_at = None
+        self._hardware_info_reprobe_delay_s = _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1388,6 +1388,27 @@ query AdapterHardwareInfo {
 }
 """
 
+_ADAPTER_HARDWARE_INFO_DETAILED_ONLY_FIELDS = [
+    "firmwareChecksum",
+    "bootloaderVersion",
+    "bootloaderChecksum",
+    "hardwareID",
+    "hardwareConfig",
+    "features",
+    "jumpers",
+    "jumperFlags",
+    "temperatureC",
+    "supplyVoltageMv",
+    "busVoltageMaxDv",
+    "busVoltageMinDv",
+    "resetCause",
+    "resetCauseCode",
+    "restartCount",
+    "wifiRssiDbm",
+    "lastIdentityQuery",
+    "lastTelemetryQuery",
+]
+
 _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S = 300.0
 _ADAPTER_HARDWARE_INFO_REPROBE_MAX_DELAY_S = 3600.0
 
@@ -1424,7 +1445,11 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
                 self._schedule_hardware_info_reprobe(now)
                 return None
             if query == QUERY_ADAPTER_HARDWARE_INFO:
-                self._hardware_info_supported = False
+                if _is_missing_field_error(
+                    exc.errors,
+                    _ADAPTER_HARDWARE_INFO_DETAILED_ONLY_FIELDS,
+                ):
+                    self._hardware_info_supported = False
                 try:
                     payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
                 except GraphQLResponseError as minimal_exc:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,6 +6,8 @@ import asyncio
 import sys
 import types
 
+import pytest
+
 update_coordinator_module = types.ModuleType("homeassistant.helpers.update_coordinator")
 
 
@@ -30,6 +32,8 @@ homeassistant_module.helpers = helpers_module
 sys.modules.setdefault("homeassistant", homeassistant_module)
 sys.modules.setdefault("homeassistant.helpers", helpers_module)
 sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_coordinator_module)
+
+import custom_components.helianthus.coordinator as coordinator_module
 
 from custom_components.helianthus.coordinator import (
     QUERY_ADAPTER_HARDWARE_INFO,
@@ -98,6 +102,8 @@ def _build_adapter_info_coordinator(client: _ScriptedClient) -> HelianthusAdapte
     coordinator = object.__new__(HelianthusAdapterInfoCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     coordinator._hardware_info_supported = None  # type: ignore[attr-defined]
+    coordinator._hardware_info_reprobe_at = None  # type: ignore[attr-defined]
+    coordinator._hardware_info_reprobe_delay_s = 300.0  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -322,32 +328,58 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]
 
 
-def test_adapter_info_query_missing_root_field_stays_non_fatal() -> None:
+def test_adapter_info_query_missing_root_field_reprobes_after_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _ScriptedClient(
         [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
+            ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
             ),
         ]
     )
     coordinator = _build_adapter_info_coordinator(client)
+    current_time = 1_000.0
+    monkeypatch.setattr(coordinator_module.time, "monotonic", lambda: current_time)
 
     first = asyncio.run(coordinator._async_update_data())
+    current_time += 60.0
+    second = asyncio.run(coordinator._async_update_data())
+    current_time += 300.0
+    third = asyncio.run(coordinator._async_update_data())
 
     assert first is None
-    assert coordinator._hardware_info_supported is False  # type: ignore[attr-defined]
-    assert client.calls == [QUERY_ADAPTER_HARDWARE_INFO]
+    assert second is None
+    assert third is None
+    assert coordinator._hardware_info_supported is None  # type: ignore[attr-defined]
+    assert client.calls == [QUERY_ADAPTER_HARDWARE_INFO, QUERY_ADAPTER_HARDWARE_INFO]
 
 
-def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
+def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() -> None:
     client = _ScriptedClient(
         [
-            GraphQLResponseError([{"message": 'boom on "adapterStatus"'}]),
-            {"adapterHardwareInfo": {"firmwareVersion": "2.0.0", "infoSupported": True}},
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "bootloaderVersion" on type "AdapterHardwareInfo".'}]
+            ),
+            {
+                "adapterHardwareInfo": {
+                    "firmwareVersion": "2.0.0",
+                    "infoSupported": True,
+                    "isWifi": True,
+                    "isEthernet": False,
+                    "versionResponseLen": 8,
+                }
+            },
             {
                 "adapterHardwareInfo": {
                     "firmwareVersion": "2.0.1",
                     "infoSupported": True,
+                    "isWifi": True,
+                    "isEthernet": False,
+                    "versionResponseLen": 8,
                     "temperatureC": 31.5,
                 }
             },
@@ -359,14 +391,14 @@ def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
     second = asyncio.run(coordinator._async_update_data())
 
     assert first["firmwareVersion"] == "2.0.0"
-    assert "temperatureC" not in first
+    assert first["isWifi"] is True
     assert second["firmwareVersion"] == "2.0.1"
     assert second["temperatureC"] == 31.5
-    assert coordinator._hardware_info_supported is None  # type: ignore[attr-defined]
+    assert coordinator._hardware_info_supported is False  # type: ignore[attr-defined]
     assert client.calls == [
         QUERY_ADAPTER_HARDWARE_INFO,
         QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
-        QUERY_ADAPTER_HARDWARE_INFO,
+        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
     ]
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -358,6 +358,48 @@ def test_adapter_info_query_missing_root_field_reprobes_after_backoff(
     assert client.calls == [QUERY_ADAPTER_HARDWARE_INFO, QUERY_ADAPTER_HARDWARE_INFO]
 
 
+def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError([{"message": 'boom on "adapterStatus"'}]),
+            {
+                "adapterHardwareInfo": {
+                    "firmwareVersion": "2.0.0",
+                    "infoSupported": True,
+                    "isWifi": True,
+                    "isEthernet": False,
+                    "versionResponseLen": 8,
+                }
+            },
+            {
+                "adapterHardwareInfo": {
+                    "firmwareVersion": "2.0.1",
+                    "infoSupported": True,
+                    "isWifi": True,
+                    "isEthernet": False,
+                    "versionResponseLen": 8,
+                    "temperatureC": 31.5,
+                }
+            },
+        ]
+    )
+    coordinator = _build_adapter_info_coordinator(client)
+
+    first = asyncio.run(coordinator._async_update_data())
+    second = asyncio.run(coordinator._async_update_data())
+
+    assert first["firmwareVersion"] == "2.0.0"
+    assert first["isWifi"] is True
+    assert second["firmwareVersion"] == "2.0.1"
+    assert second["temperatureC"] == 31.5
+    assert coordinator._hardware_info_supported is None  # type: ignore[attr-defined]
+    assert client.calls == [
+        QUERY_ADAPTER_HARDWARE_INFO,
+        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL,
+        QUERY_ADAPTER_HARDWARE_INFO,
+    ]
+
+
 def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() -> None:
     client = _ScriptedClient(
         [


### PR DESCRIPTION
## Summary
- re-probe `adapterHardwareInfo` root support after bounded cooldown instead of disabling polling forever
- persist minimal-query mode after deterministic full-query subfield incompatibility
- add focused coordinator regressions for reprobe recovery and sticky minimal fallback

## Validation
- `python3 -m pytest -q tests/test_coordinator.py`
- `./scripts/ci_local.sh`

Fixes #177
