### PR TITLE
feat: rebind HA entries by stable instance GUID

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,19 @@ Discovery uses mDNS service `_helianthus-graphql._tcp` with TXT fields:
 - `path` (default `/graphql`)
 - `version` (semantic API version)
 - `transport` (e.g., `http`)
+- `instance_guid` (installation-scoped lowercase UUIDv4)
+
+The integration does not trust Zeroconf TXT alone for identity. Every new bind or rebind must verify
+`gatewayIdentity.instanceGuid` over GraphQL before Home Assistant will create or rewrite a config entry.
+
+## Config Entry Identity
+
+- `config_entry.unique_id` is the verified Helianthus `instance_guid`.
+- `host`, `port`, `path`, and `transport` are mutable transport coordinates, not identity.
+- Reachable legacy `host:port` entries migrate in place during setup by querying
+  `gatewayIdentity.instanceGuid` from the configured endpoint.
+- Rediscovery may update stored coordinates only when the discovered endpoint verifies to the same GUID and
+  the currently stored endpoint no longer verifies.
 
 ## Device Tree
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
 - Suitable for onboarding contributors and validating operator workflows.
 - Supports polling by default and optional subscriptions with polling fallback.
 
+## Stable Instance Identity
+
+- Helianthus discovery now treats `instance_guid` as the canonical installation identity.
+- Config entries bind `unique_id` to the verified GraphQL value from `gatewayIdentity.instanceGuid`, not to `host:port`.
+- `host`, `port`, `path`, and `transport` remain mutable transport coordinates and may be rewritten on verified rediscovery.
+- Legacy reachable entries migrate in place on setup by fetching the stable GUID from the configured gateway endpoint.
+
 ## Helianthus Dependency Chain
 
 ```text
@@ -98,6 +105,8 @@ path: "/graphql"
 transport: "http"     # http | https
 version: "optional"
 ```
+
+Manual setup verifies `gatewayIdentity.instanceGuid` before the entry is created. Zeroconf rediscovery only rebinding when TXT `instance_guid` and GraphQL `gatewayIdentity.instanceGuid` match.
 
 Options flow fields:
 

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING
 
 from .const import (
     CONF_DHW_SCHEDULE_HELPER,
+    CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
     CONF_USE_SUBSCRIPTIONS,
+    CONF_VERSION,
     CONF_ZONE_SCHEDULE_HELPERS,
     DEFAULT_DHW_SCHEDULE_HELPER,
     DEFAULT_SCAN_INTERVAL,
@@ -332,6 +334,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from homeassistant.helpers.event import async_track_state_change_event
     from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
     from .graphql import GraphQLClient, build_graphql_url
+    from .identity import (
+        GatewayIdentityVerificationError,
+        configured_instance_guid,
+        normalize_instance_guid,
+        updated_entry_data,
+        verify_gateway_identity,
+    )
     from .coordinator import (
         HelianthusAdapterInfoCoordinator,
         HelianthusBoilerCoordinator,
@@ -434,6 +443,58 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = async_get_clientsession(hass)
     path = entry.data.get(CONF_PATH) or DEFAULT_GRAPHQL_PATH
     transport = entry.data.get(CONF_TRANSPORT) or DEFAULT_GRAPHQL_TRANSPORT
+    version = (entry.data.get(CONF_VERSION) or "").strip() or None
+    entry_instance_guid = configured_instance_guid(entry.data, entry.unique_id)
+    if entry_instance_guid is None:
+        try:
+            verified_endpoint = await verify_gateway_identity(
+                session=session,
+                host=str(host),
+                port=int(port),
+                path=path,
+                transport=transport,
+                expected_instance_guid=None,
+                version=version,
+            )
+        except GatewayIdentityVerificationError as exc:
+            _LOGGER.debug(
+                "Stable identity adoption skipped for Helianthus entry %s: %s",
+                entry.entry_id,
+                exc.reason,
+            )
+        else:
+            entry_instance_guid = verified_endpoint.instance_guid
+            hass.config_entries.async_update_entry(
+                entry,
+                data=updated_entry_data(
+                    entry.data,
+                    verified_endpoint,
+                    version=version or verified_endpoint.version,
+                ),
+                unique_id=entry_instance_guid,
+            )
+            host = verified_endpoint.host
+            port = verified_endpoint.port
+            path = verified_endpoint.path
+            transport = verified_endpoint.transport
+            version = version or verified_endpoint.version
+            _LOGGER.info(
+                "Migrated Helianthus entry %s to stable instance GUID %s",
+                entry.entry_id,
+                entry_instance_guid,
+            )
+    else:
+        normalized_unique_id = normalize_instance_guid(entry.unique_id)
+        stored_data_guid = normalize_instance_guid(entry.data.get(CONF_INSTANCE_GUID))
+        if normalized_unique_id != entry_instance_guid or stored_data_guid != entry_instance_guid:
+            updated_data = dict(entry.data)
+            updated_data[CONF_INSTANCE_GUID] = entry_instance_guid
+            hass.config_entries.async_update_entry(
+                entry,
+                data=updated_data,
+                unique_id=entry_instance_guid,
+            )
+
     graphql_url = build_graphql_url(host, port, path=path, transport=transport)
     client = GraphQLClient(session=session, url=graphql_url)
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)

--- a/custom_components/helianthus/config_flow.py
+++ b/custom_components/helianthus/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
+    CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
     CONF_VERSION,
@@ -24,22 +25,15 @@ from .const import (
     DOMAIN,
 )
 from .discovery import normalize_transport, parse_mdns_service
-from .graphql import (
-    GraphQLRequestError,
-    GraphQLResponseError,
-    GraphQLTimeoutError,
-    GraphQLClient,
-    build_graphql_url,
+from .identity import (
+    GatewayIdentityVerificationError,
+    VerifiedHelianthusEndpoint,
+    configured_instance_guid,
+    same_endpoint,
+    updated_entry_data,
+    verify_gateway_identity,
 )
 from .options_flow import HelianthusOptionsFlow
-
-_SCHEMA_QUERY = """
-query HelianthusSchema {
-  __schema {
-    queryType { name }
-  }
-}
-"""
 
 
 class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -71,21 +65,20 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 user_input.pop(CONF_VERSION, None)
 
-            unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
-            await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured()
-
-            connection_error = await self._async_validate_connection(
+            verified_endpoint, connection_error = await self._async_validate_connection(
                 host=str(user_input[CONF_HOST]),
                 port=int(user_input[CONF_PORT]),
                 path=path,
                 transport=transport,
+                version=version,
             )
             if connection_error:
                 errors["base"] = connection_error
             else:
-                return self.async_create_entry(
-                    title=user_input[CONF_HOST], data=user_input
+                return await self._async_finish_verified_entry(
+                    verified_endpoint,
+                    version=version,
+                    title=str(user_input[CONF_HOST]),
                 )
 
             self._discovery = {
@@ -94,6 +87,9 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PATH: path,
                 CONF_TRANSPORT: transport,
                 CONF_VERSION: version or "",
+                CONF_INSTANCE_GUID: (
+                    verified_endpoint.instance_guid if verified_endpoint is not None else ""
+                ),
             }
 
         default_host = self._discovery[CONF_HOST] if self._discovery else ""
@@ -124,26 +120,118 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _async_validate_connection(
-        self, host: str, port: int, path: str, transport: str
-    ) -> str | None:
-        url = build_graphql_url(host, port, path=path, transport=transport)
-        client = GraphQLClient(
-            session=async_get_clientsession(self.hass),
-            url=url,
-            timeout=5.0,
-        )
+        self,
+        host: str,
+        port: int,
+        path: str,
+        transport: str,
+        *,
+        addresses: list[str] | None = None,
+        expected_instance_guid: str | None = None,
+        version: str | None = None,
+    ) -> tuple[VerifiedHelianthusEndpoint | None, str | None]:
         try:
-            data = await client.execute(_SCHEMA_QUERY)
-        except (GraphQLTimeoutError, GraphQLRequestError):
-            return "cannot_connect"
-        except GraphQLResponseError:
-            return "invalid_response"
+            verified = await verify_gateway_identity(
+                session=async_get_clientsession(self.hass),
+                host=host,
+                port=port,
+                path=path,
+                transport=transport,
+                addresses=addresses,
+                expected_instance_guid=expected_instance_guid,
+                version=version,
+            )
+            return verified, None
+        except GatewayIdentityVerificationError as exc:
+            return None, exc.reason
         except Exception:  # pragma: no cover - unexpected errors
-            return "unknown"
+            return None, "unknown"
 
-        if not isinstance(data, dict) or "__schema" not in data:
-            return "invalid_response"
+    def _async_find_entry_by_guid(
+        self, instance_guid: str
+    ) -> config_entries.ConfigEntry | None:
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if configured_instance_guid(entry.data, entry.unique_id) == instance_guid:
+                return entry
         return None
+
+    async def _async_verify_existing_entry(
+        self, entry: config_entries.ConfigEntry, instance_guid: str
+    ) -> VerifiedHelianthusEndpoint | None:
+        try:
+            host = str(entry.data["host"])
+            port = int(entry.data["port"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        path = entry.data.get(CONF_PATH) or DEFAULT_GRAPHQL_PATH
+        transport = entry.data.get(CONF_TRANSPORT) or DEFAULT_GRAPHQL_TRANSPORT
+        version = (entry.data.get(CONF_VERSION) or "").strip() or None
+        verified, error = await self._async_validate_connection(
+            host=host,
+            port=port,
+            path=path,
+            transport=transport,
+            expected_instance_guid=instance_guid,
+            version=version,
+        )
+        if error:
+            return None
+        return verified
+
+    async def _async_finish_verified_entry(
+        self,
+        verified_endpoint: VerifiedHelianthusEndpoint | None,
+        *,
+        version: str | None,
+        title: str,
+    ) -> FlowResult:
+        if verified_endpoint is None:
+            return self.async_abort(reason="invalid_response")
+
+        instance_guid = verified_endpoint.instance_guid
+        await self.async_set_unique_id(instance_guid)
+        existing_entry = self._async_find_entry_by_guid(instance_guid)
+
+        if existing_entry is not None:
+            existing_data = updated_entry_data(
+                existing_entry.data,
+                verified_endpoint,
+                version=version or verified_endpoint.version,
+            )
+            if same_endpoint(existing_entry.data, verified_endpoint):
+                if (
+                    existing_entry.unique_id != instance_guid
+                    or existing_entry.data != existing_data
+                ):
+                    self.hass.config_entries.async_update_entry(
+                        existing_entry,
+                        data=existing_data,
+                        unique_id=instance_guid,
+                        title=existing_entry.title or title,
+                    )
+                return self.async_abort(reason="already_configured")
+
+            current_verified = await self._async_verify_existing_entry(
+                existing_entry, instance_guid
+            )
+            if current_verified is not None:
+                return self.async_abort(reason="duplicate_instance_guid")
+
+            self.hass.config_entries.async_update_entry(
+                existing_entry,
+                data=existing_data,
+                unique_id=instance_guid,
+                title=existing_entry.title or title,
+            )
+            await self.hass.config_entries.async_reload(existing_entry.entry_id)
+            return self.async_abort(reason="reconfigured")
+
+        data = updated_entry_data(
+            {},
+            verified_endpoint,
+            version=version or verified_endpoint.version,
+        )
+        return self.async_create_entry(title=title, data=data)
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
@@ -153,18 +241,24 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ValueError:
             return self.async_abort(reason="invalid_discovery_info")
 
-        unique_id = f"{record.host}:{record.port}"
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+        if not record.instance_guid:
+            return self.async_abort(reason="missing_instance_guid")
+
+        verified_endpoint, error = await self._async_validate_connection(
+            host=record.host,
+            port=record.port,
+            path=record.path,
+            transport=record.transport,
+            addresses=list(record.addresses),
+            expected_instance_guid=record.instance_guid,
+            version=record.version,
+        )
+        if error:
+            return self.async_abort(reason=error)
 
         self.context["title_placeholders"] = {"name": record.name or record.host}
-
-        self._discovery = {
-            CONF_HOST: record.host,
-            CONF_PORT: record.port,
-            CONF_PATH: record.path,
-            CONF_TRANSPORT: record.transport,
-            CONF_VERSION: record.version or "",
-        }
-
-        return await self.async_step_user()
+        return await self._async_finish_verified_entry(
+            verified_endpoint,
+            version=record.version,
+            title=record.name or verified_endpoint.host,
+        )

--- a/custom_components/helianthus/const.py
+++ b/custom_components/helianthus/const.py
@@ -6,6 +6,7 @@ MDNS_SERVICE_TYPE = "_helianthus-graphql._tcp.local."
 CONF_PATH = "path"
 CONF_TRANSPORT = "transport"
 CONF_VERSION = "version"
+CONF_INSTANCE_GUID = "instance_guid"
 
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_USE_SUBSCRIPTIONS = "use_subscriptions"

--- a/custom_components/helianthus/discovery.py
+++ b/custom_components/helianthus/discovery.py
@@ -22,6 +22,7 @@ class MdnsService:
     path: str
     transport: str
     version: str | None
+    instance_guid: str | None
 
 
 def _format_addresses(addresses: Iterable[bytes | str] | None) -> list[str]:
@@ -76,6 +77,7 @@ def parse_mdns_service(info: object) -> MdnsService:
     path = txt.get("path") or DEFAULT_GRAPHQL_PATH
     transport = normalize_transport(txt.get("transport"))
     version = txt.get("version") or None
+    instance_guid = txt.get("instance_guid") or None
 
     if not host or port is None:
         raise ValueError("mDNS info missing host or port")
@@ -88,4 +90,5 @@ def parse_mdns_service(info: object) -> MdnsService:
         path=path,
         transport=transport,
         version=version,
+        instance_guid=instance_guid,
     )

--- a/custom_components/helianthus/identity.py
+++ b/custom_components/helianthus/identity.py
@@ -1,0 +1,190 @@
+"""Stable gateway identity helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Iterable, Mapping
+
+from .const import (
+    CONF_INSTANCE_GUID,
+    CONF_PATH,
+    CONF_TRANSPORT,
+    CONF_VERSION,
+    DEFAULT_GRAPHQL_PATH,
+)
+from .discovery import normalize_transport
+from .graphql import (
+    GraphQLClient,
+    GraphQLRequestError,
+    GraphQLResponseError,
+    GraphQLTimeoutError,
+    build_graphql_url,
+)
+
+_INSTANCE_GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+QUERY_GATEWAY_IDENTITY = """
+query GatewayIdentity {
+  gatewayIdentity {
+    instanceGuid
+  }
+}
+"""
+
+
+class GatewayIdentityVerificationError(RuntimeError):
+    """Raised when a GraphQL endpoint cannot prove stable Helianthus identity."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class VerifiedHelianthusEndpoint:
+    """Verified GraphQL endpoint bound to a stable Helianthus instance GUID."""
+
+    instance_guid: str
+    host: str
+    port: int
+    path: str
+    transport: str
+    version: str | None = None
+
+
+def normalize_instance_guid(value: object | None) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if not _INSTANCE_GUID_RE.match(normalized):
+        return None
+    return normalized
+
+
+def configured_instance_guid(
+    data: Mapping[str, Any] | None,
+    unique_id: object | None = None,
+) -> str | None:
+    """Return the canonical GUID stored on a config entry, if any."""
+
+    normalized_unique_id = normalize_instance_guid(unique_id)
+    if normalized_unique_id is not None:
+        return normalized_unique_id
+    if data is None:
+        return None
+    return normalize_instance_guid(data.get(CONF_INSTANCE_GUID))
+
+
+def normalize_graphql_path(value: object | None) -> str:
+    path = str(value or "").strip() or DEFAULT_GRAPHQL_PATH
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+def candidate_hosts(host: str, addresses: Iterable[str] | None = None) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for candidate in (host, *(addresses or ())):
+        normalized = str(candidate or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    return tuple(ordered)
+
+
+def same_endpoint(data: Mapping[str, Any], endpoint: VerifiedHelianthusEndpoint) -> bool:
+    host = str(data.get("host") or "").strip()
+    try:
+        port = int(data.get("port"))
+    except (TypeError, ValueError):
+        return False
+    path = normalize_graphql_path(data.get(CONF_PATH))
+    transport = normalize_transport(data.get(CONF_TRANSPORT))
+    return (
+        host == endpoint.host
+        and port == endpoint.port
+        and path == endpoint.path
+        and transport == endpoint.transport
+    )
+
+
+def updated_entry_data(
+    data: Mapping[str, Any],
+    endpoint: VerifiedHelianthusEndpoint,
+    *,
+    version: str | None = None,
+) -> dict[str, Any]:
+    updated = dict(data)
+    updated["host"] = endpoint.host
+    updated["port"] = endpoint.port
+    updated[CONF_PATH] = endpoint.path
+    updated[CONF_TRANSPORT] = endpoint.transport
+    updated[CONF_INSTANCE_GUID] = endpoint.instance_guid
+    if version:
+        updated[CONF_VERSION] = version
+    else:
+        updated.pop(CONF_VERSION, None)
+    return updated
+
+
+async def verify_gateway_identity(
+    *,
+    session: Any,
+    host: str,
+    port: int,
+    path: str,
+    transport: str,
+    addresses: Iterable[str] | None = None,
+    expected_instance_guid: str | None = None,
+    version: str | None = None,
+    timeout: float = 5.0,
+) -> VerifiedHelianthusEndpoint:
+    normalized_path = normalize_graphql_path(path)
+    normalized_transport = normalize_transport(transport)
+    expected_guid = normalize_instance_guid(expected_instance_guid)
+    last_connection_error: Exception | None = None
+
+    for candidate in candidate_hosts(host, addresses):
+        client = GraphQLClient(
+            session=session,
+            url=build_graphql_url(candidate, port, path=normalized_path, transport=normalized_transport),
+            timeout=timeout,
+            retries=0,
+        )
+        try:
+            payload = await client.execute(QUERY_GATEWAY_IDENTITY)
+        except (GraphQLTimeoutError, GraphQLRequestError) as exc:
+            last_connection_error = exc
+            continue
+        except GraphQLResponseError as exc:
+            raise GatewayIdentityVerificationError("requires_gateway_upgrade") from exc
+
+        if not isinstance(payload, dict):
+            raise GatewayIdentityVerificationError("invalid_response")
+        identity = payload.get("gatewayIdentity")
+        if not isinstance(identity, dict):
+            raise GatewayIdentityVerificationError("invalid_response")
+        instance_guid = normalize_instance_guid(identity.get("instanceGuid"))
+        if instance_guid is None:
+            raise GatewayIdentityVerificationError("missing_instance_guid")
+        if expected_guid is not None and instance_guid != expected_guid:
+            raise GatewayIdentityVerificationError("identity_mismatch")
+        return VerifiedHelianthusEndpoint(
+            instance_guid=instance_guid,
+            host=candidate,
+            port=port,
+            path=normalized_path,
+            transport=normalized_transport,
+            version=version,
+        )
+
+    if last_connection_error is None:
+        raise GatewayIdentityVerificationError("cannot_connect")
+    raise GatewayIdentityVerificationError("cannot_connect") from last_connection_error

--- a/custom_components/helianthus/strings.json
+++ b/custom_components/helianthus/strings.json
@@ -20,12 +20,22 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to the Helianthus GraphQL endpoint.",
-      "invalid_response": "Helianthus responded with an invalid schema.",
+      "invalid_response": "Helianthus responded with an invalid identity payload.",
+      "requires_gateway_upgrade": "The Helianthus gateway must be updated before this integration can bind to it.",
+      "missing_instance_guid": "The Helianthus gateway did not expose a stable instance GUID.",
+      "identity_mismatch": "Discovered identity did not match the verified Helianthus gateway.",
       "unknown": "Unexpected error."
     },
     "abort": {
       "already_configured": "This Helianthus endpoint is already configured.",
-      "invalid_discovery_info": "Discovery data is invalid."
+      "invalid_discovery_info": "Discovery data is invalid.",
+      "cannot_connect": "Failed to connect to the discovered Helianthus GraphQL endpoint.",
+      "invalid_response": "The discovered Helianthus gateway returned an invalid identity payload.",
+      "requires_gateway_upgrade": "The discovered Helianthus gateway must be updated before it can be added.",
+      "missing_instance_guid": "The discovered Helianthus gateway did not advertise a stable instance GUID.",
+      "identity_mismatch": "Discovery TXT data did not match the verified Helianthus gateway identity.",
+      "duplicate_instance_guid": "Another live Helianthus endpoint already claims this instance GUID. Automatic rebinding was refused.",
+      "reconfigured": "The existing Helianthus entry was rebound to the rediscovered endpoint."
     }
   }
 }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -46,6 +46,7 @@ def test_parse_mdns_service_txt_fields() -> None:
             b"Path": b"/gql",
             b"VERSION": b"1.2.3",
             b"Transport": b"https",
+            b"instance_guid": b"4d9336aa-f125-4f12-8b07-fcd18dbfcb10",
         },
     )
 
@@ -54,6 +55,7 @@ def test_parse_mdns_service_txt_fields() -> None:
     assert record.path == "/gql"
     assert record.transport == "https"
     assert record.version == "1.2.3"
+    assert record.instance_guid == "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"
 
 
 def test_parse_mdns_service_invalid_transport_falls_back() -> None:

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,227 @@
+"""Tests for stable gateway identity helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import custom_components.helianthus.graphql as gql
+from custom_components.helianthus.identity import (
+    GatewayIdentityVerificationError,
+    VerifiedHelianthusEndpoint,
+    configured_instance_guid,
+    same_endpoint,
+    updated_entry_data,
+    verify_gateway_identity,
+)
+
+
+INSTANCE_GUID = "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"
+
+
+@dataclass
+class _FakeResponse:
+    payload: dict
+    raise_error: Exception | None = None
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        if self.raise_error is not None:
+            raise self.raise_error
+
+    async def json(self) -> dict:
+        return self.payload
+
+
+class _FakeSession:
+    def __init__(self, post_actions: list[_FakeResponse | Exception]) -> None:
+        self.post_actions = post_actions
+        self.urls: list[str] = []
+
+    def post(self, url: str, json: dict) -> _FakeResponse:
+        self.urls.append(url)
+        action = self.post_actions.pop(0)
+        if isinstance(action, Exception):
+            raise action
+        return action
+
+
+def test_configured_instance_guid_prefers_unique_id() -> None:
+    assert configured_instance_guid(
+        {"instance_guid": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ) == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def test_configured_instance_guid_falls_back_to_entry_data() -> None:
+    assert configured_instance_guid(
+        {"instance_guid": INSTANCE_GUID},
+        "gateway.local:8080",
+    ) == INSTANCE_GUID
+
+
+def test_verify_gateway_identity_uses_fallback_address() -> None:
+    session = _FakeSession(
+        post_actions=[
+            gql.aiohttp.ClientError("host lookup failed"),
+            _FakeResponse(
+                payload={
+                    "data": {
+                        "gatewayIdentity": {
+                            "instanceGuid": INSTANCE_GUID,
+                        }
+                    }
+                }
+            ),
+        ]
+    )
+
+    verified = asyncio.run(
+        verify_gateway_identity(
+            session=session,
+            host="gateway.local",
+            port=8080,
+            path="graphql",
+            transport="HTTP",
+            addresses=["192.0.2.10"],
+            expected_instance_guid=INSTANCE_GUID,
+            version="1",
+        )
+    )
+
+    assert verified == VerifiedHelianthusEndpoint(
+        instance_guid=INSTANCE_GUID,
+        host="192.0.2.10",
+        port=8080,
+        path="/graphql",
+        transport="http",
+        version="1",
+    )
+    assert session.urls == [
+        "http://gateway.local:8080/graphql",
+        "http://192.0.2.10:8080/graphql",
+    ]
+
+
+def test_verify_gateway_identity_rejects_guid_mismatch() -> None:
+    session = _FakeSession(
+        post_actions=[
+            _FakeResponse(
+                payload={
+                    "data": {
+                        "gatewayIdentity": {
+                            "instanceGuid": "ccccccee-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                        }
+                    }
+                }
+            )
+        ]
+    )
+
+    try:
+        asyncio.run(
+            verify_gateway_identity(
+                session=session,
+                host="gateway.local",
+                port=8080,
+                path="/graphql",
+                transport="http",
+                expected_instance_guid=INSTANCE_GUID,
+            )
+        )
+    except GatewayIdentityVerificationError as exc:
+        assert exc.reason == "identity_mismatch"
+    else:
+        raise AssertionError("expected identity_mismatch")
+
+
+def test_verify_gateway_identity_requires_gateway_upgrade_on_graphql_error() -> None:
+    session = _FakeSession(
+        post_actions=[
+            _FakeResponse(
+                payload={
+                    "errors": [
+                        {"message": 'Cannot query field "gatewayIdentity" on type "Query".'}
+                    ]
+                }
+            )
+        ]
+    )
+
+    try:
+        asyncio.run(
+            verify_gateway_identity(
+                session=session,
+                host="gateway.local",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            )
+        )
+    except GatewayIdentityVerificationError as exc:
+        assert exc.reason == "requires_gateway_upgrade"
+    else:
+        raise AssertionError("expected requires_gateway_upgrade")
+
+
+def test_verify_gateway_identity_reports_missing_guid() -> None:
+    session = _FakeSession(
+        post_actions=[
+            _FakeResponse(
+                payload={
+                    "data": {
+                        "gatewayIdentity": {
+                            "instanceGuid": "",
+                        }
+                    }
+                }
+            )
+        ]
+    )
+
+    try:
+        asyncio.run(
+            verify_gateway_identity(
+                session=session,
+                host="gateway.local",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            )
+        )
+    except GatewayIdentityVerificationError as exc:
+        assert exc.reason == "missing_instance_guid"
+    else:
+        raise AssertionError("expected missing_instance_guid")
+
+
+def test_same_endpoint_and_updated_entry_data() -> None:
+    endpoint = VerifiedHelianthusEndpoint(
+        instance_guid=INSTANCE_GUID,
+        host="192.0.2.10",
+        port=8080,
+        path="/graphql",
+        transport="https",
+        version="1",
+    )
+
+    updated = updated_entry_data(
+        {"host": "gateway.local", "port": 1234, "path": "/old", "transport": "http"},
+        endpoint,
+        version="2",
+    )
+
+    assert updated == {
+        "host": "192.0.2.10",
+        "port": 8080,
+        "path": "/graphql",
+        "transport": "https",
+        "instance_guid": INSTANCE_GUID,
+        "version": "2",
+    }
+    assert same_endpoint(updated, endpoint) is True


### PR DESCRIPTION
## What
- make `ConfigEntry.unique_id` use the verified gateway instance GUID
- verify manual and Zeroconf discovery against GraphQL before create/rebind
- migrate reachable legacy `host:port` entries in place during setup
- refuse unsafe create/rebind cases when GUIDs are missing, mismatched, or duplicated
- add identity and migration test coverage

## Why
- fixes endpoint drift when the add-on IP/host/path changes
- keeps GUID as the canonical identity while transport coordinates stay mutable

## Validation
- `./scripts/ci_local.sh`
- live smoke: `python3 -m custom_components.helianthus.smoke_profile --host 192.168.100.4 --port 8080 --path /graphql --json`
- live config entry migrated in place: `entry_id=01KK2FYJ7KCXCZ4A766ZPJSPE9`, `unique_id=3678381d-034e-4f6a-ab72-fce6eaa91245`
- live GraphQL verification returns `3678381d-034e-4f6a-ab72-fce6eaa91245`

Refs #179