### PR TITLE
feat: HA 2026.4 entity naming alignment + UI fixes

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -1102,6 +1102,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ", ".join(unresolved_zone_ids),
         )
 
+    # Reverse map: device_id → zone_name for radio device naming (HA 2026.4).
+    radio_device_zone_names: dict[tuple[str, str], str] = {}
+    if isinstance(semantic_coordinator.data, dict):
+        for zone in semantic_coordinator.data.get("zones", []) or []:
+            if not isinstance(zone, dict):
+                continue
+            zone_id = zone.get("id")
+            zone_name = zone.get("name")
+            if zone_id is None or not zone_name:
+                continue
+            from .climate import _normalize_zone_id as _nzid
+            normalized = _nzid(zone_id)
+            if normalized is None:
+                continue
+            device_id = zone_parent_device_ids.get(normalized)
+            if device_id is not None and device_id != regulator_device:
+                radio_device_zone_names[device_id] = str(zone_name).strip()
+
     zone_schedule_helpers = _parse_zone_schedule_helper_bindings(
         str(
             entry.options.get(
@@ -1352,6 +1370,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "boiler_burner_device_id": boiler_burner_device_id,
         "boiler_hydraulics_device_id": boiler_hydraulics_device_id,
         "zone_parent_device_ids": zone_parent_device_ids,
+        "radio_device_zone_names": radio_device_zone_names,
         "unresolved_zone_ids": unresolved_zone_ids,
         "b524_merge_targets": b524_merge_targets,
     }

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -298,6 +298,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusScheduleBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Read-only schedule mirror binary sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -319,7 +321,7 @@ class HelianthusScheduleBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._target_name = target_name
         self._target_device_id = target_device_id
         self._schedule_key = schedule_key
-        self._attr_name = f"{target_name} {schedule_label}"
+        self._attr_name = schedule_label
         unique_target = target_id or "dhw"
         self._attr_unique_id = f"{entry_id}-{target_kind}-{unique_target}-schedule-{schedule_key}"
         _SCHEDULE_ICONS: dict[str, str] = {
@@ -380,6 +382,7 @@ class HelianthusBoilerStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Boiler read-only boolean state exposed on the physical boiler device."""
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -431,6 +434,7 @@ class HelianthusCircuitPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Per-circuit pump active state."""
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -447,7 +451,7 @@ class HelianthusCircuitPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._manufacturer = manufacturer
         self._circuit_index = circuit_index
         self._initial_name = initial_name
-        self._attr_name = f"{initial_name} Pump Active"
+        self._attr_name = "Pump Active"
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-binary-pumpActive"
 
     def _circuit(self) -> dict[str, Any]:
@@ -479,6 +483,7 @@ class HelianthusCircuitPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
 class HelianthusSolarBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Sparse solar binary sensor that auto-enables when live data appears."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -543,6 +548,7 @@ class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Reduced-profile central heating pump state on physical BAI00."""
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -553,7 +559,7 @@ class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
     ) -> None:
         super().__init__(coordinator)
         self._boiler_device_id = boiler_device_id
-        self._attr_name = "Boiler Central Heating Pump Active"
+        self._attr_name = "Central Heating Pump Active"
         self._attr_unique_id = f"{entry_id}-boiler-central-heating-pump-active"
 
     @property
@@ -573,6 +579,8 @@ class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
 class HelianthusSystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """System-level BASV2 binary sensor."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -628,6 +636,7 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
     """Remote-slot connected-state binary sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
     _attr_icon = "mdi:radio-tower"
 
     def __init__(
@@ -688,6 +697,7 @@ class HelianthusZoneValveBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Zone valve open/closed derived from valve_position_pct."""
 
     _attr_device_class = BinarySensorDeviceClass.OPENING
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -704,7 +714,7 @@ class HelianthusZoneValveBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._manufacturer = manufacturer
         self._zone_id = zone_id
         self._target_device_id = target_device_id
-        self._attr_name = f"{zone_name} Valve"
+        self._attr_name = "Valve"
         self._attr_unique_id = f"{entry_id}-zone-{zone_id}-binary-valve"
 
     def _zone(self) -> dict[str, Any]:

--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -103,11 +103,10 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
         self._target_device_id = target_device_id or regulator_device_id
 
         hc_label = _HC_LABELS.get(hc, hc)
+        self._attr_name = f"{hc_label} Schedule"
         if zone == 255:
-            self._attr_name = f"{hc_label} Schedule"
             zone_tag = "dhw"
         else:
-            self._attr_name = f"Zone {zone + 1} {hc_label} Schedule"
             zone_tag = f"zone-{zone + 1}"
 
         self._attr_unique_id = (

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -153,6 +153,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             target_device_id = regulator_device_id
         if target_device_id is None:
             continue
+        is_dedicated_device = target_device_id != regulator_device_id
         entities.append(
             HelianthusZoneClimate(
                 entry.entry_id,
@@ -165,6 +166,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 source_address,
                 zone_id,
                 zone.get("name"),
+                is_dedicated_device=is_dedicated_device,
             )
         )
     async_add_entities([entity for entity in entities if entity.zone_id])
@@ -173,6 +175,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     """Zone climate entity."""
 
+    _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
@@ -190,6 +193,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         source_address: int | None,
         zone_id: str | None,
         name: str | None,
+        *,
+        is_dedicated_device: bool = False,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
@@ -201,7 +206,12 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         self._source_address = source_address
         self._zone_id = _normalize_zone_id(zone_id)
         self._zone_instance = _zone_instance(self._zone_id)
-        self._attr_name = name or _zone_default_name(self._zone_id)
+        self._zone_name = name or _zone_default_name(self._zone_id)
+        self._is_dedicated_device = is_dedicated_device
+        if is_dedicated_device:
+            self._attr_name = "Thermostat"
+        else:
+            self._attr_name = f"{self._zone_name} Thermostat"
         if self._zone_id:
             self._attr_unique_id = f"{entry_id}-zone-{self._zone_id}"
 
@@ -219,9 +229,11 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def name(self) -> str | None:
+        if self._is_dedicated_device:
+            return "Thermostat"
         zone_name = self._zone().get("name")
         if zone_name is not None and str(zone_name).strip():
-            return str(zone_name).strip()
+            return f"{str(zone_name).strip()} Thermostat"
         return self._attr_name
 
     @property

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -60,6 +60,7 @@ async def async_setup_entry(
 class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
     """Writable maintenance date from B524 controller."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:calendar-clock"
 

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -105,6 +105,7 @@ def _coerce_percentage(value: object | None) -> int | None:
 class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
     """Read-only burner state exposed as a fan."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:fire"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -168,6 +169,7 @@ class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
 class HelianthusBoilerPumpFan(HelianthusReadOnlyFan):
     """Read-only boiler pump state under the Hydraulics sub-device."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:pump"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -242,6 +244,7 @@ class HelianthusBoilerPumpFan(HelianthusReadOnlyFan):
 class HelianthusCircuitPumpFan(HelianthusReadOnlyFan):
     """Read-only circuit pump state as a fan entity."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:pump"
 
     def __init__(
@@ -271,7 +274,7 @@ class HelianthusCircuitPumpFan(HelianthusReadOnlyFan):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} Pump"
+        return "Pump"
 
     def _device_name(self) -> str:
         circuit = self._circuit()
@@ -313,6 +316,7 @@ class HelianthusCircuitPumpFan(HelianthusReadOnlyFan):
 class HelianthusSolarPumpFan(CoordinatorEntity, FanEntity):
     """Read-only solar pump state."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:pump"
     _attr_supported_features = FanEntityFeature(0)
 
@@ -329,7 +333,7 @@ class HelianthusSolarPumpFan(CoordinatorEntity, FanEntity):
         self._manufacturer = manufacturer
         self._solar_device_id = solar_device_id
         self._parent_device_id = parent_device_id
-        self._attr_name = "Solar Pump"
+        self._attr_name = "Pump"
         self._attr_unique_id = f"{entry_id}-solar-pump"
 
     @property

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.number import NumberEntity
+
+try:
+    from homeassistant.components.number import NumberMode
+except ImportError:
+    class NumberMode:  # type: ignore[no-redef]
+        BOX = "box"
+        SLIDER = "slider"
 from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -192,17 +199,6 @@ _SYSTEM_NUMBER_FIELDS = [
         cast_int=True,
         icon="mdi:water-percent",
     ),
-    SystemNumberField(
-        mutation_field="installerMenuCode",
-        config_key="installerMenuCode",
-        label="Installer Menu Code",
-        minimum=0.0,
-        maximum=999.0,
-        step=1.0,
-        cast_int=True,
-        icon="mdi:key-variant",
-        sensitive=True,
-    ),
 ]
 
 _CYLINDER_NUMBER_FIELDS = [
@@ -271,15 +267,6 @@ _BOILER_NUMBER_FIELDS = [
         step=0.1,
         unit="kW",
         icon="mdi:lightning-bolt",
-    ),
-    BoilerNumberField(
-        key="installerMenuCode",
-        label="Boiler Installer Menu Code",
-        minimum=0.0,
-        maximum=255.0,
-        step=1.0,
-        icon="mdi:key-variant",
-        sensitive=True,
     ),
 ]
 
@@ -377,7 +364,9 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
     """Writable boiler configuration number on the physical BAI00 device."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,
@@ -456,7 +445,9 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
 class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
     """Writable circuit configuration number."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,
@@ -477,7 +468,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         self._initial_name = initial_name
         self._field = field
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-number-{field.key}"
-        self._attr_name = f"{initial_name} {field.label}"
+        self._attr_name = field.label
         self._attr_native_min_value = field.minimum
         self._attr_native_max_value = field.maximum
         self._attr_native_step = field.step
@@ -497,7 +488,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} {self._field.label}"
+        return self._field.label
 
     def _device_name(self) -> str:
         circuit = self._circuit()
@@ -560,7 +551,9 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
 class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
     """Writable BASV2 system configuration number."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,
@@ -646,7 +639,9 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
 class HelianthusCylinderConfigNumber(CoordinatorEntity, NumberEntity):
     """Read-only interpreted cylinder configuration number."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,
@@ -665,7 +660,7 @@ class HelianthusCylinderConfigNumber(CoordinatorEntity, NumberEntity):
         self._cylinder_index = cylinder_index
         self._field = field
         self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-number-{field.key}"
-        self._attr_name = f"Cylinder {cylinder_index + 1} {field.label}"
+        self._attr_name = field.label
         self._attr_native_min_value = field.minimum
         self._attr_native_max_value = field.maximum
         self._attr_native_step = field.step

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -82,6 +82,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
     """Circuit room temperature control select."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_options = _OPTIONS
     _attr_icon = "mdi:thermostat"
@@ -103,7 +104,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-room-temp-control"
-        self._attr_name = f"{initial_name} Room Temperature Control"
+        self._attr_name = "Room Temperature Control"
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -116,7 +117,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} Room Temperature Control"
+        return "Room Temperature Control"
 
     def _device_name(self) -> str:
         circuit = self._circuit()

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -64,6 +64,7 @@ class SystemSensorField:
     entity_category: str | None = None
     cast_int: bool = False
     icon: str | None = None
+    optional: bool = False
 
 
 STATUS_FIELDS = [
@@ -208,6 +209,7 @@ SYSTEM_SENSOR_FIELDS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
+        optional=True,
     ),
     SystemSensorField(
         key="hwcCylinderTemperatureBottom",
@@ -216,6 +218,7 @@ SYSTEM_SENSOR_FIELDS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
+        optional=True,
     ),
     SystemSensorField(
         key="systemScheme",
@@ -490,6 +493,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     vr71_device_id = data.get("vr71_device_id")
     via_device = data.get("regulator_device_id") or data.get("adapter_device_id")
     zone_parent_device_ids = data.get("zone_parent_device_ids") or {}
+    radio_device_zone_names: dict[tuple[str, str], str] = data.get("radio_device_zone_names") or {}
     b524_merge_targets: dict[str, tuple[str, str]] = data.get("b524_merge_targets") or {}
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
@@ -602,6 +606,10 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     if system_coordinator and system_coordinator.data and regulator_device_id:
         for field in SYSTEM_SENSOR_FIELDS:
+            if field.optional:
+                source_data = system_coordinator.data.get(field.source, {})
+                if not isinstance(source_data, dict) or source_data.get(field.key) is None:
+                    continue
             sensors.append(
                 HelianthusSystemSensor(
                     coordinator=system_coordinator,
@@ -629,6 +637,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             is_room = class_address in _RADIO_ROOM_CLASSES
             radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
             radio_name = _radio_model_name(radio)
+            radio_zone_name = radio_device_zone_names.get(radio_device_id)
             if is_room or radio.get("receptionStrength") is not None:
                 sensors.append(
                     HelianthusRadioSensor(
@@ -643,6 +652,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         label="Signal Quality",
                         entity_category=EntityCategory.DIAGNOSTIC,
                         cast_int=True,
+                        zone_name=radio_zone_name,
                     )
                 )
             if is_room:
@@ -660,6 +670,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         device_class=SensorDeviceClass.TEMPERATURE,
                         native_unit=UnitOfTemperature.CELSIUS,
                         state_class=SensorStateClass.MEASUREMENT,
+                        zone_name=radio_zone_name,
                     )
                 )
                 sensors.append(
@@ -676,6 +687,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         device_class=_SENSOR_DEVICE_CLASS_HUMIDITY,
                         native_unit=PERCENTAGE,
                         state_class=SensorStateClass.MEASUREMENT,
+                        zone_name=radio_zone_name,
                     )
                 )
             elif group == 0x0C:
@@ -707,6 +719,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                             entity_category=EntityCategory.DIAGNOSTIC,
                             cast_int=True,
                             icon=_radio_metadata_icons.get(key),
+                            zone_name=radio_zone_name,
                         )
                     )
 
@@ -955,6 +968,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusBusAddressSensor(CoordinatorEntity, SensorEntity):
     """eBUS address sensor for a physical bus device."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:chip"
 
@@ -982,6 +996,7 @@ class HelianthusBusAddressSensor(CoordinatorEntity, SensorEntity):
 class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
     """Daemon/adapter status sensor."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -996,7 +1011,7 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         self._status = status
         self._field = field
         self._identifier = identifier or (DOMAIN, f"unknown-{target_name.lower()}")
-        self._attr_name = f"{target_name} {field.name}"
+        self._attr_name = field.name
         self._attr_unique_id = f"{self._identifier[1]}-{field.key}"
         if field.icon is not None:
             self._attr_icon = field.icon
@@ -1013,6 +1028,7 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
 class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
     """Reduced-profile boiler temperature sensor on physical BAI00."""
 
+    _attr_has_entity_name = True
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -1027,7 +1043,7 @@ class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._boiler_device_id = boiler_device_id
         self._field = field
-        self._attr_name = f"Boiler {field.label}"
+        self._attr_name = field.label
         self._attr_unique_id = f"{entry_id}-boiler-{field.key}"
 
     def _boiler_state(self) -> dict[str, Any]:
@@ -1047,6 +1063,8 @@ class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
 
 class HelianthusBoilerStateSensor(CoordinatorEntity, SensorEntity):
     """Read-only boiler state sensor attached directly to the physical boiler."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1100,6 +1118,8 @@ class HelianthusBoilerStateSensor(CoordinatorEntity, SensorEntity):
 class HelianthusBoilerDiagnosticsSensor(CoordinatorEntity, SensorEntity):
     """Boiler diagnostic counter sensor (hours, starts, deactivations)."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -1113,7 +1133,7 @@ class HelianthusBoilerDiagnosticsSensor(CoordinatorEntity, SensorEntity):
         self._manufacturer = manufacturer
         self._boiler_device_id = boiler_device_id
         self._field = field
-        self._attr_name = f"Boiler {field['label']}"
+        self._attr_name = field['label']
         self._attr_unique_id = f"{entry_id}-boiler-diag-{field['key']}"
         if field.get("device_class") is not None:
             self._attr_device_class = field["device_class"]
@@ -1154,6 +1174,8 @@ class HelianthusBoilerDiagnosticsSensor(CoordinatorEntity, SensorEntity):
 class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
     """Per-circuit sensor values sourced from the circuit coordinator."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -1171,7 +1193,7 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
         self._initial_name = initial_name
         self._field = field
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-sensor-{field.key}"
-        self._attr_name = f"{initial_name} {field.label}"
+        self._attr_name = field.label
         if field.device_class is not None:
             self._attr_device_class = field.device_class
         if field.native_unit is not None:
@@ -1194,7 +1216,7 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} {self._field.label}"
+        return self._field.label
 
     def _device_name(self) -> str:
         circuit = self._circuit()
@@ -1247,6 +1269,8 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
 
 class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
     """System-level BASV2 sensor."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1306,6 +1330,8 @@ class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
 class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
     """Per-slot remote radio sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -1324,16 +1350,18 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
         entity_category: str | None = None,
         cast_int: bool = False,
         icon: str | None = None,
+        zone_name: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._radio_device_id = radio_device_id
         self._radio_name = radio_name
+        self._zone_name = zone_name
         self._group = group
         self._instance = instance
         self._key = key
         self._cast_int = cast_int
-        self._attr_name = f"{radio_name} {label}"
+        self._attr_name = label
         self._attr_unique_id = f"{entry_id}-radio-{group:02x}-{instance:02d}-sensor-{key}"
         if device_class is not None:
             self._attr_device_class = device_class
@@ -1370,10 +1398,12 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        device_name = self._zone_name if self._zone_name else self._radio_name
         return DeviceInfo(
             identifiers={self._radio_device_id},
             manufacturer=self._manufacturer,
-            name=self._radio_name,
+            model=self._radio_name,
+            name=device_name,
         )
 
     @property
@@ -1415,6 +1445,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
 class HelianthusFM5ModeSensor(CoordinatorEntity, SensorEntity):
     """FM5 semantic mode marker."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:chip"
 
@@ -1447,6 +1478,8 @@ class HelianthusFM5ModeSensor(CoordinatorEntity, SensorEntity):
 class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
     """Solar semantic sensor values (interpreted mode only)."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -1467,7 +1500,7 @@ class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
         self._solar_device_id = solar_device_id
         self._parent_device_id = parent_device_id
         self._key = key
-        self._attr_name = f"Solar {label}"
+        self._attr_name = label
         self._attr_unique_id = f"{entry_id}-solar-sensor-{key}"
         if device_class is not None:
             self._attr_device_class = device_class
@@ -1518,6 +1551,7 @@ class HelianthusSolarSensor(CoordinatorEntity, SensorEntity):
 class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
     """Cylinder temperature sensor (interpreted mode only)."""
 
+    _attr_has_entity_name = True
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -1536,7 +1570,7 @@ class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
         self._manufacturer = manufacturer
         self._cylinder_index = cylinder_index
         self._parent_device_id = parent_device_id
-        self._attr_name = f"Cylinder {cylinder_index + 1} Temperature"
+        self._attr_name = "Temperature"
         self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-temperature"
         self._attr_entity_registry_enabled_default = self._cylinder().get("temperatureC") is not None
 
@@ -1582,6 +1616,8 @@ class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
 class HelianthusCylinderConfigSensor(CoordinatorEntity, SensorEntity):
     """Read-only cylinder configuration sensor."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -1598,7 +1634,7 @@ class HelianthusCylinderConfigSensor(CoordinatorEntity, SensorEntity):
         self._cylinder_index = cylinder_index
         self._parent_device_id = parent_device_id
         self._field = field
-        self._attr_name = f"Cylinder {cylinder_index + 1} {field['label']}"
+        self._attr_name = field['label']
         self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-config-{field['key']}"
         if field.get("native_unit") is not None:
             self._attr_native_unit_of_measurement = field["native_unit"]
@@ -1652,6 +1688,7 @@ class HelianthusCylinderConfigSensor(CoordinatorEntity, SensorEntity):
 class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
     """Zone valve position attached directly to the physical parent device."""
 
+    _attr_has_entity_name = True
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -1673,7 +1710,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
         self._zone_id = zone_id
         self._zone_name = zone_name
         self._target_device_id = target_device_id
-        self._attr_name = f"{zone_name} Valve Position"
+        self._attr_name = "Valve Position"
         self._attr_unique_id = f"{entry_id}-zone-{zone_id}-sensor-valvePositionPct"
 
     def _zone(self) -> dict[str, Any]:
@@ -1711,6 +1748,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
 class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
     """Heating demand sensor (percentage)."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -1733,7 +1771,7 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
         self._target = target
         self._target_device_id = target_device_id
         self._device_name = label if target[0] == "zone" else "Domestic Hot Water"
-        self._attr_name = f"{label} Heating Demand"
+        self._attr_name = "Heating Demand"
         self._attr_unique_id = (
             f"{entry_id}-{target[0]}-{target[1] or 'dhw'}-heating-demand"
         )
@@ -1785,6 +1823,7 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
 class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
     """DHW charging/status sensor."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:water-boiler"
 
@@ -1799,7 +1838,7 @@ class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
         self._entry_id = entry_id
         self._via_device = via_device
         self._manufacturer = manufacturer
-        self._attr_name = "Domestic Hot Water HWC Status"
+        self._attr_name = "HWC Status"
         self._attr_unique_id = f"{entry_id}-dhw-hwc-status"
 
     @property
@@ -1828,6 +1867,7 @@ class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
 class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
     """Energy total sensor (kWh)."""
 
+    _attr_has_entity_name = True
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = _SENSOR_STATE_CLASS_TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
@@ -1847,7 +1887,7 @@ class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
         self._manufacturer = manufacturer
         self._source = source
         self._usage = usage
-        self._attr_name = f"{source.capitalize()} {usage.upper()} Energy"
+        self._attr_name = f"{source.capitalize()} {usage.upper()}"
         self._attr_unique_id = f"{entry_id}-energy-{source}-{usage}"
 
     @property
@@ -1887,6 +1927,7 @@ class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
 class HelianthusAdapterInfoSensor(CoordinatorEntity, SensorEntity):
     """Adapter hardware telemetry diagnostic sensor."""
 
+    _attr_has_entity_name = True
     entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -1941,6 +1982,7 @@ class HelianthusAdapterInfoSensor(CoordinatorEntity, SensorEntity):
 class HelianthusBoilerHoursTillServiceSensor(CoordinatorEntity, SensorEntity):
     """Hours until next boiler service (B509 read-only counter)."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = _SENSOR_DEVICE_CLASS_DURATION
     _attr_native_unit_of_measurement = "h"

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -67,6 +67,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
     """Writable switch for circuit cooling mode."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:snowflake"
 
@@ -87,7 +88,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-cooling-enabled"
-        self._attr_name = f"{initial_name} Cooling Enabled"
+        self._attr_name = "Cooling Enabled"
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -100,7 +101,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} Cooling Enabled"
+        return "Cooling Enabled"
 
     def _device_name(self) -> str:
         circuit = self._circuit()
@@ -162,6 +163,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
 class HelianthusSolarSwitch(CoordinatorEntity, SwitchEntity):
     """Read-only interpreted solar config switch."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:solar-power"
 
@@ -181,7 +183,7 @@ class HelianthusSolarSwitch(CoordinatorEntity, SwitchEntity):
         self._solar_device_id = solar_device_id
         self._parent_device_id = parent_device_id
         self._key = key
-        self._attr_name = f"Solar {label}"
+        self._attr_name = label
         self._attr_unique_id = f"{entry_id}-solar-switch-{key}"
 
     @property

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -53,6 +53,25 @@ _BOILER_TEXT_FIELDS = [
 ]
 
 
+@dataclass(frozen=True)
+class InstallerMenuCodeField:
+    key: str
+    label: str
+    max_value: int
+    digits: int
+    source: str  # "system" or "boiler"
+    icon: str = "mdi:key-variant"
+
+
+_SYSTEM_MENU_CODE_FIELD = InstallerMenuCodeField(
+    key="installerMenuCode", label="Installer Menu Code", max_value=999, digits=3, source="system",
+)
+
+_BOILER_MENU_CODE_FIELD = InstallerMenuCodeField(
+    key="installerMenuCode", label="Boiler Installer Menu Code", max_value=255, digits=3, source="boiler",
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -85,6 +104,18 @@ async def async_setup_entry(
                     field=field,
                 )
             )
+        entities.append(
+            HelianthusInstallerMenuCodeText(
+                coordinator=system_coordinator,
+                entry_id=entry_id,
+                manufacturer=manufacturer,
+                client=client,
+                device_id=regulator_device_id,
+                field=_SYSTEM_MENU_CODE_FIELD,
+                mutation=_SET_SYSTEM_CONFIG_MUTATION,
+                mutation_key="setSystemConfig",
+            )
+        )
 
     if boiler_coordinator is not None and boiler_device_id is not None:
         for field in _BOILER_TEXT_FIELDS:
@@ -98,6 +129,18 @@ async def async_setup_entry(
                     field=field,
                 )
             )
+        entities.append(
+            HelianthusInstallerMenuCodeText(
+                coordinator=boiler_coordinator,
+                entry_id=entry_id,
+                manufacturer=manufacturer,
+                client=client,
+                device_id=boiler_device_id,
+                field=_BOILER_MENU_CODE_FIELD,
+                mutation=_SET_BOILER_CONFIG_MUTATION,
+                mutation_key="setBoilerConfig",
+            )
+        )
 
     async_add_entities(entities)
 
@@ -105,6 +148,7 @@ async def async_setup_entry(
 class HelianthusSystemText(CoordinatorEntity, TextEntity):
     """Writable B524 controller text field."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = TextMode.TEXT
 
@@ -167,6 +211,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
 class HelianthusBoilerText(CoordinatorEntity, TextEntity):
     """Writable B509 boiler text field."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = TextMode.TEXT
 
@@ -218,6 +263,94 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
         result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("success"):
+            await self.coordinator.async_request_refresh()
+            return
+
+        error = result.get("error", "unknown error") if isinstance(result, dict) else "unknown error"
+        raise HomeAssistantError(f"Helianthus write failed: {error}")
+
+
+class HelianthusInstallerMenuCodeText(CoordinatorEntity, TextEntity):
+    """Installer menu code as zero-padded 3-digit text field."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = TextMode.TEXT
+    _attr_entity_registry_enabled_default = False
+    _attr_native_max = 3
+    _attr_pattern = r"^\d{1,3}$"
+
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id: str,
+        manufacturer: str,
+        client: GraphQLClient | None,
+        device_id: tuple[str, str],
+        field: InstallerMenuCodeField,
+        mutation: str,
+        mutation_key: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._manufacturer = manufacturer
+        self._client = client
+        self._device_id = device_id
+        self._field = field
+        self._mutation = mutation
+        self._mutation_key = mutation_key
+        self._attr_unique_id = f"{entry_id}-{field.source}-text-{field.key}"
+        self._attr_name = field.label
+        self._attr_icon = field.icon
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={self._device_id}, manufacturer=self._manufacturer)
+
+    @property
+    def available(self) -> bool:
+        source = self._field.source
+        if source == "system":
+            return super().available and getattr(self.coordinator, "system_sensitive_available", True)
+        return super().available and getattr(self.coordinator, "boiler_sensitive_available", True)
+
+    @property
+    def native_value(self) -> str | None:
+        if self._field.source == "boiler":
+            payload = self.coordinator.data or {}
+            boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+            config = boiler_status.get("config", {}) if isinstance(boiler_status, dict) else {}
+        else:
+            payload = self.coordinator.data or {}
+            config = payload.get("config", {})
+        value = config.get(self._field.key)
+        if value is None:
+            return None
+        try:
+            return f"{int(value):0{self._field.digits}d}"
+        except (TypeError, ValueError):
+            return str(value)
+
+    async def async_set_value(self, value: str) -> None:
+        stripped = value.strip()
+        if not stripped.isdigit():
+            raise HomeAssistantError("Installer menu code must contain only digits")
+        numeric = int(stripped)
+        if numeric < 0 or numeric > self._field.max_value:
+            raise HomeAssistantError(
+                f"Value {numeric} outside allowed range [0, {self._field.max_value}]"
+            )
+        if self._client is None:
+            raise HomeAssistantError("GraphQL client is unavailable")
+
+        variables = {"field": self._field.key, "value": str(numeric)}
+        try:
+            payload = await self._client.mutation(self._mutation, variables)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
+
+        result = payload.get(self._mutation_key) if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -133,6 +133,7 @@ def _boiler_state(payload: dict[str, Any] | None) -> dict[str, Any]:
 class HelianthusBoilerDiverterValve(HelianthusReadOnlyValve):
     """Read-only diverter valve position under the Hydraulics sub-device."""
 
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -182,6 +183,8 @@ class HelianthusBoilerDiverterValve(HelianthusReadOnlyValve):
 class HelianthusCircuitMixingValve(HelianthusReadOnlyValve):
     """Read-only circuit mixing valve position."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         *,
@@ -209,7 +212,7 @@ class HelianthusCircuitMixingValve(HelianthusReadOnlyValve):
 
     @property
     def name(self) -> str | None:
-        return f"{self._device_name()} Mixing Valve"
+        return "Mixing Valve"
 
     def _device_name(self) -> str:
         circuit = self._circuit()
@@ -236,6 +239,8 @@ class HelianthusCircuitMixingValve(HelianthusReadOnlyValve):
 
 class HelianthusZoneValve(HelianthusReadOnlyValve):
     """Read-only zone valve status (0/100)."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -264,10 +269,7 @@ class HelianthusZoneValve(HelianthusReadOnlyValve):
 
     @property
     def name(self) -> str | None:
-        zone_name = self._zone().get("name")
-        if zone_name is not None and str(zone_name).strip():
-            return f"{str(zone_name).strip()} Valve"
-        return f"{self._initial_name} Valve"
+        return "Valve"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     """DHW water heater entity."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:water-boiler"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
@@ -91,7 +92,7 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._client = client
         self._regulator_bus_address = regulator_bus_address
         self._source_address = source_address
-        self._attr_name = "Domestic Hot Water"
+        self._attr_name = None
         self._attr_unique_id = f"{entry_id}-dhw"
 
     def _dhw(self) -> dict[str, Any]:
@@ -132,7 +133,7 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         return float(value) if value is not None else None
 
     @property
-    def operation_mode(self) -> str | None:
+    def current_operation(self) -> str | None:
         mode = str(self._dhw_config().get("operatingMode") or "").strip().lower()
         if mode in {"off", "auto", "manual"}:
             return mode

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -219,7 +219,7 @@ def test_zone_valve_binary_sensor_open_when_position_nonzero() -> None:
     assert len(valve_entities) == 1
     valve = valve_entities[0]
     assert valve._attr_unique_id == "entry-1-zone-zone-1-binary-valve"
-    assert valve._attr_name == "Living Room Valve"
+    assert valve._attr_name == "Valve"
     assert valve.is_on is True
 
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -129,7 +129,7 @@ def test_unique_id_dhw() -> None:
 def test_name_zone() -> None:
     program = _make_program(zone=1, hc="cooling")
     cal = _make_calendar(program, zone=1, hc="cooling")
-    assert cal._attr_name == "Zone 2 Cooling Schedule"
+    assert cal._attr_name == "Cooling Schedule"
 
 
 def test_name_dhw() -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -150,13 +150,12 @@ def test_async_setup_entry_adds_boiler_config_numbers_on_bai00() -> None:
     boiler_numbers = [
         entity for entity in entities if isinstance(entity, number_platform.HelianthusBoilerNumber)
     ]
-    assert len(boiler_numbers) == 5
+    assert len(boiler_numbers) == 4
     assert {entity._attr_name for entity in boiler_numbers} == {
         "CH Max Flow Setpoint",
         "DHW Max Flow Setpoint",
         "CH Partload",
         "DHW Partload",
-        "Boiler Installer Menu Code",
     }
     for entity in boiler_numbers:
         assert entity._attr_entity_category == number_platform.EntityCategory.CONFIG

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -187,10 +187,10 @@ def test_async_setup_entry_adds_reduced_boiler_temperature_sensors_on_bai00_only
         "entry-1-boiler-dhwStorageTemperatureC",
     }
     assert {entity._attr_name for entity in boiler_entities} == {
-        "Boiler Flow Temperature",
-        "Boiler Return Temperature",
-        "Boiler DHW Temperature",
-        "Boiler DHW Storage Temperature",
+        "Flow Temperature",
+        "Return Temperature",
+        "DHW Temperature",
+        "DHW Storage Temperature",
     }
     assert {entity.native_value for entity in boiler_entities} == {
         63.1,

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -298,7 +298,7 @@ def test_system_number_entities_write_set_system_config_mutation() -> None:
     system_numbers = [
         entity for entity in entities if isinstance(entity, number_platform.HelianthusSystemNumber)
     ]
-    assert len(system_numbers) == 6
+    assert len(system_numbers) == 5
 
     hc_bivalence = next(
         entity for entity in system_numbers if entity._field.mutation_field == "hcBivalencePointC"


### PR DESCRIPTION
## Summary
- **Fix DHW "Unknown" bug**: rename `operation_mode` → `current_operation` (HA reads `current_operation` on WaterHeaterEntity)
- **HA 2026.4 compliance**: adopt `has_entity_name = True` across all ~40 entity classes — entity names no longer include device/zone prefixes (HA prepends device name automatically)
- **UI improvements**: installer menu code as zero-padded text (017), all sliders → box mode, HWC cylinder temp conditional exposure, energy sensor naming cleanup
- **Radio device naming**: device name = zone name (e.g., "Etaj"), model = "VR92f" in device_info
- **Entity name cleanup**: strip redundant prefixes from binary sensors, sensors, calendars, fans, valves, selects, switches; climate entities get "Thermostat" suffix

## Files changed (18)
- `water_heater.py` — DHW bug fix + has_entity_name
- `number.py` — NumberMode.BOX, installer menu code removal, has_entity_name
- `text.py` — installer menu code TextEntity (zero-padded), has_entity_name
- `sensor.py` — energy naming, HWC conditional, radio zone naming, has_entity_name (~15 classes)
- `binary_sensor.py` — zone prefix removal, has_entity_name (~8 classes)
- `climate.py` — "Thermostat" suffix, shared device logic, has_entity_name
- `calendar.py`, `fan.py`, `valve.py`, `date.py`, `select.py`, `switch.py` — has_entity_name + prefix stripping
- `__init__.py` — build radio_device_zone_names reverse map
- 5 test files — assertion updates for new naming

## Test plan
- [x] `pytest tests/ -v` — 232 passed, 0 failed
- [ ] Deploy to RPi, restart HA core
- [ ] Verify entity names in HA UI (climate, energy, binary sensors, radio device)
- [ ] Verify DHW shows "manual" instead of "Unknown"
- [ ] Verify installer menu code renders as "017"
- [ ] Verify number entities show as input boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)