### PR TITLE
Migrate to snake_case GraphQL fields + unique_id migration (#183)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,13 @@ This repository is part of the **Helianthus Multi-Protocol HVAC Gateway Platform
 
 All development follows the dual-AI orchestrator protocol defined in the workspace-root [`AGENTS.md`](../AGENTS.md):
 
-- **Orchestrator:** Claude Code — orchestration, hard dev (complexity 7–10), angry tester, deep consultant
-- **Co-Pilot:** Codex — adversarial planning, easy dev (complexity 1–6), code review, second opinions
+- **Role binding:** `ORCHESTRATOR` and `CO_PILOT` are portable roles. The current workspace default is Claude as orchestrator and Codex as co-pilot, but this repo must remain swap-ready.
+- **Co-Pilot use:** Use the co-pilot only for adversarial/cooperative reasoning roles such as planner, bounded developer, reviewer, and second-opinion consultant. Do not spend Claude MCP or any equivalent co-pilot runtime on file reads, globs, grep, polling, or routine repo inspection.
+- **Fallback:** If the preferred co-pilot is unavailable, throttled, or not integrated, the active orchestrator spawns fresh-context agents on the available runtime and keeps the same supervision contract.
 - Phases: Adversarial Planning → Smart Routing → Dual Code Review
 - Hard rules: one issue/PR per repo, squash+merge only, doc-gate, transport-gate, MCP-first
 
-See the root AGENTS.md for the full protocol, routing tables, system prompts, and invariants.
+See the root AGENTS.md for the full protocol, routing tables, portable role prompts, and invariants. When running under Codex local orchestration, use the workspace-root skills `helianthus-orchestrator-supervision` and `helianthus-review-watch` as the portable supervision contract.
 
 ---
 

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -45,6 +45,125 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# --- B524 namespace: camelCase -> snake_case unique_id migration (C2) ---
+# Sorted by key length descending to prevent substring collision during replace.
+_SNAKE_CASE_UID_RENAME_MAP: list[tuple[str, str]] = [
+    ("hwcCylinderTemperatureBottom", "hwc_cylinder_temperature_bottom"),
+    ("hwcCylinderTemperatureTop", "hwc_cylinder_temperature_top"),
+    ("centralHeatingPumpActive", "central_heating_pump_active"),
+    ("diverterValvePositionPct", "diverter_valve_position_pct"),
+    ("deactivationsTemplimiter", "deactivations_templimiter"),
+    ("outdoorTemperatureAvg24h", "outdoor_temperature_avg24h"),
+    ("dhwStorageTemperatureC", "dhw_storage_temperature_c"),
+    ("circulationPumpActive", "circulation_pump_active"),
+    ("systemFlowTemperature", "system_flow_temperature"),
+    ("collectorTemperatureC", "collector_temperature_c"),
+    ("adaptiveHeatingCurve", "adaptive_heating_curve"),
+    ("centralHeatingStarts", "central_heating_starts"),
+    ("remoteControlAddress", "remote_control_address"),
+    ("ionisationVoltageUa", "ionisation_voltage_ua"),
+    ("centralHeatingHours", "central_heating_hours"),
+    ("systemWaterPressure", "system_water_pressure"),
+    ("externalPumpActive", "external_pump_active"),
+    ("returnTemperatureC", "return_temperature_c"),
+    ("storageLoadPumpPct", "storage_load_pump_pct"),
+    ("outdoorTemperature", "outdoor_temperature"),
+    ("deviceClassAddress", "device_class_address"),
+    ("hardwareIdentifier", "hardware_identifier"),
+    ("dhwBivalencePointC", "dhw_bivalence_point_c"),
+    ("maxRoomHumidityPct", "max_room_humidity_pct"),
+    ("receptionStrength", "reception_strength"),
+    ("chargeHysteresisC", "charge_hysteresis_c"),
+    ("hcBivalencePointC", "hc_bivalence_point_c"),
+    ("installerMenuCode", "installer_menu_code"),
+    ("updatesAvailable", "updates_available"),
+    ("initiatorAddress", "initiator_address"),
+    ("flowTemperatureC", "flow_temperature_c"),
+    ("deactivationsIFC", "deactivations_ifc"),
+    ("mixerPositionPct", "mixer_position_pct"),
+    ("roomTemperatureC", "room_temperature_c"),
+    ("valvePositionPct", "valve_position_pct"),
+    ("hoursTillService", "hours_till_service"),
+    ("hcEmergencyTempC", "hc_emergency_temp_c"),
+    ("firmwareVersion", "firmware_version"),
+    ("dhwTemperatureC", "dhw_temperature_c"),
+    ("roomHumidityPct", "room_humidity_pct"),
+    ("supplyVoltageMv", "supply_voltage_mv"),
+    ("busVoltageMaxDv", "bus_voltage_max_dv"),
+    ("busVoltageMinDv", "bus_voltage_min_dv"),
+    ("hwcMaxFlowTempC", "hwc_max_flow_temp_c"),
+    ("maintenanceDate", "maintenance_date"),
+    ("gasValveActive", "gas_valve_active"),
+    ("maintenanceDue", "maintenance_due"),
+    ("zoneAssignment", "zone_assignment"),
+    ("flowsetHwcMaxC", "flowset_hwc_max_c"),
+    ("installerPhone", "installer_phone"),
+    ("modulationPct", "modulation_pct"),
+    ("flowSetpointC", "flow_setpoint_c"),
+    ("calcFlowTempC", "calc_flow_temp_c"),
+    ("chargeOffsetC", "charge_offset_c"),
+    ("flowsetHcMaxC", "flowset_hc_max_c"),
+    ("partloadHwcKW", "partload_hwc_kw"),
+    ("installerName", "installer_name"),
+    ("solarEnabled", "solar_enabled"),
+    ("functionMode", "function_mode"),
+    ("circuitState", "circuit_state"),
+    ("systemScheme", "system_scheme"),
+    ("currentYield", "current_yield"),
+    ("maxSetpointC", "max_setpoint_c"),
+    ("temperatureC", "temperature_c"),
+    ("restartCount", "restart_count"),
+    ("heatingCurve", "heating_curve"),
+    ("flowTempMaxC", "flow_temp_max_c"),
+    ("flowTempMinC", "flow_temp_min_c"),
+    ("summerLimitC", "summer_limit_c"),
+    ("partloadHcKW", "partload_hc_kw"),
+    ("flameActive", "flame_active"),
+    ("fanSpeedRpm", "fan_speed_rpm"),
+    ("wifiRssiDbm", "wifi_rssi_dbm"),
+    ("phoneNumber", "phone_number"),
+    ("pumpActive", "pump_active"),
+    ("pumpStarts", "pump_starts"),
+    ("resetCause", "reset_cause"),
+    ("frostProtC", "frost_prot_c"),
+    ("pumpHours", "pump_hours"),
+    ("dhwStarts", "dhw_starts"),
+    ("dhwHours", "dhw_hours"),
+    ("fanHours", "fan_hours"),
+    ("dewPoint", "dew_point"),
+]
+
+
+def _migrate_unique_ids_to_snake_case(hass: object, entry: object) -> int:
+    """Migrate camelCase unique_ids to snake_case (B524 namespace contract).
+
+    Returns the number of entities migrated.
+    """
+    import homeassistant.helpers.entity_registry as er
+
+    registry = er.async_get(hass)
+    migrated = 0
+    for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        old_uid = entity_entry.unique_id
+        new_uid = old_uid
+        for old_key, new_key in _SNAKE_CASE_UID_RENAME_MAP:
+            new_uid = new_uid.replace(old_key, new_key)
+        if new_uid != old_uid:
+            try:
+                registry.async_update_entity(
+                    entity_entry.entity_id, new_unique_id=new_uid
+                )
+                migrated += 1
+            except Exception:
+                _LOGGER.warning(
+                    "Failed to migrate unique_id %s -> %s for %s",
+                    old_uid,
+                    new_uid,
+                    entity_entry.entity_id,
+                )
+    return migrated
+
+
 _HEX4_RE = re.compile(r"^[0-9a-fA-F]{4}$")
 _KNOWN_BUS_DISPLAY_NAMES: dict[str, str] = {
     "BASV": "sensoCOMFORT RF",
@@ -102,16 +221,16 @@ def _normalized_ebus_code(device_id: object | None) -> str:
 
 
 def _canonical_bus_display_name(device: dict) -> str | None:
-    device_id = _normalized_ebus_code(device.get("deviceId"))
+    device_id = _normalized_ebus_code(device.get("device_id"))
     known = _KNOWN_BUS_DISPLAY_NAMES.get(device_id)
     if known:
         return known
-    return _clean_label(device.get("displayName")) or _clean_label(device.get("productFamily"))
+    return _clean_label(device.get("display_name")) or _clean_label(device.get("product_family"))
 
 
 def _canonical_bus_model_name(device: dict) -> str:
-    product_model = _clean_label(device.get("productModel"))
-    device_id = _clean_label(device.get("deviceId")) or "unknown"
+    product_model = _clean_label(device.get("product_model"))
+    device_id = _clean_label(device.get("device_id")) or "unknown"
     ebus_code = _normalized_ebus_code(device_id)
     base_model = product_model or _KNOWN_BUS_MODELS.get(ebus_code) or str(device_id)
     if "(eBUS:" in base_model:
@@ -122,7 +241,7 @@ def _canonical_bus_model_name(device: dict) -> str:
 def _stable_bus_identity_model(device: dict) -> str:
     from .device_ids import stable_bus_identity_model
 
-    return stable_bus_identity_model(device.get("deviceId"), device.get("productModel"))
+    return stable_bus_identity_model(device.get("device_id"), device.get("product_model"))
 
 
 def _parse_bus_address(value: object | None) -> int | None:
@@ -378,6 +497,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
+
+    # Phase C2: migrate camelCase unique_ids to snake_case before platform setup.
+    uid_migrated = _migrate_unique_ids_to_snake_case(hass, entry)
+    if uid_migrated:
+        _LOGGER.info(
+            "Migrated %d entity unique_ids from camelCase to snake_case for entry %s",
+            uid_migrated,
+            entry.entry_id,
+        )
+
     active_entry_ids = {
         config_entry.entry_id for config_entry in hass.config_entries.async_entries(DOMAIN)
     }
@@ -524,11 +653,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await adapter_info_coordinator.async_config_entry_first_refresh()
 
     adapter_hw = adapter_info_coordinator.data
-    if isinstance(adapter_hw, dict) and adapter_hw.get("firmwareVersion"):
-        hw_id = adapter_hw.get("hardwareID") or None
+    if isinstance(adapter_hw, dict) and adapter_hw.get("firmware_version"):
+        hw_id = adapter_hw.get("hardware_id") or None
         device_registry.async_update_device(
             adapter_device_entry.id,
-            sw_version=adapter_hw["firmwareVersion"],
+            sw_version=adapter_hw["firmware_version"],
             hw_version=hw_id,
             serial_number=hw_id,
         )
@@ -548,20 +677,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:
             return None
-        model = stable_bus_identity_model(device.get("deviceId"), device.get("productModel"))
+        model = stable_bus_identity_model(device.get("device_id"), device.get("product_model"))
         return build_bus_device_key(
             model=model,
             address=address,
-            serial_number=_clean_label(device.get("serialNumber")),
-            mac_address=_clean_label(device.get("macAddress")),
-            hardware_version=_clean_label(device.get("hardwareVersion")),
-            software_version=_clean_label(device.get("softwareVersion")),
+            serial_number=_clean_label(device.get("serial_number")),
+            mac_address=_clean_label(device.get("mac_address")),
+            hardware_version=_clean_label(device.get("hardware_version")),
+            software_version=_clean_label(device.get("software_version")),
         )
 
     def is_regulator_device(device: dict) -> bool:
-        device_id = str(device.get("deviceId") or "").upper()
-        display_name = str(device.get("displayName") or "").upper()
-        product_family = str(device.get("productFamily") or "").upper()
+        device_id = str(device.get("device_id") or "").upper()
+        display_name = str(device.get("display_name") or "").upper()
+        product_family = str(device.get("product_family") or "").upper()
         return bool(
             device_id.startswith("BASV")
             or device_id.startswith("VRC")
@@ -590,10 +719,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return None
 
     def radio_model_name(device: dict) -> str:
-        model = _clean_label(device.get("deviceModel"))
+        model = _clean_label(device.get("device_model"))
         if model:
             return model
-        class_address = parse_optional_int(device.get("deviceClassAddress"))
+        class_address = parse_optional_int(device.get("device_class_address"))
         if class_address == 0x15:
             return "VRC720f/2"
         if class_address == 0x35:
@@ -646,11 +775,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     vr71_device: tuple[str, str] | None = None
     for device in devices:
         address = resolve_bus_address(device.get("address"), device.get("addresses"))
-        device_id = device.get("deviceId", "unknown")
-        serial_number = device.get("serialNumber")
+        device_id = device.get("device_id", "unknown")
+        serial_number = device.get("serial_number")
         manufacturer = _clean_label(device.get("manufacturer")) or "Unknown"
-        sw_version = device.get("softwareVersion")
-        hw_version = device.get("hardwareVersion")
+        sw_version = device.get("software_version")
+        hw_version = device.get("hardware_version")
         display_name = _canonical_bus_display_name(device)
 
         if address is None:
@@ -731,7 +860,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 break
 
     radio_payload = radio_coordinator.data or {}
-    radio_devices_payload = radio_payload.get("radioDevices")
+    radio_devices_payload = radio_payload.get("radio_devices")
     if not isinstance(radio_devices_payload, list):
         radio_devices_payload = []
 
@@ -746,7 +875,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         group = parse_optional_int(device.get("group"))
         if group != _B524_FUNCTION_MODULE_GROUP:
             continue
-        class_addr = parse_optional_int(device.get("deviceClassAddress"))
+        class_addr = parse_optional_int(device.get("device_class_address"))
         if class_addr is None:
             continue
         bus_device_id = bus_address_device_ids.get(class_addr)
@@ -755,7 +884,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         inst = parse_optional_int(device.get("instance"))
         if inst is None:
             continue
-        bus_key = str(device.get("radioBusKey") or "").strip()
+        bus_key = str(device.get("radio_bus_key") or "").strip()
         if not bus_key:
             bus_key = build_radio_bus_key(group, inst)
         b524_merge_targets[bus_key] = bus_device_id
@@ -773,7 +902,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         instance = parse_optional_int(device.get("instance"))
         if group is None or instance is None:
             continue
-        bus_key = str(device.get("radioBusKey") or "").strip()
+        bus_key = str(device.get("radio_bus_key") or "").strip()
         if not bus_key:
             bus_key = build_radio_bus_key(group, instance)
         known_radio_bus_keys.add(bus_key)
@@ -791,10 +920,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         }
         if radio_parent is not None:
             device_kwargs["via_device"] = radio_parent
-        sw_version = radio_firmware_display(device.get("firmwareVersion"))
+        sw_version = radio_firmware_display(device.get("firmware_version"))
         if sw_version:
             device_kwargs["sw_version"] = sw_version
-        hardware_identifier = parse_optional_int(device.get("hardwareIdentifier"))
+        hardware_identifier = parse_optional_int(device.get("hardware_identifier"))
         if hardware_identifier is not None and hardware_identifier >= 0:
             device_kwargs["hw_version"] = f"0x{hardware_identifier:04X}"
         device_registry.async_get_or_create(**device_kwargs)
@@ -809,14 +938,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if index is None:
             continue
         known_circuit_indexes.add(index)
-        circuit_type_name = circuit_type_display_name(circuit.get("circuitType"))
+        circuit_type_name = circuit_type_display_name(circuit.get("circuit_type"))
         managing_device = managing_device_identifier(
             group=0x02,
             instance=index,
             regulator_device_id=regulator_device,
             vr71_device_id=vr71_device,
             adapter_device_id=adapter_device_id,
-            managing_device=circuit.get("managingDevice"),
+            managing_device=circuit.get("managing_device"),
         )
         circuit_device_id = circuit_identifier(entry.entry_id, index)
         device_kwargs: dict[str, object] = {
@@ -831,7 +960,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_registry.async_get_or_create(**device_kwargs)
 
     fm5_payload = fm5_coordinator.data or {}
-    known_fm5_mode = str(fm5_payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    known_fm5_mode = str(fm5_payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
     known_cylinder_indexes: set[int] = set()
     for cylinder in fm5_payload.get("cylinders", []) or []:
         if not isinstance(cylinder, dict):
@@ -841,7 +970,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             known_cylinder_indexes.add(index)
 
     daemon_data = status_coordinator.data.get("daemon", {}) if status_coordinator.data else {}
-    daemon_source_addr = _parse_bus_address(daemon_data.get("initiatorAddress"))
+    daemon_source_addr = _parse_bus_address(daemon_data.get("initiator_address"))
 
     semantic = semantic_coordinator.data or {}
     semantic_zones = [
@@ -875,14 +1004,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return payload if isinstance(payload, dict) else {}
 
     def _current_fm5_mode() -> str:
-        return str(_current_fm5_payload().get("fm5SemanticMode") or "ABSENT").strip().upper()
+        return str(_current_fm5_payload().get("fm5_semantic_mode") or "ABSENT").strip().upper()
 
     def _current_radio_slots_with_live_values() -> dict[tuple[int, int], set[str]]:
         payload = radio_coordinator.data if radio_coordinator else None
         if not isinstance(payload, dict):
             return {}
         out: dict[tuple[int, int], set[str]] = {}
-        for radio in payload.get("radioDevices", []) or []:
+        for radio in payload.get("radio_devices", []) or []:
             if not isinstance(radio, dict):
                 continue
             group = parse_optional_int(radio.get("group"))
@@ -938,7 +1067,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_key = cylinder_match.group("config_key")
             if config_key:
                 return config_key in live_keys
-            return "temperatureC" in live_keys
+            return "temperature_c" in live_keys
         return False
 
     # ADR-027: build set of merged B524 slot prefixes for entity cleanup.
@@ -1237,10 +1366,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def handle_radio_update() -> None:
         payload = radio_coordinator.data or {}
         current_keys: set[str] = set()
-        for radio in payload.get("radioDevices", []) or []:
+        for radio in payload.get("radio_devices", []) or []:
             if not isinstance(radio, dict):
                 continue
-            key = str(radio.get("radioBusKey") or "").strip()
+            key = str(radio.get("radio_bus_key") or "").strip()
             if key:
                 current_keys.add(key)
                 continue
@@ -1262,7 +1391,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def handle_fm5_update() -> None:
         payload = fm5_coordinator.data or {}
-        mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+        mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
         current_indexes: set[int] = set()
         for cylinder in payload.get("cylinders", []) or []:
             if not isinstance(cylinder, dict):

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -58,7 +58,7 @@ def _radio_bus_key(device: dict[str, Any]) -> str | None:
     slot = _radio_slot(device)
     if slot is None:
         return None
-    explicit = str(device.get("radioBusKey") or "").strip()
+    explicit = str(device.get("radio_bus_key") or "").strip()
     if explicit:
         return explicit
     return build_radio_bus_key(slot[0], slot[1])
@@ -119,7 +119,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         if normalized_zone_id is None:
             continue
         config = zone.get("config")
-        mapping = _parse_optional_int(config.get("roomTemperatureZoneMapping")) if isinstance(config, dict) else None
+        mapping = _parse_optional_int(config.get("room_temperature_zone_mapping")) if isinstance(config, dict) else None
         zone_name = str(zone.get("name") or f"Zone {zone_id}")
         parent_device_id = zone_parent_device_ids.get(normalized_zone_id)
         if parent_device_id is None:
@@ -180,11 +180,11 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     if boiler_coordinator and boiler_device_id:
         for key, label in [
-            ("flameActive", "Burner Flame Active"),
-            ("gasValveActive", "Burner Gas Valve Active"),
-            ("centralHeatingPumpActive", "Hydraulics CH Pump"),
-            ("externalPumpActive", "Hydraulics External Pump"),
-            ("circulationPumpActive", "Hydraulics Circulation Pump"),
+            ("flame_active", "Burner Flame Active"),
+            ("gas_valve_active", "Burner Gas Valve Active"),
+            ("central_heating_pump_active", "Hydraulics CH Pump"),
+            ("external_pump_active", "Hydraulics External Pump"),
+            ("circulation_pump_active", "Hydraulics Circulation Pump"),
         ]:
             entities.append(
                 HelianthusBoilerStateBinarySensor(
@@ -204,7 +204,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             circuit_index = _parse_optional_int(circuit.get("index"))
             if circuit_index is None or circuit_index < 0:
                 continue
-            circuit_type = str(circuit.get("circuitType") or "").strip().lower()
+            circuit_type = str(circuit.get("circuit_type") or "").strip().lower()
             label = circuit_type.replace("_", " ").title() if circuit_type else f"Circuit {circuit_index + 1}"
             entities.append(
                 HelianthusCircuitPumpBinarySensor(
@@ -218,14 +218,14 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     if fm5_coordinator and isinstance(fm5_coordinator.data, dict):
         payload = fm5_coordinator.data
-        mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+        mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
         solar = payload.get("solar") if isinstance(payload.get("solar"), dict) else None
         if mode == "INTERPRETED":
             solar_device_id = data.get("solar_device_id") or solar_identifier(entry.entry_id)
             for key, label in [
-                ("pumpActive", "Solar Pump Active"),
-                ("solarEnabled", "Solar Enabled"),
-                ("functionMode", "Solar Function Mode"),
+                ("pump_active", "Solar Pump Active"),
+                ("solar_enabled", "Solar Enabled"),
+                ("function_mode", "Solar Function Mode"),
             ]:
                 entities.append(
                     HelianthusSolarBinarySensor(
@@ -249,7 +249,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     manufacturer=manufacturer,
                     regulator_device_id=regulator_device_id,
                     source="state",
-                    key="maintenanceDue",
+                    key="maintenance_due",
                     label="Maintenance Due",
                     device_class=_BINARY_SENSOR_DEVICE_CLASS_PROBLEM,
                     entity_category=EntityCategory.DIAGNOSTIC,
@@ -260,7 +260,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     manufacturer=manufacturer,
                     regulator_device_id=regulator_device_id,
                     source="config",
-                    key="adaptiveHeatingCurve",
+                    key="adaptive_heating_curve",
                     label="Adaptive Heating Curve",
                     device_class=None,
                     entity_category=EntityCategory.DIAGNOSTIC,
@@ -269,7 +269,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         )
 
     if radio_coordinator and radio_coordinator.data:
-        for radio in radio_coordinator.data.get("radioDevices", []) or []:
+        for radio in radio_coordinator.data.get("radio_devices", []) or []:
             if not isinstance(radio, dict):
                 continue
             slot = _radio_slot(radio)
@@ -402,11 +402,11 @@ class HelianthusBoilerStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = label
         self._attr_unique_id = f"{entry_id}-boiler-binary-{key}"
         _BOILER_STATE_ICONS: dict[str, str] = {
-            "flameActive": "mdi:fire",
-            "gasValveActive": "mdi:gas-cylinder",
-            "centralHeatingPumpActive": "mdi:pump",
-            "externalPumpActive": "mdi:pump",
-            "circulationPumpActive": "mdi:pump",
+            "flame_active": "mdi:fire",
+            "gas_valve_active": "mdi:gas-cylinder",
+            "central_heating_pump_active": "mdi:pump",
+            "external_pump_active": "mdi:pump",
+            "circulation_pump_active": "mdi:pump",
         }
         boiler_icon = _BOILER_STATE_ICONS.get(key)
         if boiler_icon is not None:
@@ -422,7 +422,7 @@ class HelianthusBoilerStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") or {}
+        boiler_status = payload.get("boiler_status") or {}
         state = boiler_status.get("state") if isinstance(boiler_status, dict) else {}
         value = state.get(self._key) if isinstance(state, dict) else None
         if isinstance(value, bool):
@@ -452,7 +452,7 @@ class HelianthusCircuitPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._attr_name = "Pump Active"
-        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-binary-pumpActive"
+        self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-binary-pump_active"
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -474,7 +474,7 @@ class HelianthusCircuitPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         circuit = self._circuit()
         state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
-        value = state.get("pumpActive") if isinstance(state, dict) else None
+        value = state.get("pump_active") if isinstance(state, dict) else None
         if isinstance(value, bool):
             return value
         return None
@@ -507,9 +507,9 @@ class HelianthusSolarBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_unique_id = f"{entry_id}-solar-binary-{key}"
         self._attr_entity_registry_enabled_default = enabled_by_default
         _SOLAR_ICONS: dict[str, str] = {
-            "pumpActive": "mdi:pump",
-            "solarEnabled": "mdi:solar-power",
-            "functionMode": "mdi:solar-panel",
+            "pump_active": "mdi:pump",
+            "solar_enabled": "mdi:solar-power",
+            "function_mode": "mdi:solar-panel",
         }
         solar_icon = _SOLAR_ICONS.get(key)
         if solar_icon is not None:
@@ -518,7 +518,7 @@ class HelianthusSolarBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def available(self) -> bool:
         payload = self.coordinator.data if isinstance(self.coordinator.data, dict) else None
-        return str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper() == "INTERPRETED" if isinstance(payload, dict) else False
+        return str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper() == "INTERPRETED" if isinstance(payload, dict) else False
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -569,9 +569,9 @@ class HelianthusBoilerPumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") or {}
+        boiler_status = payload.get("boiler_status") or {}
         state = boiler_status.get("state") or {}
-        value = state.get("centralHeatingPumpActive")
+        value = state.get("central_heating_pump_active")
         if isinstance(value, bool):
             return value
         return None
@@ -607,7 +607,7 @@ class HelianthusSystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
         if entity_category is not None:
             self._attr_entity_category = entity_category
         _SYSTEM_BINARY_ICONS: dict[str, str] = {
-            "adaptiveHeatingCurve": "mdi:chart-bell-curve-cumulative",
+            "adaptive_heating_curve": "mdi:chart-bell-curve-cumulative",
         }
         system_icon = _SYSTEM_BINARY_ICONS.get(key)
         if system_icon is not None:
@@ -660,7 +660,7 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
 
     def _device(self) -> dict[str, Any] | None:
         payload = self.coordinator.data or {}
-        for device in payload.get("radioDevices", []) or []:
+        for device in payload.get("radio_devices", []) or []:
             if not isinstance(device, dict):
                 continue
             if _radio_slot(device) == (self._group, self._instance):
@@ -672,7 +672,7 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
         device = self._device()
         if device is None:
             return False
-        stale = _parse_optional_int(device.get("staleCycles")) or 0
+        stale = _parse_optional_int(device.get("stale_cycles")) or 0
         return stale < _RADIO_STALE_GRACE_CYCLES
 
     @property
@@ -687,7 +687,7 @@ class HelianthusRadioConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity
         device = self._device()
         if not isinstance(device, dict):
             return None
-        value = device.get("deviceConnected")
+        value = device.get("device_connected")
         if isinstance(value, bool):
             return value
         return None
@@ -740,7 +740,7 @@ class HelianthusZoneValveBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         zone = self._zone()
         state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
-        value = state.get("valvePositionPct") if isinstance(state, dict) else None
+        value = state.get("valve_position_pct") if isinstance(state, dict) else None
         if value is None:
             return None
         try:

--- a/custom_components/helianthus/calendar.py
+++ b/custom_components/helianthus/calendar.py
@@ -196,11 +196,11 @@ class HelianthusScheduleCalendar(CoordinatorEntity, CalendarEntity):
     def _make_event(
         self, slot: dict[str, Any], day: date
     ) -> CalendarEvent | None:
-        start_h = slot.get("startHour", 0)
-        start_m = slot.get("startMinute", 0)
-        end_h = slot.get("endHour", 0)
-        end_m = slot.get("endMinute", 0)
-        temp_c = slot.get("temperatureC")
+        start_h = slot.get("start_hour", 0)
+        start_m = slot.get("start_minute", 0)
+        end_h = slot.get("end_hour", 0)
+        end_m = slot.get("end_minute", 0)
+        temp_c = slot.get("temperature_c")
 
         tz = dt_util.DEFAULT_TIME_ZONE
         start_dt = datetime.combine(day, datetime.min.time().replace(

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -145,7 +145,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         if zone_id is None:
             continue
         config = zone.get("config")
-        mapping = _parse_optional_int(config.get("roomTemperatureZoneMapping")) if isinstance(config, dict) else None
+        mapping = _parse_optional_int(config.get("room_temperature_zone_mapping")) if isinstance(config, dict) else None
         target_device_id = zone_parent_device_ids.get(zone_id)
         if target_device_id is None:
             if mapping in (1, 2, 3, 4):
@@ -250,12 +250,12 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         return self._zone().get("config") or {}
 
     def _room_temperature_zone_mapping(self) -> int | None:
-        return _parse_optional_int(self._zone_config().get("roomTemperatureZoneMapping"))
+        return _parse_optional_int(self._zone_config().get("room_temperature_zone_mapping"))
 
     def _radio_zone_candidates(self) -> dict[int, list[dict[str, Any]]]:
         if self._radio_coordinator is None or not isinstance(self._radio_coordinator.data, dict):
             return {}
-        raw_candidates = self._radio_coordinator.data.get("radioZoneCandidates")
+        raw_candidates = self._radio_coordinator.data.get("radio_zone_candidates")
         if not isinstance(raw_candidates, dict):
             return {}
         out: dict[int, list[dict[str, Any]]] = {}
@@ -279,7 +279,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     def _radio_devices(self) -> list[dict[str, Any]]:
         if self._radio_coordinator is None or not isinstance(self._radio_coordinator.data, dict):
             return []
-        items = self._radio_coordinator.data.get("radioDevices")
+        items = self._radio_coordinator.data.get("radio_devices")
         if not isinstance(items, list):
             return []
         return [item for item in items if isinstance(item, dict)]
@@ -291,7 +291,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
             instance = _parse_optional_int(device.get("instance"))
             if group is None or instance is None:
                 continue
-            bus_key = str(device.get("radioBusKey") or "").strip()
+            bus_key = str(device.get("radio_bus_key") or "").strip()
             if not bus_key:
                 bus_key = build_radio_bus_key(group, instance)
             out[(group, instance)] = radio_device_identifier(self._entry_id, bus_key)
@@ -304,8 +304,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
             instance = _parse_optional_int(device.get("instance"))
             if group is None or instance is None:
                 continue
-            model = str(device.get("deviceModel") or "").strip()
-            class_address = _parse_optional_int(device.get("deviceClassAddress"))
+            model = str(device.get("device_model") or "").strip()
+            class_address = _parse_optional_int(device.get("device_class_address"))
             if not model:
                 if class_address == 0x15:
                     model = "VRC720f/2"
@@ -332,7 +332,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode | None:
-        mode = str(self._zone_config().get("operatingMode") or "").strip().lower()
+        mode = str(self._zone_config().get("operating_mode") or "").strip().lower()
         if not mode:
             return None
         return OPERATING_MODE_MAP.get(mode, HVACMode.AUTO)
@@ -340,7 +340,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     @property
     def hvac_modes(self) -> list[HVACMode]:
         supported: list[HVACMode] = []
-        for token in normalize_allowed_mode_tokens(self._zone_config().get("allowedModes")):
+        for token in normalize_allowed_mode_tokens(self._zone_config().get("allowed_modes")):
             mapped = OPERATING_MODE_MAP.get(token)
             if mapped is not None and mapped not in supported:
                 supported.append(mapped)
@@ -358,17 +358,17 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        value = self._zone_state().get("currentTempC")
+        value = self._zone_state().get("current_temp_c")
         return float(value) if value is not None else None
 
     @property
     def target_temperature(self) -> float | None:
-        value = self._zone_config().get("targetTempC")
+        value = self._zone_config().get("target_temp_c")
         return float(value) if value is not None else None
 
     @property
     def current_humidity(self) -> float | None:
-        value = self._zone_state().get("currentHumidityPct")
+        value = self._zone_state().get("current_humidity_pct")
         return float(value) if value is not None else None
 
     @property
@@ -377,15 +377,15 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         state = self._zone_state()
         config = self._zone_config()
         mapping = self._room_temperature_zone_mapping()
-        demand = state.get("heatingDemandPct")
+        demand = state.get("heating_demand_pct")
         if demand is not None:
             attrs["heating_demand_pct"] = demand
         for field, source, key in [
-            ("hvac_action", state, "hvacAction"),
-            ("special_function", state, "specialFunction"),
-            ("valve_position_pct", state, "valvePositionPct"),
-            ("circuit_type", config, "circuitType"),
-            ("associated_circuit", config, "associatedCircuit"),
+            ("hvac_action", state, "hvac_action"),
+            ("special_function", state, "special_function"),
+            ("valve_position_pct", state, "valve_position_pct"),
+            ("circuit_type", config, "circuit_type"),
+            ("associated_circuit", config, "associated_circuit"),
         ]:
             value = source.get(key)
             if value is not None and str(value).strip() != "":
@@ -399,15 +399,15 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         )
 
         for field, key in [
-            ("quick_veto", "quickVeto"),
-            ("quick_veto_setpoint_c", "quickVetoSetpoint"),
-            ("quick_veto_duration_h", "quickVetoDuration"),
-            ("quick_veto_expiry", "quickVetoExpiry"),
-            ("holiday_start_date", "holidayStartDate"),
-            ("holiday_end_date", "holidayEndDate"),
-            ("holiday_setpoint_c", "holidaySetpoint"),
-            ("holiday_start_time", "holidayStartTime"),
-            ("holiday_end_time", "holidayEndTime"),
+            ("quick_veto", "quick_veto"),
+            ("quick_veto_setpoint_c", "quick_veto_setpoint"),
+            ("quick_veto_duration_h", "quick_veto_duration"),
+            ("quick_veto_expiry", "quick_veto_expiry"),
+            ("holiday_start_date", "holiday_start_date"),
+            ("holiday_end_date", "holiday_end_date"),
+            ("holiday_setpoint_c", "holiday_setpoint"),
+            ("holiday_start_time", "holiday_start_time"),
+            ("holiday_end_time", "holiday_end_time"),
         ]:
             value = config.get(key)
             if value is not None:
@@ -476,9 +476,9 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
     async def _activate_quick_veto(self) -> None:
         """Activate quick veto with the current target temperature and default duration."""
         config = self._zone_config()
-        temp = config.get("targetTempC")
+        temp = config.get("target_temp_c")
         if temp is None:
-            temp = config.get("quickVetoSetpoint")
+            temp = config.get("quick_veto_setpoint")
         if temp is None:
             temp = 20.0
         temp = max(5.0, min(30.0, float(temp)))
@@ -495,7 +495,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         the window where the controller sees a partial holiday state.
         """
         config = self._zone_config()
-        setpoint = config.get("holidaySetpoint")
+        setpoint = config.get("holiday_setpoint")
         if setpoint is None:
             setpoint = 10.0
         setpoint = max(5.0, min(30.0, float(setpoint)))
@@ -518,7 +518,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         """
         config = self._zone_config()
         has_holiday_dates = bool(
-            config.get("holidayStartDate") or config.get("holidayEndDate")
+            config.get("holiday_start_date") or config.get("holiday_end_date")
         )
         if self.preset_mode != "away" and not has_holiday_dates:
             return

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -20,15 +20,15 @@ query Devices {
     address
     addresses
     manufacturer
-    deviceId
-    displayName
-    productFamily
-    productModel
-    partNumber
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    display_name
+    product_family
+    product_model
+    part_number
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -39,14 +39,14 @@ query Devices {
     address
     addresses
     manufacturer
-    deviceId
-    displayName
-    productFamily
-    productModel
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    display_name
+    product_family
+    product_model
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -56,15 +56,15 @@ query Devices {
   devices {
     address
     manufacturer
-    deviceId
-    displayName
-    productFamily
-    productModel
-    partNumber
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    display_name
+    product_family
+    product_model
+    part_number
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -74,14 +74,14 @@ query Devices {
   devices {
     address
     manufacturer
-    deviceId
-    displayName
-    productFamily
-    productModel
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    display_name
+    product_family
+    product_model
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -92,11 +92,11 @@ query Devices {
     address
     addresses
     manufacturer
-    deviceId
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -106,11 +106,11 @@ query Devices {
   devices {
     address
     manufacturer
-    deviceId
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -121,9 +121,9 @@ query Devices {
     address
     addresses
     manufacturer
-    deviceId
-    softwareVersion
-    hardwareVersion
+    device_id
+    software_version
+    hardware_version
   }
 }
 """
@@ -133,40 +133,40 @@ query Devices {
   devices {
     address
     manufacturer
-    deviceId
-    softwareVersion
-    hardwareVersion
+    device_id
+    software_version
+    hardware_version
   }
 }
 """
 
 QUERY_STATUS = """
 query Status {
-  daemonStatus {
+  daemon_status {
     status
-    firmwareVersion
-    updatesAvailable
-    initiatorAddress
+    firmware_version
+    updates_available
+    initiator_address
   }
-  adapterStatus {
+  adapter_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
 }
 """
 
 QUERY_STATUS_LEGACY = """
 query Status {
-  daemonStatus {
+  daemon_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
-  adapterStatus {
+  adapter_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
 }
 """
@@ -177,44 +177,44 @@ query Semantic {
     id
     name
     state {
-      currentTempC
-      currentHumidityPct
-      hvacAction
-      specialFunction
-      heatingDemandPct
-      valvePositionPct
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      allowedModes
-      circuitType
-      associatedCircuit
-      roomTemperatureZoneMapping
-      quickVeto
-      quickVetoSetpoint
-      quickVetoDuration
-      quickVetoExpiry
-      holidayStartDate
-      holidayEndDate
-      holidaySetpoint
-      holidayStartTime
-      holidayEndTime
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
+      room_temperature_zone_mapping
+      quick_veto
+      quick_veto_setpoint
+      quick_veto_duration
+      quick_veto_expiry
+      holiday_start_date
+      holiday_end_date
+      holiday_setpoint
+      holiday_start_time
+      holiday_end_time
     }
   }
   dhw {
     state {
-      currentTempC
-      specialFunction
-      heatingDemandPct
+      current_temp_c
+      special_function
+      heating_demand_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      holidayStartDate
-      holidayEndDate
+      target_temp_c
+      holiday_start_date
+      holiday_end_date
     }
   }
 }
@@ -226,37 +226,37 @@ query Semantic {
     id
     name
     state {
-      currentTempC
-      currentHumidityPct
-      hvacAction
-      specialFunction
-      heatingDemandPct
-      valvePositionPct
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      allowedModes
-      circuitType
-      associatedCircuit
-      roomTemperatureZoneMapping
-      quickVeto
-      quickVetoSetpoint
-      quickVetoDuration
-      quickVetoExpiry
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
+      room_temperature_zone_mapping
+      quick_veto
+      quick_veto_setpoint
+      quick_veto_duration
+      quick_veto_expiry
     }
   }
   dhw {
     state {
-      currentTempC
-      specialFunction
-      heatingDemandPct
+      current_temp_c
+      special_function
+      heating_demand_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
+      target_temp_c
     }
   }
 }
@@ -268,33 +268,33 @@ query Semantic {
     id
     name
     state {
-      currentTempC
-      currentHumidityPct
-      hvacAction
-      specialFunction
-      heatingDemandPct
-      valvePositionPct
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      allowedModes
-      circuitType
-      associatedCircuit
-      roomTemperatureZoneMapping
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
+      room_temperature_zone_mapping
     }
   }
   dhw {
     state {
-      currentTempC
-      specialFunction
-      heatingDemandPct
+      current_temp_c
+      special_function
+      heating_demand_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
+      target_temp_c
     }
   }
 }
@@ -306,72 +306,72 @@ query Semantic {
     id
     name
     state {
-      currentTempC
-      currentHumidityPct
-      hvacAction
-      specialFunction
-      heatingDemandPct
-      valvePositionPct
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      allowedModes
-      circuitType
-      associatedCircuit
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
     }
   }
   dhw {
     state {
-      currentTempC
-      specialFunction
-      heatingDemandPct
+      current_temp_c
+      special_function
+      heating_demand_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
+      target_temp_c
     }
   }
 }
 """
 
-_HOLIDAY_FIELDS = ["holidayStartDate", "holidayEndDate", "holidaySetpoint", "holidayStartTime", "holidayEndTime"]
-_QV_FIELDS = ["quickVeto", "quickVetoSetpoint", "quickVetoDuration", "quickVetoExpiry"]
-_SEMANTIC_RECOVERABLE_FIELDS = _HOLIDAY_FIELDS + _QV_FIELDS + ["roomTemperatureZoneMapping"]
+_HOLIDAY_FIELDS = ["holiday_start_date", "holiday_end_date", "holiday_setpoint", "holiday_start_time", "holiday_end_time"]
+_QV_FIELDS = ["quick_veto", "quick_veto_setpoint", "quick_veto_duration", "quick_veto_expiry"]
+_SEMANTIC_RECOVERABLE_FIELDS = _HOLIDAY_FIELDS + _QV_FIELDS + ["room_temperature_zone_mapping"]
 
 QUERY_CIRCUITS = """
 query Circuits {
   circuits {
     index
-    circuitType
-    hasMixer
-    managingDevice {
+    circuit_type
+    has_mixer
+    managing_device {
       role
-      deviceId
+      device_id
       address
     }
     state {
-      pumpActive
-      mixerPositionPct
-      flowTemperatureC
-      flowSetpointC
-      calcFlowTempC
-      circuitState
+      pump_active
+      mixer_position_pct
+      flow_temperature_c
+      flow_setpoint_c
+      calc_flow_temp_c
+      circuit_state
       humidity
-      dewPoint
-      pumpHours
-      pumpStarts
+      dew_point
+      pump_hours
+      pump_starts
     }
     config {
-      heatingCurve
-      flowTempMaxC
-      flowTempMinC
-      summerLimitC
-      frostProtC
-      roomTempControl
-      coolingEnabled
+      heating_curve
+      flow_temp_max_c
+      flow_temp_min_c
+      summer_limit_c
+      frost_prot_c
+      room_temp_control
+      cooling_enabled
     }
   }
 }
@@ -379,43 +379,43 @@ query Circuits {
 
 QUERY_RADIO_DEVICES = """
 query RadioDevices {
-  radioDevices {
+  radio_devices {
     group
     instance
-    slotMode
-    deviceConnected
-    deviceClassAddress
-    deviceModel
-    firmwareVersion
-    hardwareIdentifier
-    remoteControlAddress
-    devicePaired
-    receptionStrength
-    zoneAssignment
-    roomTemperatureC
-    roomHumidityPct
+    slot_mode
+    device_connected
+    device_class_address
+    device_model
+    firmware_version
+    hardware_identifier
+    remote_control_address
+    device_paired
+    reception_strength
+    zone_assignment
+    room_temperature_c
+    room_humidity_pct
   }
 }
 """
 
 QUERY_FM5 = """
 query FM5Semantic {
-  fm5SemanticMode
+  fm5_semantic_mode
   solar {
-    collectorTemperatureC
-    returnTemperatureC
-    pumpActive
-    currentYield
-    pumpHours
-    solarEnabled
-    functionMode
+    collector_temperature_c
+    return_temperature_c
+    pump_active
+    current_yield
+    pump_hours
+    solar_enabled
+    function_mode
   }
   cylinders {
     index
-    temperatureC
-    maxSetpointC
-    chargeHysteresisC
-    chargeOffsetC
+    temperature_c
+    max_setpoint_c
+    charge_hysteresis_c
+    charge_offset_c
   }
 }
 """
@@ -424,25 +424,25 @@ QUERY_SYSTEM = """
 query System {
   system {
     state {
-      systemWaterPressure
-      systemFlowTemperature
-      outdoorTemperature
-      outdoorTemperatureAvg24h
-      maintenanceDue
-      hwcCylinderTemperatureTop
-      hwcCylinderTemperatureBottom
+      system_water_pressure
+      system_flow_temperature
+      outdoor_temperature
+      outdoor_temperature_avg24h
+      maintenance_due
+      hwc_cylinder_temperature_top
+      hwc_cylinder_temperature_bottom
     }
     config {
-      adaptiveHeatingCurve
-      heatingCircuitBivalencePoint
-      dhwBivalencePoint
-      hcEmergencyTemperature
-      hwcMaxFlowTempDesired
-      maxRoomHumidity
+      adaptive_heating_curve
+      heating_circuit_bivalence_point
+      dhw_bivalence_point
+      hc_emergency_temperature
+      hwc_max_flow_temp_desired
+      max_room_humidity
     }
     properties {
-      systemScheme
-      moduleConfigurationVR71
+      system_scheme
+      module_configuration_vr71
     }
   }
 }
@@ -450,7 +450,7 @@ query System {
 
 QUERY_ENERGY = """
 query Energy {
-  energyTotals {
+  energy_totals {
     gas { dhw { today yearly monthly } climate { today yearly monthly } }
     electric { dhw { today yearly monthly } climate { today yearly monthly } }
     solar { dhw { today yearly monthly } climate { today yearly monthly } }
@@ -460,7 +460,7 @@ query Energy {
 
 QUERY_ENERGY_LEGACY = """
 query Energy {
-  energyTotals {
+  energy_totals {
     gas { dhw { today yearly } climate { today yearly } }
     electric { dhw { today yearly } climate { today yearly } }
     solar { dhw { today yearly } climate { today yearly } }
@@ -470,37 +470,37 @@ query Energy {
 
 QUERY_BOILER = """
 query BoilerStatus {
-  boilerStatus {
+  boiler_status {
     state {
-      flowTemperatureC
-      returnTemperatureC
-      centralHeatingPumpActive
-      flameActive
-      modulationPct
-      gasValveActive
-      fanSpeedRpm
-      ionisationVoltageUa
-      externalPumpActive
-      circulationPumpActive
-      storageLoadPumpPct
-      diverterValvePositionPct
+      flow_temperature_c
+      return_temperature_c
+      central_heating_pump_active
+      flame_active
+      modulation_pct
+      gas_valve_active
+      fan_speed_rpm
+      ionisation_voltage_ua
+      external_pump_active
+      circulation_pump_active
+      storage_load_pump_pct
+      diverter_valve_position_pct
     }
     config {
-      flowsetHcMaxC
-      flowsetHwcMaxC
-      partloadHcKW
-      partloadHwcKW
+      flowset_hc_max_c
+      flowset_hwc_max_c
+      partload_hc_kw
+      partload_hwc_kw
     }
     diagnostics {
-      heatingStatusRaw
-      centralHeatingHours
-      dhwHours
-      centralHeatingStarts
-      dhwStarts
-      pumpHours
-      fanHours
-      deactivationsIFC
-      deactivationsTemplimiter
+      heating_status_raw
+      central_heating_hours
+      dhw_hours
+      central_heating_starts
+      dhw_starts
+      pump_hours
+      fan_hours
+      deactivations_ifc
+      deactivations_templimiter
     }
   }
 }
@@ -554,7 +554,7 @@ class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             except GraphQLClientError as exc:
                 raise UpdateFailed(str(exc)) from exc
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+                if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
                     return await fetch_base_devices()
                 raise UpdateFailed(str(exc)) from exc
 
@@ -567,20 +567,20 @@ class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             except GraphQLClientError as exc:
                 raise UpdateFailed(str(exc)) from exc
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["displayName", "productFamily", "productModel"]):
+                if _is_missing_field_error(exc.errors, ["display_name", "product_family", "product_model"]):
                     return await fetch_v2_devices()
-                if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+                if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
                     return await fetch_base_devices()
                 raise UpdateFailed(str(exc)) from exc
 
         try:
             return await fetch_with_addresses(QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_ADDRESSES)
         except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["partNumber"]):
+            if _is_missing_field_error(exc.errors, ["part_number"]):
                 return await fetch_v3_no_part_devices()
-            if _is_missing_field_error(exc.errors, ["displayName", "productFamily", "productModel"]):
+            if _is_missing_field_error(exc.errors, ["display_name", "product_family", "product_model"]):
                 return await fetch_v2_devices()
-            if _is_missing_field_error(exc.errors, ["serialNumber", "macAddress"]):
+            if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
                 return await fetch_base_devices()
             raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
@@ -603,7 +603,7 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
         try:
             payload = await self._client.execute(QUERY_STATUS)
         except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["initiatorAddress"]):
+            if _is_missing_field_error(exc.errors, ["initiator_address"]):
                 try:
                     payload = await self._client.execute(QUERY_STATUS_LEGACY)
                 except GraphQLClientError as nested:
@@ -618,8 +618,8 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
         if not isinstance(payload, dict):
             return {"daemon": {}, "adapter": {}}
         return {
-            "daemon": payload.get("daemonStatus", {}) or {},
-            "adapter": payload.get("adapterStatus", {}) or {},
+            "daemon": payload.get("daemon_status", {}) or {},
+            "adapter": payload.get("adapter_status", {}) or {},
         }
 
 
@@ -680,27 +680,27 @@ class HelianthusCircuitCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 [
                     "circuits",
                     "index",
-                    "circuitType",
-                    "hasMixer",
+                    "circuit_type",
+                    "has_mixer",
                     "state",
                     "config",
-                    "pumpActive",
-                    "mixerPositionPct",
-                    "flowTemperatureC",
-                    "flowSetpointC",
-                    "calcFlowTempC",
-                    "circuitState",
+                    "pump_active",
+                    "mixer_position_pct",
+                    "flow_temperature_c",
+                    "flow_setpoint_c",
+                    "calc_flow_temp_c",
+                    "circuit_state",
                     "humidity",
-                    "dewPoint",
-                    "pumpHours",
-                    "pumpStarts",
-                    "heatingCurve",
-                    "flowTempMaxC",
-                    "flowTempMinC",
-                    "summerLimitC",
-                    "frostProtC",
-                    "roomTempControl",
-                    "coolingEnabled",
+                    "dew_point",
+                    "pump_hours",
+                    "pump_starts",
+                    "heating_curve",
+                    "flow_temp_max_c",
+                    "flow_temp_min_c",
+                    "summer_limit_c",
+                    "frost_prot_c",
+                    "room_temp_control",
+                    "cooling_enabled",
                 ],
             ):
                 return {"circuits": []}
@@ -737,23 +737,23 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._stale_cycles: dict[tuple[int, int], int] = {}
 
     async def _async_update_data(self) -> dict[str, Any]:
-        empty = {"radioDevices": [], "radioZoneCandidates": {}}
+        empty = {"radio_devices": [], "radio_zone_candidates": {}}
         missing_fields = [
-            "radioDevices",
+            "radio_devices",
             "group",
             "instance",
-            "slotMode",
-            "deviceConnected",
-            "deviceClassAddress",
-            "deviceModel",
-            "firmwareVersion",
-            "hardwareIdentifier",
-            "remoteControlAddress",
-            "devicePaired",
-            "receptionStrength",
-            "zoneAssignment",
-            "roomTemperatureC",
-            "roomHumidityPct",
+            "slot_mode",
+            "device_connected",
+            "device_class_address",
+            "device_model",
+            "firmware_version",
+            "hardware_identifier",
+            "remote_control_address",
+            "device_paired",
+            "reception_strength",
+            "zone_assignment",
+            "room_temperature_c",
+            "room_humidity_pct",
         ]
         try:
             payload = await self._client.execute(QUERY_RADIO_DEVICES)
@@ -770,7 +770,7 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._last_by_slot = {}
             self._stale_cycles = {}
             return empty
-        devices = payload.get("radioDevices")
+        devices = payload.get("radio_devices")
         if not isinstance(devices, list):
             self._last_by_slot = {}
             self._stale_cycles = {}
@@ -800,8 +800,8 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         next_stale_cycles: dict[tuple[int, int], int] = {}
         for slot, device in active_by_slot.items():
             current = dict(device)
-            current["staleCycles"] = 0
-            current["radioBusKey"] = _radio_bus_key(slot[0], slot[1])
+            current["stale_cycles"] = 0
+            current["radio_bus_key"] = _radio_bus_key(slot[0], slot[1])
             combined[slot] = current
             next_stale_cycles[slot] = 0
 
@@ -816,9 +816,9 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if isinstance(observed, dict):
                 carried.update(observed)
             if observed is None or not _is_active_radio_device(observed):
-                carried["deviceConnected"] = False
-            carried["staleCycles"] = stale
-            carried["radioBusKey"] = _radio_bus_key(slot[0], slot[1])
+                carried["device_connected"] = False
+            carried["stale_cycles"] = stale
+            carried["radio_bus_key"] = _radio_bus_key(slot[0], slot[1])
             combined[slot] = carried
             next_stale_cycles[slot] = stale
 
@@ -830,14 +830,14 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             slot: {
                 key: value
                 for key, value in combined[slot].items()
-                if key not in {"staleCycles"}
+                if key not in {"stale_cycles"}
             }
             for slot in sorted_slots
         }
         self._stale_cycles = dict(next_stale_cycles)
         return {
-            "radioDevices": radio_devices,
-            "radioZoneCandidates": candidates,
+            "radio_devices": radio_devices,
+            "radio_zone_candidates": candidates,
         }
 
 
@@ -855,26 +855,26 @@ class HelianthusFM5Coordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         empty = {
-            "fm5SemanticMode": "ABSENT",
+            "fm5_semantic_mode": "ABSENT",
             "solar": None,
             "cylinders": [],
         }
         missing_fields = [
-            "fm5SemanticMode",
+            "fm5_semantic_mode",
             "solar",
             "cylinders",
-            "collectorTemperatureC",
-            "returnTemperatureC",
-            "pumpActive",
-            "currentYield",
-            "pumpHours",
-            "solarEnabled",
-            "functionMode",
+            "collector_temperature_c",
+            "return_temperature_c",
+            "pump_active",
+            "current_yield",
+            "pump_hours",
+            "solar_enabled",
+            "function_mode",
             "index",
-            "temperatureC",
-            "maxSetpointC",
-            "chargeHysteresisC",
-            "chargeOffsetC",
+            "temperature_c",
+            "max_setpoint_c",
+            "charge_hysteresis_c",
+            "charge_offset_c",
         ]
         try:
             payload = await self._client.execute(QUERY_FM5)
@@ -888,13 +888,13 @@ class HelianthusFM5Coordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not isinstance(payload, dict):
             return empty
 
-        mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+        mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
         if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
             mode = "ABSENT"
 
         if mode != "INTERPRETED":
             return {
-                "fm5SemanticMode": mode,
+                "fm5_semantic_mode": mode,
                 "solar": None,
                 "cylinders": [],
             }
@@ -917,7 +917,7 @@ class HelianthusFM5Coordinator(DataUpdateCoordinator[dict[str, Any]]):
         normalized_cylinders.sort(key=lambda item: int(item.get("index") or 0))
 
         return {
-            "fm5SemanticMode": mode,
+            "fm5_semantic_mode": mode,
             "solar": solar,
             "cylinders": normalized_cylinders,
         }
@@ -927,9 +927,9 @@ QUERY_SYSTEM_INSTALLER = """
 query SystemInstaller {
   system {
     config {
-      maintenanceDate
-      installerName
-      installerPhone
+      maintenance_date
+      installer_name
+      installer_phone
     }
   }
 }
@@ -939,7 +939,7 @@ QUERY_SYSTEM_SENSITIVE = """
 query SystemSensitive {
   system {
     config {
-      installerMenuCode
+      installer_menu_code
     }
   }
 }
@@ -975,21 +975,21 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "state",
             "config",
             "properties",
-            "systemWaterPressure",
-            "systemFlowTemperature",
-            "outdoorTemperature",
-            "outdoorTemperatureAvg24h",
-            "maintenanceDue",
-            "hwcCylinderTemperatureTop",
-            "hwcCylinderTemperatureBottom",
-            "adaptiveHeatingCurve",
-            "heatingCircuitBivalencePoint",
-            "dhwBivalencePoint",
-            "hcEmergencyTemperature",
-            "hwcMaxFlowTempDesired",
-            "maxRoomHumidity",
-            "systemScheme",
-            "moduleConfigurationVR71",
+            "system_water_pressure",
+            "system_flow_temperature",
+            "outdoor_temperature",
+            "outdoor_temperature_avg24h",
+            "maintenance_due",
+            "hwc_cylinder_temperature_top",
+            "hwc_cylinder_temperature_bottom",
+            "adaptive_heating_curve",
+            "heating_circuit_bivalence_point",
+            "dhw_bivalence_point",
+            "hc_emergency_temperature",
+            "hwc_max_flow_temp_desired",
+            "max_room_humidity",
+            "system_scheme",
+            "module_configuration_vr71",
         ]
 
         try:
@@ -1028,7 +1028,7 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if self._system_installer_available is None:
                     self._system_installer_available = True
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["maintenanceDate", "installerName", "installerPhone"]):
+                if _is_missing_field_error(exc.errors, ["maintenance_date", "installer_name", "installer_phone"]):
                     self._system_installer_available = False
             except GraphQLClientError:
                 pass  # transient — retry next cycle
@@ -1044,7 +1044,7 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if self._system_sensitive_available is None:
                     self._system_sensitive_available = True
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["installerMenuCode"]):
+                if _is_missing_field_error(exc.errors, ["installer_menu_code"]):
                     self._system_sensitive_available = False
             except GraphQLClientError:
                 pass  # transient — retry next cycle
@@ -1076,7 +1076,7 @@ class HelianthusEnergyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ):
                 self._monthly_supported = False
                 return await self._async_update_data()
-            if _is_missing_field_error(exc.errors, ["energyTotals"]):
+            if _is_missing_field_error(exc.errors, ["energy_totals"]):
                 return self._hold_last_valid_energy_totals()
             return self._hold_last_valid_energy_totals()
         except GraphQLClientError:
@@ -1087,21 +1087,21 @@ class HelianthusEnergyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return self._hold_last_valid_energy_totals()
 
         self._last_valid_energy_totals = deepcopy(totals)
-        return {"energyTotals": deepcopy(totals)}
+        return {"energy_totals": deepcopy(totals)}
 
     def _hold_last_valid_energy_totals(self) -> dict[str, Any]:
         totals = getattr(self, "_last_valid_energy_totals", None)
         if isinstance(totals, dict):
-            return {"energyTotals": deepcopy(totals)}
-        return {"energyTotals": None}
+            return {"energy_totals": deepcopy(totals)}
+        return {"energy_totals": None}
 
 
 QUERY_BOILER_INSTALLER = """
 query BoilerInstaller {
-  boilerStatus {
+  boiler_status {
     config {
-      phoneNumber
-      hoursTillService
+      phone_number
+      hours_till_service
     }
   }
 }
@@ -1109,9 +1109,9 @@ query BoilerInstaller {
 
 QUERY_BOILER_SENSITIVE = """
 query BoilerSensitive {
-  boilerStatus {
+  boiler_status {
     config {
-      installerMenuCode
+      installer_menu_code
     }
   }
 }
@@ -1152,47 +1152,47 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if _is_missing_field_error(
                 exc.errors,
                 [
-                    "boilerStatus",
-                    "flowTemperatureC",
-                    "returnTemperatureC",
-                    "centralHeatingPumpActive",
-                    "flameActive",
-                    "modulationPct",
-                    "gasValveActive",
-                    "fanSpeedRpm",
-                    "ionisationVoltageUa",
-                    "externalPumpActive",
-                    "circulationPumpActive",
-                    "storageLoadPumpPct",
-                    "diverterValvePositionPct",
-                    "flowsetHcMaxC",
-                    "flowsetHwcMaxC",
-                    "partloadHcKW",
-                    "partloadHwcKW",
-                    "heatingStatusRaw",
-                    "centralHeatingHours",
-                    "dhwHours",
-                    "centralHeatingStarts",
-                    "dhwStarts",
-                    "pumpHours",
-                    "fanHours",
-                    "deactivationsIFC",
-                    "deactivationsTemplimiter",
+                    "boiler_status",
+                    "flow_temperature_c",
+                    "return_temperature_c",
+                    "central_heating_pump_active",
+                    "flame_active",
+                    "modulation_pct",
+                    "gas_valve_active",
+                    "fan_speed_rpm",
+                    "ionisation_voltage_ua",
+                    "external_pump_active",
+                    "circulation_pump_active",
+                    "storage_load_pump_pct",
+                    "diverter_valve_position_pct",
+                    "flowset_hc_max_c",
+                    "flowset_hwc_max_c",
+                    "partload_hc_kw",
+                    "partload_hwc_kw",
+                    "heating_status_raw",
+                    "central_heating_hours",
+                    "dhw_hours",
+                    "central_heating_starts",
+                    "dhw_starts",
+                    "pump_hours",
+                    "fan_hours",
+                    "deactivations_ifc",
+                    "deactivations_templimiter",
                 ],
             ):
                 self.boiler_supported = False
-                return {"boilerStatus": None}
+                return {"boiler_status": None}
             raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError as exc:
             raise UpdateFailed(str(exc)) from exc
 
         if not isinstance(payload, dict):
             self.boiler_supported = False
-            return {"boilerStatus": None}
+            return {"boiler_status": None}
         self.boiler_supported = True
-        result = {"boilerStatus": payload.get("boilerStatus")}
+        result = {"boiler_status": payload.get("boiler_status")}
 
-        boiler_status = result.get("boilerStatus")
+        boiler_status = result.get("boiler_status")
         if not isinstance(boiler_status, dict):
             return result
         config = boiler_status.get("config")
@@ -1204,14 +1204,14 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._boiler_installer_available is not False:
             try:
                 inst_payload = await self._client.execute(QUERY_BOILER_INSTALLER)
-                inst_boiler = inst_payload.get("boilerStatus", {}) if isinstance(inst_payload, dict) else {}
+                inst_boiler = inst_payload.get("boiler_status", {}) if isinstance(inst_payload, dict) else {}
                 inst_cfg = inst_boiler.get("config", {}) if isinstance(inst_boiler, dict) else {}
                 if isinstance(inst_cfg, dict):
                     config.update(inst_cfg)
                 if self._boiler_installer_available is None:
                     self._boiler_installer_available = True
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["phoneNumber", "hoursTillService"]):
+                if _is_missing_field_error(exc.errors, ["phone_number", "hours_till_service"]):
                     self._boiler_installer_available = False
             except GraphQLClientError:
                 pass
@@ -1220,14 +1220,14 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._boiler_sensitive_available is not False:
             try:
                 sens_payload = await self._client.execute(QUERY_BOILER_SENSITIVE)
-                sens_boiler = sens_payload.get("boilerStatus", {}) if isinstance(sens_payload, dict) else {}
+                sens_boiler = sens_payload.get("boiler_status", {}) if isinstance(sens_payload, dict) else {}
                 sens_cfg = sens_boiler.get("config", {}) if isinstance(sens_boiler, dict) else {}
                 if isinstance(sens_cfg, dict):
                     config.update(sens_cfg)
                 if self._boiler_sensitive_available is None:
                     self._boiler_sensitive_available = True
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["installerMenuCode"]):
+                if _is_missing_field_error(exc.errors, ["installer_menu_code"]):
                     self._boiler_sensitive_available = False
             except GraphQLClientError:
                 pass
@@ -1242,23 +1242,23 @@ query Schedules {
       zone
       hc
       config {
-        maxSlots
-        timeResolution
-        minDuration
-        hasTemperature
-        tempSlots
-        minTempC
-        maxTempC
+        max_slots
+        time_resolution
+        min_duration
+        has_temperature
+        temp_slots
+        min_temp_c
+        max_temp_c
       }
-      slotsUsed
+      slots_used
       days {
         weekday
         slots {
-          startHour
-          startMinute
-          endHour
-          endMinute
-          temperatureC
+          start_hour
+          start_minute
+          end_hour
+          end_minute
+          temperature_c
         }
       }
     }
@@ -1338,57 +1338,57 @@ def _normalize_radio_device(raw: dict[str, Any]) -> dict[str, Any] | None:
     normalized: dict[str, Any] = {
         "group": group,
         "instance": instance,
-        "slotMode": str(raw.get("slotMode") or "").strip() or "active",
+        "slot_mode": str(raw.get("slot_mode") or "").strip() or "active",
     }
 
-    connected = raw.get("deviceConnected")
+    connected = raw.get("device_connected")
     if isinstance(connected, bool):
-        normalized["deviceConnected"] = connected
-    class_address = _parse_optional_int(raw.get("deviceClassAddress"))
+        normalized["device_connected"] = connected
+    class_address = _parse_optional_int(raw.get("device_class_address"))
     if class_address is not None and 0 <= class_address <= 0xFF:
-        normalized["deviceClassAddress"] = class_address
+        normalized["device_class_address"] = class_address
 
-    device_model = str(raw.get("deviceModel") or "").strip()
+    device_model = str(raw.get("device_model") or "").strip()
     if device_model:
-        normalized["deviceModel"] = device_model
-    firmware = str(raw.get("firmwareVersion") or "").strip()
+        normalized["device_model"] = device_model
+    firmware = str(raw.get("firmware_version") or "").strip()
     if firmware:
-        normalized["firmwareVersion"] = firmware
+        normalized["firmware_version"] = firmware
 
-    hardware_identifier = _parse_optional_int(raw.get("hardwareIdentifier"))
+    hardware_identifier = _parse_optional_int(raw.get("hardware_identifier"))
     if hardware_identifier is not None and hardware_identifier >= 0:
-        normalized["hardwareIdentifier"] = hardware_identifier
-    remote_control_address = _parse_optional_int(raw.get("remoteControlAddress"))
+        normalized["hardware_identifier"] = hardware_identifier
+    remote_control_address = _parse_optional_int(raw.get("remote_control_address"))
     if remote_control_address is not None and remote_control_address >= 0:
-        normalized["remoteControlAddress"] = remote_control_address
-    paired = raw.get("devicePaired")
+        normalized["remote_control_address"] = remote_control_address
+    paired = raw.get("device_paired")
     if isinstance(paired, bool):
-        normalized["devicePaired"] = paired
-    reception_strength = _parse_optional_int(raw.get("receptionStrength"))
+        normalized["device_paired"] = paired
+    reception_strength = _parse_optional_int(raw.get("reception_strength"))
     if reception_strength is not None:
-        normalized["receptionStrength"] = reception_strength
-    zone_assignment = _parse_optional_int(raw.get("zoneAssignment"))
+        normalized["reception_strength"] = reception_strength
+    zone_assignment = _parse_optional_int(raw.get("zone_assignment"))
     if zone_assignment is not None and zone_assignment >= 0:
-        normalized["zoneAssignment"] = zone_assignment
-    room_temperature = _parse_optional_float(raw.get("roomTemperatureC"))
+        normalized["zone_assignment"] = zone_assignment
+    room_temperature = _parse_optional_float(raw.get("room_temperature_c"))
     if room_temperature is not None:
-        normalized["roomTemperatureC"] = room_temperature
-    room_humidity = _parse_optional_float(raw.get("roomHumidityPct"))
+        normalized["room_temperature_c"] = room_temperature
+    room_humidity = _parse_optional_float(raw.get("room_humidity_pct"))
     if room_humidity is not None:
-        normalized["roomHumidityPct"] = room_humidity
+        normalized["room_humidity_pct"] = room_humidity
 
     return normalized
 
 
 def _has_radio_identity_evidence(device: dict[str, Any]) -> bool:
-    class_address = _parse_optional_int(device.get("deviceClassAddress"))
+    class_address = _parse_optional_int(device.get("device_class_address"))
     if class_address == 0x26:
         return True
-    if str(device.get("deviceModel") or "").strip():
+    if str(device.get("device_model") or "").strip():
         return True
-    if str(device.get("firmwareVersion") or "").strip():
+    if str(device.get("firmware_version") or "").strip():
         return True
-    if _parse_optional_int(device.get("hardwareIdentifier")) is not None:
+    if _parse_optional_int(device.get("hardware_identifier")) is not None:
         return True
     return False
 
@@ -1397,7 +1397,7 @@ def _is_active_radio_device(device: dict[str, Any]) -> bool:
     group = _parse_optional_int(device.get("group"))
     if group is None:
         return False
-    connected = device.get("deviceConnected") is True
+    connected = device.get("device_connected") is True
     if group in (_RADIO_GROUP_ZONE_VRC, _RADIO_GROUP_ZONE_VR92):
         return connected
     if group == _RADIO_GROUP_INVENTORY:
@@ -1420,9 +1420,9 @@ def _build_radio_zone_candidates(
             continue
         if instance is None:
             continue
-        if device.get("deviceConnected") is not True:
+        if device.get("device_connected") is not True:
             continue
-        zone_assignment = _parse_optional_int(device.get("zoneAssignment"))
+        zone_assignment = _parse_optional_int(device.get("zone_assignment"))
         if zone_assignment is None or zone_assignment <= 0:
             continue
         zone_instance = zone_assignment - 1
@@ -1430,7 +1430,7 @@ def _build_radio_zone_candidates(
             {
                 "group": group,
                 "instance": instance,
-                "remote_control_address": _parse_optional_int(device.get("remoteControlAddress")),
+                "remote_control_address": _parse_optional_int(device.get("remote_control_address")),
                 "radio_bus_key": _radio_bus_key(group, instance),
             }
         )
@@ -1470,7 +1470,7 @@ def _is_missing_field_error(errors: object, fields: list[str]) -> bool:
 def _normalize_energy_totals_payload(payload: Any) -> dict[str, Any] | None:
     if not isinstance(payload, dict):
         return None
-    totals = payload.get("energyTotals")
+    totals = payload.get("energy_totals")
     if not isinstance(totals, dict):
         return None
 
@@ -1489,65 +1489,65 @@ def _normalize_energy_totals_payload(payload: Any) -> dict[str, Any] | None:
 
 QUERY_ADAPTER_HARDWARE_INFO = """
 query AdapterHardwareInfo {
-  adapterHardwareInfo {
-    firmwareVersion
-    firmwareChecksum
-    bootloaderVersion
-    bootloaderChecksum
-    hardwareID
-    hardwareConfig
+  adapter_hardware_info {
+    firmware_version
+    firmware_checksum
+    bootloader_version
+    bootloader_checksum
+    hardware_id
+    hardware_config
     features
     jumpers
-    jumperFlags
-    isWifi
-    isEthernet
-    temperatureC
-    supplyVoltageMv
-    busVoltageMaxDv
-    busVoltageMinDv
-    resetCause
-    resetCauseCode
-    restartCount
-    wifiRssiDbm
-    lastIdentityQuery
-    lastTelemetryQuery
-    versionResponseLen
-    infoSupported
+    jumper_flags
+    is_wifi
+    is_ethernet
+    temperature_c
+    supply_voltage_mv
+    bus_voltage_max_dv
+    bus_voltage_min_dv
+    reset_cause
+    reset_cause_code
+    restart_count
+    wifi_rssi_dbm
+    last_identity_query
+    last_telemetry_query
+    version_response_len
+    info_supported
   }
 }
 """
 
 QUERY_ADAPTER_HARDWARE_INFO_MINIMAL = """
 query AdapterHardwareInfo {
-  adapterHardwareInfo {
-    firmwareVersion
-    isWifi
-    isEthernet
-    infoSupported
-    versionResponseLen
+  adapter_hardware_info {
+    firmware_version
+    is_wifi
+    is_ethernet
+    info_supported
+    version_response_len
   }
 }
 """
 
 _ADAPTER_HARDWARE_INFO_DETAILED_ONLY_FIELDS = [
-    "firmwareChecksum",
-    "bootloaderVersion",
-    "bootloaderChecksum",
-    "hardwareID",
-    "hardwareConfig",
+    "firmware_checksum",
+    "bootloader_version",
+    "bootloader_checksum",
+    "hardware_id",
+    "hardware_config",
     "features",
     "jumpers",
-    "jumperFlags",
-    "temperatureC",
-    "supplyVoltageMv",
-    "busVoltageMaxDv",
-    "busVoltageMinDv",
-    "resetCause",
-    "resetCauseCode",
-    "restartCount",
-    "wifiRssiDbm",
-    "lastIdentityQuery",
-    "lastTelemetryQuery",
+    "jumper_flags",
+    "temperature_c",
+    "supply_voltage_mv",
+    "bus_voltage_max_dv",
+    "bus_voltage_min_dv",
+    "reset_cause",
+    "reset_cause_code",
+    "restart_count",
+    "wifi_rssi_dbm",
+    "last_identity_query",
+    "last_telemetry_query",
 ]
 
 _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S = 300.0
@@ -1582,7 +1582,7 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         try:
             payload = await self._client.execute(query)
         except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["adapterHardwareInfo"]):
+            if _is_missing_field_error(exc.errors, ["adapter_hardware_info"]):
                 self._schedule_hardware_info_reprobe(now)
                 return None
             if query == QUERY_ADAPTER_HARDWARE_INFO:
@@ -1594,7 +1594,7 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
                 try:
                     payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
                 except GraphQLResponseError as minimal_exc:
-                    if _is_missing_field_error(minimal_exc.errors, ["adapterHardwareInfo"]):
+                    if _is_missing_field_error(minimal_exc.errors, ["adapter_hardware_info"]):
                         self._schedule_hardware_info_reprobe(now)
                     return None
                 except GraphQLClientError:
@@ -1608,7 +1608,7 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         if not isinstance(payload, dict):
             return None
 
-        info = payload.get("adapterHardwareInfo")
+        info = payload.get("adapter_hardware_info")
         if not isinstance(info, dict):
             return None
 

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -17,7 +17,7 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_SYSTEM_CONFIG_MUTATION = """
 mutation SetSystemConfig($field: String!, $value: String!) {
-  setSystemConfig(field: $field, value: $value) {
+  set_system_config(field: $field, value: $value) {
     success
     error
   }
@@ -105,7 +105,7 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -69,7 +69,7 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
         self._manufacturer = manufacturer
         self._client = client
         self._device_id = device_id
-        self._attr_unique_id = f"{entry_id}-system-date-maintenanceDate"
+        self._attr_unique_id = f"{entry_id}-system-date-maintenance_date"
         self._attr_name = "Maintenance Date"
 
     @property
@@ -84,7 +84,7 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
     def native_value(self) -> datetime.date | None:
         payload = self.coordinator.data or {}
         config = payload.get("config", {})
-        raw = config.get("maintenanceDate")
+        raw = config.get("maintenance_date")
         if raw is None or not isinstance(raw, str):
             return None
         try:
@@ -99,13 +99,13 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
 
-        variables = {"field": "maintenanceDate", "value": iso}
+        variables = {"field": "maintenance_date", "value": iso}
         try:
             payload = await self._client.mutation(_SET_SYSTEM_CONFIG_MUTATION, variables)
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -105,7 +105,7 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_system_config") if isinstance(payload, dict) else None
+        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -232,7 +232,7 @@ def managing_device_identifier(
         if role == "FUNCTION_MODULE":
             device_id = _clean((managing_device or {}).get("device_id"))
             if device_id is None:
-                device_id = _clean((managing_device or {}).get("device_id"))
+                device_id = _clean((managing_device or {}).get("deviceId"))
             address = _parse_bus_address((managing_device or {}).get("address"))
             if vr71_device_id and (device_id == "VR_71" or address == 0x26):
                 return vr71_device_id

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -230,7 +230,7 @@ def managing_device_identifier(
         if role == "REGULATOR":
             return regulator_device_id
         if role == "FUNCTION_MODULE":
-            device_id = _clean((managing_device or {}).get("deviceId"))
+            device_id = _clean((managing_device or {}).get("device_id"))
             if device_id is None:
                 device_id = _clean((managing_device or {}).get("device_id"))
             address = _parse_bus_address((managing_device or {}).get("address"))

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -231,8 +231,6 @@ def managing_device_identifier(
             return regulator_device_id
         if role == "FUNCTION_MODULE":
             device_id = _clean((managing_device or {}).get("device_id"))
-            if device_id is None:
-                device_id = _clean((managing_device or {}).get("deviceId"))
             address = _parse_bus_address((managing_device or {}).get("address"))
             if vr71_device_id and (device_id == "VR_71" or address == 0x26):
                 return vr71_device_id

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -41,7 +41,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -49,7 +49,7 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
 def _fm5_mode(payload: dict[str, Any] | None) -> str:
     if not isinstance(payload, dict):
         return "ABSENT"
-    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
     if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
         return "ABSENT"
     return mode
@@ -79,7 +79,7 @@ class HelianthusReadOnlyFan(CoordinatorEntity, FanEntity):
 def _boiler_state(payload: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {}
-    boiler_status = payload.get("boilerStatus")
+    boiler_status = payload.get("boiler_status")
     if not isinstance(boiler_status, dict):
         return {}
     state = boiler_status.get("state")
@@ -142,14 +142,14 @@ class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
 
     @property
     def is_on(self) -> bool | None:
-        value = self._state().get("flameActive")
+        value = self._state().get("flame_active")
         if isinstance(value, bool):
             return value
         return None
 
     @property
     def percentage(self) -> int | None:
-        return _coerce_percentage(self._state().get("modulationPct"))
+        return _coerce_percentage(self._state().get("modulation_pct"))
 
     @property
     def speed_count(self) -> int:
@@ -160,9 +160,9 @@ class HelianthusBoilerBurnerFan(HelianthusReadOnlyFan):
         state = self._state()
         return {
             "helianthus_role": "modulating_burner",
-            "gas_valve_active": state.get("gasValveActive"),
-            "fan_speed_rpm": state.get("fanSpeedRpm"),
-            "ionisation_ua": state.get("ionisationVoltageUa"),
+            "gas_valve_active": state.get("gas_valve_active"),
+            "fan_speed_rpm": state.get("fan_speed_rpm"),
+            "ionisation_ua": state.get("ionisation_voltage_ua"),
         }
 
 
@@ -296,7 +296,7 @@ class HelianthusCircuitPumpFan(HelianthusReadOnlyFan):
     def is_on(self) -> bool | None:
         circuit = self._circuit()
         state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
-        value = state.get("pumpActive")
+        value = state.get("pump_active")
         if isinstance(value, bool):
             return value
         return None
@@ -359,7 +359,7 @@ class HelianthusSolarPumpFan(CoordinatorEntity, FanEntity):
         solar = payload.get("solar") if isinstance(payload, dict) else None
         if not isinstance(solar, dict):
             return None
-        value = solar.get("pumpActive")
+        value = solar.get("pump_active")
         if isinstance(value, bool):
             return value
         return None

--- a/custom_components/helianthus/identity.py
+++ b/custom_components/helianthus/identity.py
@@ -28,8 +28,8 @@ _INSTANCE_GUID_RE = re.compile(
 
 QUERY_GATEWAY_IDENTITY = """
 query GatewayIdentity {
-  gatewayIdentity {
-    instanceGuid
+  gateway_identity {
+    instance_guid
   }
 }
 """

--- a/custom_components/helianthus/identity.py
+++ b/custom_components/helianthus/identity.py
@@ -168,10 +168,10 @@ async def verify_gateway_identity(
 
         if not isinstance(payload, dict):
             raise GatewayIdentityVerificationError("invalid_response")
-        identity = payload.get("gatewayIdentity")
+        identity = payload.get("gateway_identity")
         if not isinstance(identity, dict):
             raise GatewayIdentityVerificationError("invalid_response")
-        instance_guid = normalize_instance_guid(identity.get("instanceGuid"))
+        instance_guid = normalize_instance_guid(identity.get("instance_guid"))
         if instance_guid is None:
             raise GatewayIdentityVerificationError("missing_instance_guid")
         if expected_guid is not None and instance_guid != expected_guid:

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -430,7 +430,7 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
+        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -536,7 +536,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -624,7 +624,7 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_system_config") if isinstance(payload, dict) else None
+        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -108,9 +108,9 @@ class BoilerNumberField:
 
 
 _CIRCUIT_NUMBER_FIELDS = [
-    CircuitNumberField("heatingCurve", "Heating Curve", 0.1, 4.0, 0.1, icon="mdi:chart-bell-curve-cumulative"),
+    CircuitNumberField("heating_curve", "Heating Curve", 0.1, 4.0, 0.1, icon="mdi:chart-bell-curve-cumulative"),
     CircuitNumberField(
-        "flowTempMaxC",
+        "flow_temp_max_c",
         "Flow Temperature Maximum",
         15.0,
         80.0,
@@ -119,7 +119,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         icon="mdi:thermometer-chevron-up",
     ),
     CircuitNumberField(
-        "flowTempMinC",
+        "flow_temp_min_c",
         "Flow Temperature Minimum",
         5.0,
         30.0,
@@ -128,7 +128,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         icon="mdi:thermometer-chevron-down",
     ),
     CircuitNumberField(
-        "summerLimitC",
+        "summer_limit_c",
         "Summer Limit",
         15.0,
         30.0,
@@ -137,7 +137,7 @@ _CIRCUIT_NUMBER_FIELDS = [
         icon="mdi:weather-sunny",
     ),
     CircuitNumberField(
-        "frostProtC",
+        "frost_prot_c",
         "Frost Protection",
         -20.0,
         10.0,
@@ -149,8 +149,8 @@ _CIRCUIT_NUMBER_FIELDS = [
 
 _SYSTEM_NUMBER_FIELDS = [
     SystemNumberField(
-        mutation_field="hcBivalencePointC",
-        config_key="heatingCircuitBivalencePoint",
+        mutation_field="hc_bivalence_point_c",
+        config_key="heating_circuit_bivalence_point",
         label="HC Bivalence Point",
         minimum=-20.0,
         maximum=30.0,
@@ -159,8 +159,8 @@ _SYSTEM_NUMBER_FIELDS = [
         icon="mdi:thermometer",
     ),
     SystemNumberField(
-        mutation_field="dhwBivalencePointC",
-        config_key="dhwBivalencePoint",
+        mutation_field="dhw_bivalence_point_c",
+        config_key="dhw_bivalence_point",
         label="DHW Bivalence Point",
         minimum=-20.0,
         maximum=50.0,
@@ -169,8 +169,8 @@ _SYSTEM_NUMBER_FIELDS = [
         icon="mdi:thermometer",
     ),
     SystemNumberField(
-        mutation_field="hcEmergencyTempC",
-        config_key="hcEmergencyTemperature",
+        mutation_field="hc_emergency_temp_c",
+        config_key="hc_emergency_temperature",
         label="HC Emergency Temperature",
         minimum=20.0,
         maximum=80.0,
@@ -179,8 +179,8 @@ _SYSTEM_NUMBER_FIELDS = [
         icon="mdi:thermometer-alert",
     ),
     SystemNumberField(
-        mutation_field="hwcMaxFlowTempC",
-        config_key="hwcMaxFlowTempDesired",
+        mutation_field="hwc_max_flow_temp_c",
+        config_key="hwc_max_flow_temp_desired",
         label="HWC Max Flow Temperature",
         minimum=15.0,
         maximum=80.0,
@@ -189,8 +189,8 @@ _SYSTEM_NUMBER_FIELDS = [
         icon="mdi:thermometer-chevron-up",
     ),
     SystemNumberField(
-        mutation_field="maxRoomHumidityPct",
-        config_key="maxRoomHumidity",
+        mutation_field="max_room_humidity_pct",
+        config_key="max_room_humidity",
         label="Max Room Humidity",
         minimum=30.0,
         maximum=80.0,
@@ -203,7 +203,7 @@ _SYSTEM_NUMBER_FIELDS = [
 
 _CYLINDER_NUMBER_FIELDS = [
     CylinderNumberField(
-        key="maxSetpointC",
+        key="max_setpoint_c",
         label="Max Setpoint",
         minimum=20.0,
         maximum=80.0,
@@ -212,7 +212,7 @@ _CYLINDER_NUMBER_FIELDS = [
         icon="mdi:thermometer-high",
     ),
     CylinderNumberField(
-        key="chargeHysteresisC",
+        key="charge_hysteresis_c",
         label="Charge Hysteresis",
         minimum=0.0,
         maximum=30.0,
@@ -221,7 +221,7 @@ _CYLINDER_NUMBER_FIELDS = [
         icon="mdi:thermometer",
     ),
     CylinderNumberField(
-        key="chargeOffsetC",
+        key="charge_offset_c",
         label="Charge Offset",
         minimum=-20.0,
         maximum=20.0,
@@ -233,7 +233,7 @@ _CYLINDER_NUMBER_FIELDS = [
 
 _BOILER_NUMBER_FIELDS = [
     BoilerNumberField(
-        key="flowsetHcMaxC",
+        key="flowset_hc_max_c",
         label="CH Max Flow Setpoint",
         minimum=20.0,
         maximum=80.0,
@@ -242,7 +242,7 @@ _BOILER_NUMBER_FIELDS = [
         icon="mdi:thermometer-chevron-up",
     ),
     BoilerNumberField(
-        key="flowsetHwcMaxC",
+        key="flowset_hwc_max_c",
         label="DHW Max Flow Setpoint",
         minimum=30.0,
         maximum=65.0,
@@ -251,7 +251,7 @@ _BOILER_NUMBER_FIELDS = [
         icon="mdi:thermometer-chevron-up",
     ),
     BoilerNumberField(
-        key="partloadHcKW",
+        key="partload_hc_kw",
         label="CH Partload",
         minimum=0.0,
         maximum=40.0,
@@ -260,7 +260,7 @@ _BOILER_NUMBER_FIELDS = [
         icon="mdi:lightning-bolt",
     ),
     BoilerNumberField(
-        key="partloadHwcKW",
+        key="partload_hwc_kw",
         label="DHW Partload",
         minimum=0.0,
         maximum=40.0,
@@ -284,7 +284,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -292,7 +292,7 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
 def _fm5_mode(payload: dict[str, Any] | None) -> str:
     if not isinstance(payload, dict):
         return "ABSENT"
-    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
     if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
         return "ABSENT"
     return mode
@@ -406,7 +406,7 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+        boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
         config = boiler_status.get("config") if isinstance(boiler_status, dict) else {}
         value = config.get(self._field.key)
         if value is None:
@@ -430,7 +430,7 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -536,7 +536,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -624,7 +624,7 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -24,7 +24,7 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
 mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
-  setCircuitConfig(index: $index, field: $field, value: $value) {
+  set_circuit_config(index: $index, field: $field, value: $value) {
     success
     error
   }
@@ -33,7 +33,7 @@ mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
 
 _SET_SYSTEM_CONFIG_MUTATION = """
 mutation SetSystemConfig($field: String!, $value: String!) {
-  setSystemConfig(field: $field, value: $value) {
+  set_system_config(field: $field, value: $value) {
     success
     error
   }
@@ -42,7 +42,7 @@ mutation SetSystemConfig($field: String!, $value: String!) {
 
 _SET_BOILER_CONFIG_MUTATION = """
 mutation SetBoilerConfig($field: String!, $value: String!) {
-  setBoilerConfig(field: $field, value: $value) {
+  set_boiler_config(field: $field, value: $value) {
     success
     error
   }
@@ -430,7 +430,7 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -536,7 +536,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -624,7 +624,7 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -161,7 +161,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -16,7 +16,7 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
 mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
-  setCircuitConfig(index: $index, field: $field, value: $value) {
+  set_circuit_config(index: $index, field: $field, value: $value) {
     success
     error
   }
@@ -161,7 +161,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -45,7 +45,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -139,7 +139,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
     def current_option(self) -> str | None:
         circuit = self._circuit()
         config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
-        token = str(config.get("roomTempControl") or "").strip().lower()
+        token = str(config.get("room_temp_control") or "").strip().lower()
         if token in _OPTIONS:
             return token
         return None
@@ -153,7 +153,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
 
         variables = {
             "index": int(self._circuit_index),
-            "field": "roomTempControl",
+            "field": "room_temp_control",
             "value": token,
         }
         try:
@@ -161,7 +161,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -69,21 +69,21 @@ class SystemSensorField:
 
 STATUS_FIELDS = [
     InventoryField("status", "Status", icon="mdi:information-outline"),
-    InventoryField("firmwareVersion", "Firmware Version", icon="mdi:tag-text-outline"),
-    InventoryField("updatesAvailable", "Updates Available", icon="mdi:update"),
+    InventoryField("firmware_version", "Firmware Version", icon="mdi:tag-text-outline"),
+    InventoryField("updates_available", "Updates Available", icon="mdi:update"),
 ]
 
 DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
-    InventoryField("initiatorAddress", "eBUS Initiator Address", icon="mdi:chip")
+    InventoryField("initiator_address", "eBUS Initiator Address", icon="mdi:chip")
 ]
 
 ADAPTER_STATUS_FIELDS = STATUS_FIELDS
 
 REDUCED_BOILER_TEMPERATURE_FIELDS = [
-    BoilerTemperatureField("flowTemperatureC", "Flow Temperature"),
-    BoilerTemperatureField("returnTemperatureC", "Return Temperature"),
-    BoilerTemperatureField("dhwTemperatureC", "DHW Temperature"),
-    BoilerTemperatureField("dhwStorageTemperatureC", "DHW Storage Temperature"),
+    BoilerTemperatureField("flow_temperature_c", "Flow Temperature"),
+    BoilerTemperatureField("return_temperature_c", "Return Temperature"),
+    BoilerTemperatureField("dhw_temperature_c", "DHW Temperature"),
+    BoilerTemperatureField("dhw_storage_temperature_c", "DHW Storage Temperature"),
 ]
 
 _SENSOR_DEVICE_CLASS_HUMIDITY = getattr(SensorDeviceClass, "HUMIDITY", None)
@@ -103,28 +103,28 @@ _CIRCUIT_TYPE_LABELS = {
 
 CIRCUIT_SENSOR_FIELDS = [
     CircuitSensorField(
-        key="flowTemperatureC",
+        key="flow_temperature_c",
         label="Flow Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     CircuitSensorField(
-        key="flowSetpointC",
+        key="flow_setpoint_c",
         label="Flow Setpoint",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     CircuitSensorField(
-        key="calcFlowTempC",
+        key="calc_flow_temp_c",
         label="Calculated Flow Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     CircuitSensorField(
-        key="mixerPositionPct",
+        key="mixer_position_pct",
         label="Mixing Valve Position",
         native_unit=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -132,7 +132,7 @@ CIRCUIT_SENSOR_FIELDS = [
         icon="mdi:valve",
     ),
     CircuitSensorField(
-        key="circuitState",
+        key="circuit_state",
         label="State",
         include_circuit_attributes=True,
         icon="mdi:information-outline",
@@ -145,14 +145,14 @@ CIRCUIT_SENSOR_FIELDS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     CircuitSensorField(
-        key="dewPoint",
+        key="dew_point",
         label="Dew Point",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     CircuitSensorField(
-        key="pumpHours",
+        key="pump_hours",
         label="Pump Hours",
         device_class=_SENSOR_DEVICE_CLASS_DURATION,
         native_unit="h",
@@ -160,7 +160,7 @@ CIRCUIT_SENSOR_FIELDS = [
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     CircuitSensorField(
-        key="pumpStarts",
+        key="pump_starts",
         label="Pump Starts",
         state_class=_SENSOR_STATE_CLASS_TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -171,7 +171,7 @@ CIRCUIT_SENSOR_FIELDS = [
 
 SYSTEM_SENSOR_FIELDS = [
     SystemSensorField(
-        key="systemWaterPressure",
+        key="system_water_pressure",
         label="System Water Pressure",
         source="state",
         device_class=_SENSOR_DEVICE_CLASS_PRESSURE,
@@ -179,7 +179,7 @@ SYSTEM_SENSOR_FIELDS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SystemSensorField(
-        key="outdoorTemperature",
+        key="outdoor_temperature",
         label="Outdoor Temperature",
         source="state",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -187,7 +187,7 @@ SYSTEM_SENSOR_FIELDS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SystemSensorField(
-        key="outdoorTemperatureAvg24h",
+        key="outdoor_temperature_avg24h",
         label="Outdoor Temperature 24h Average",
         source="state",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -195,7 +195,7 @@ SYSTEM_SENSOR_FIELDS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SystemSensorField(
-        key="systemFlowTemperature",
+        key="system_flow_temperature",
         label="System Flow Temperature",
         source="state",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -203,7 +203,7 @@ SYSTEM_SENSOR_FIELDS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SystemSensorField(
-        key="hwcCylinderTemperatureTop",
+        key="hwc_cylinder_temperature_top",
         label="HWC Cylinder Temperature Top",
         source="state",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -212,7 +212,7 @@ SYSTEM_SENSOR_FIELDS = [
         optional=True,
     ),
     SystemSensorField(
-        key="hwcCylinderTemperatureBottom",
+        key="hwc_cylinder_temperature_bottom",
         label="HWC Cylinder Temperature Bottom",
         source="state",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -221,7 +221,7 @@ SYSTEM_SENSOR_FIELDS = [
         optional=True,
     ),
     SystemSensorField(
-        key="systemScheme",
+        key="system_scheme",
         label="System Scheme",
         source="properties",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -232,7 +232,7 @@ SYSTEM_SENSOR_FIELDS = [
 
 BOILER_STATE_SENSOR_FIELDS = [
     {
-        "key": "modulationPct",
+        "key": "modulation_pct",
         "label": "Burner Modulation",
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -240,7 +240,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "icon": "mdi:gas-burner",
     },
     {
-        "key": "fanSpeedRpm",
+        "key": "fan_speed_rpm",
         "label": "Burner Fan Speed",
         "native_unit": "rpm",
         "state_class": SensorStateClass.MEASUREMENT,
@@ -249,7 +249,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "icon": "mdi:fan",
     },
     {
-        "key": "ionisationVoltageUa",
+        "key": "ionisation_voltage_ua",
         "label": "Burner Ionisation",
         "native_unit": "uA",
         "state_class": SensorStateClass.MEASUREMENT,
@@ -258,7 +258,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "icon": "mdi:flash-triangle-outline",
     },
     {
-        "key": "storageLoadPumpPct",
+        "key": "storage_load_pump_pct",
         "label": "Hydraulics Storage Load Pump",
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -266,7 +266,7 @@ BOILER_STATE_SENSOR_FIELDS = [
         "icon": "mdi:pump",
     },
     {
-        "key": "diverterValvePositionPct",
+        "key": "diverter_valve_position_pct",
         "label": "Hydraulics Diverter Valve Position",
         "native_unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -277,7 +277,7 @@ BOILER_STATE_SENSOR_FIELDS = [
 
 BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
     {
-        "key": "centralHeatingHours",
+        "key": "central_heating_hours",
         "label": "Central Heating Hours",
         "device_class": _SENSOR_DEVICE_CLASS_DURATION,
         "native_unit": "h",
@@ -285,7 +285,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     {
-        "key": "dhwHours",
+        "key": "dhw_hours",
         "label": "DHW Hours",
         "device_class": _SENSOR_DEVICE_CLASS_DURATION,
         "native_unit": "h",
@@ -293,7 +293,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     {
-        "key": "pumpHours",
+        "key": "pump_hours",
         "label": "Pump Hours",
         "device_class": _SENSOR_DEVICE_CLASS_DURATION,
         "native_unit": "h",
@@ -301,7 +301,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     {
-        "key": "fanHours",
+        "key": "fan_hours",
         "label": "Fan Hours",
         "device_class": _SENSOR_DEVICE_CLASS_DURATION,
         "native_unit": "h",
@@ -309,7 +309,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     {
-        "key": "centralHeatingStarts",
+        "key": "central_heating_starts",
         "label": "Central Heating Starts",
         "state_class": _SENSOR_STATE_CLASS_TOTAL_INCREASING,
         "entity_category": EntityCategory.DIAGNOSTIC,
@@ -317,7 +317,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "icon": "mdi:counter",
     },
     {
-        "key": "dhwStarts",
+        "key": "dhw_starts",
         "label": "DHW Starts",
         "state_class": _SENSOR_STATE_CLASS_TOTAL_INCREASING,
         "entity_category": EntityCategory.DIAGNOSTIC,
@@ -325,14 +325,14 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
         "icon": "mdi:counter",
     },
     {
-        "key": "deactivationsIFC",
+        "key": "deactivations_ifc",
         "label": "Deactivations IFC",
         "entity_category": EntityCategory.DIAGNOSTIC,
         "cast_int": True,
         "icon": "mdi:counter",
     },
     {
-        "key": "deactivationsTemplimiter",
+        "key": "deactivations_templimiter",
         "label": "Deactivations Temperature Limiter",
         "entity_category": EntityCategory.DIAGNOSTIC,
         "cast_int": True,
@@ -342,7 +342,7 @@ BOILER_DIAGNOSTICS_SENSOR_FIELDS = [
 
 CYLINDER_CONFIG_SENSOR_FIELDS = [
     {
-        "key": "maxSetpointC",
+        "key": "max_setpoint_c",
         "label": "Max Setpoint",
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -350,7 +350,7 @@ CYLINDER_CONFIG_SENSOR_FIELDS = [
         "icon": "mdi:thermometer-high",
     },
     {
-        "key": "chargeHysteresisC",
+        "key": "charge_hysteresis_c",
         "label": "Charge Hysteresis",
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -358,7 +358,7 @@ CYLINDER_CONFIG_SENSOR_FIELDS = [
         "icon": "mdi:thermometer",
     },
     {
-        "key": "chargeOffsetC",
+        "key": "charge_offset_c",
         "label": "Charge Offset",
         "native_unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -410,17 +410,17 @@ def _radio_bus_key(device: dict[str, Any]) -> str | None:
     slot = _radio_slot(device)
     if slot is None:
         return None
-    explicit = _clean_text(device.get("radioBusKey"))
+    explicit = _clean_text(device.get("radio_bus_key"))
     if explicit:
         return explicit
     return build_radio_bus_key(slot[0], slot[1])
 
 
 def _radio_model_name(device: dict[str, Any]) -> str:
-    model = _clean_text(device.get("deviceModel"))
+    model = _clean_text(device.get("device_model"))
     if model:
         return model
-    class_address = _parse_optional_int(device.get("deviceClassAddress"))
+    class_address = _parse_optional_int(device.get("device_class_address"))
     if class_address == 0x15:
         return "VRC720f/2"
     if class_address == 0x35:
@@ -435,14 +435,14 @@ def _radio_model_name(device: dict[str, Any]) -> str:
 def _fm5_mode(payload: dict[str, Any] | None) -> str:
     if not isinstance(payload, dict):
         return "ABSENT"
-    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
     if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
         return "ABSENT"
     return mode
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -500,18 +500,18 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     sensors: list[SensorEntity] = []
     seen_bus_keys: set[str] = set()
     for device in device_coordinator.data or []:
-        device_id = _clean_text(device.get("deviceId")) or "unknown"
+        device_id = _clean_text(device.get("device_id")) or "unknown"
         address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:
             continue
-        model = stable_bus_identity_model(device.get("deviceId"), device.get("productModel"))
+        model = stable_bus_identity_model(device.get("device_id"), device.get("product_model"))
         bus_key = build_bus_device_key(
             model=model,
             address=address,
-            serial_number=_clean_text(device.get("serialNumber")),
-            mac_address=_clean_text(device.get("macAddress")),
-            hardware_version=_clean_text(device.get("hardwareVersion")),
-            software_version=_clean_text(device.get("softwareVersion")),
+            serial_number=_clean_text(device.get("serial_number")),
+            mac_address=_clean_text(device.get("mac_address")),
+            hardware_version=_clean_text(device.get("hardware_version")),
+            software_version=_clean_text(device.get("software_version")),
         )
         if bus_key in seen_bus_keys:
             continue
@@ -621,7 +621,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             )
 
     if radio_coordinator and radio_coordinator.data:
-        radio_devices = radio_coordinator.data.get("radioDevices", []) or []
+        radio_devices = radio_coordinator.data.get("radio_devices", []) or []
         for radio in radio_devices:
             if not isinstance(radio, dict):
                 continue
@@ -633,12 +633,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             # ADR-027: skip all sensors for merged B524 function-module slots.
             if bus_key in b524_merge_targets:
                 continue
-            class_address = _parse_optional_int(radio.get("deviceClassAddress"))
+            class_address = _parse_optional_int(radio.get("device_class_address"))
             is_room = class_address in _RADIO_ROOM_CLASSES
             radio_device_id = radio_device_identifier(entry.entry_id, bus_key)
             radio_name = _radio_model_name(radio)
             radio_zone_name = radio_device_zone_names.get(radio_device_id)
-            if is_room or radio.get("receptionStrength") is not None:
+            if is_room or radio.get("reception_strength") is not None:
                 sensors.append(
                     HelianthusRadioSensor(
                         coordinator=radio_coordinator,
@@ -648,7 +648,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         radio_name=radio_name,
                         group=group,
                         instance=instance,
-                        key="receptionStrength",
+                        key="reception_strength",
                         label="Signal Quality",
                         entity_category=EntityCategory.DIAGNOSTIC,
                         cast_int=True,
@@ -665,7 +665,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         radio_name=radio_name,
                         group=group,
                         instance=instance,
-                        key="roomTemperatureC",
+                        key="room_temperature_c",
                         label="Room Temperature",
                         device_class=SensorDeviceClass.TEMPERATURE,
                         native_unit=UnitOfTemperature.CELSIUS,
@@ -682,7 +682,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         radio_name=radio_name,
                         group=group,
                         instance=instance,
-                        key="roomHumidityPct",
+                        key="room_humidity_pct",
                         label="Room Humidity",
                         device_class=_SENSOR_DEVICE_CLASS_HUMIDITY,
                         native_unit=PERCENTAGE,
@@ -692,16 +692,16 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 )
             elif group == 0x0C:
                 _radio_metadata_icons = {
-                    "deviceClassAddress": "mdi:identifier",
-                    "hardwareIdentifier": "mdi:identifier",
-                    "remoteControlAddress": "mdi:remote",
-                    "zoneAssignment": "mdi:home-map-marker",
+                    "device_class_address": "mdi:identifier",
+                    "hardware_identifier": "mdi:identifier",
+                    "remote_control_address": "mdi:remote",
+                    "zone_assignment": "mdi:home-map-marker",
                 }
                 for key, label in [
-                    ("deviceClassAddress", "Device Class Address"),
-                    ("hardwareIdentifier", "Hardware Identifier"),
-                    ("remoteControlAddress", "Remote Control Address"),
-                    ("zoneAssignment", "Zone Assignment"),
+                    ("device_class_address", "Device Class Address"),
+                    ("hardware_identifier", "Hardware Identifier"),
+                    ("remote_control_address", "Remote Control Address"),
+                    ("zone_assignment", "Zone Assignment"),
                 ]:
                     if radio.get(key) is None:
                         continue
@@ -742,7 +742,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 solar_device_id = solar_identifier(entry.entry_id)
                 for key, label, device_class, unit, state_class, icon in [
                     (
-                        "collectorTemperatureC",
+                        "collector_temperature_c",
                         "Collector Temperature",
                         SensorDeviceClass.TEMPERATURE,
                         UnitOfTemperature.CELSIUS,
@@ -750,15 +750,15 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         None,
                     ),
                     (
-                        "returnTemperatureC",
+                        "return_temperature_c",
                         "Return Temperature",
                         SensorDeviceClass.TEMPERATURE,
                         UnitOfTemperature.CELSIUS,
                         SensorStateClass.MEASUREMENT,
                         None,
                     ),
-                    ("currentYield", "Current Yield", None, None, None, "mdi:solar-power"),
-                    ("pumpHours", "Pump Hours", _SENSOR_DEVICE_CLASS_DURATION, "h", _SENSOR_STATE_CLASS_TOTAL_INCREASING, None),
+                    ("current_yield", "Current Yield", None, None, None, "mdi:solar-power"),
+                    ("pump_hours", "Pump Hours", _SENSOR_DEVICE_CLASS_DURATION, "h", _SENSOR_STATE_CLASS_TOTAL_INCREASING, None),
                 ]:
                     sensors.append(
                         HelianthusSolarSensor(
@@ -812,7 +812,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 if normalized_zone_id is None:
                     continue
                 config = zone.get("config")
-                mapping = _parse_optional_int(config.get("roomTemperatureZoneMapping")) if isinstance(config, dict) else None
+                mapping = _parse_optional_int(config.get("room_temperature_zone_mapping")) if isinstance(config, dict) else None
                 target_device_id = zone_parent_device_ids.get(normalized_zone_id)
                 if target_device_id is None:
                     if mapping in (1, 2, 3, 4):
@@ -890,12 +890,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     adapter_device_id = data.get("adapter_device_id")
     if adapter_info_coordinator and adapter_device_id:
         adapter_hw = adapter_info_coordinator.data
-        is_wifi = isinstance(adapter_hw, dict) and adapter_hw.get("isWifi") is True
-        has_reset = isinstance(adapter_hw, dict) and adapter_hw.get("resetCause") is not None
+        is_wifi = isinstance(adapter_hw, dict) and adapter_hw.get("is_wifi") is True
+        has_reset = isinstance(adapter_hw, dict) and adapter_hw.get("reset_cause") is not None
         sensors.append(
             HelianthusAdapterInfoSensor(
                 adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                key="temperatureC", label="Adapter Temperature",
+                key="temperature_c", label="Adapter Temperature",
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit=UnitOfTemperature.CELSIUS,
                 state_class=SensorStateClass.MEASUREMENT,
@@ -905,7 +905,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         sensors.append(
             HelianthusAdapterInfoSensor(
                 adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                key="supplyVoltageMv", label="Adapter Supply Voltage",
+                key="supply_voltage_mv", label="Adapter Supply Voltage",
                 device_class=SensorDeviceClass.VOLTAGE,
                 native_unit="mV",
                 state_class=SensorStateClass.MEASUREMENT,
@@ -915,7 +915,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         sensors.append(
             HelianthusAdapterInfoSensor(
                 adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                key="busVoltageMaxDv", label="eBUS Voltage Max",
+                key="bus_voltage_max_dv", label="eBUS Voltage Max",
                 device_class=SensorDeviceClass.VOLTAGE,
                 native_unit="V",
                 state_class=SensorStateClass.MEASUREMENT,
@@ -926,7 +926,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         sensors.append(
             HelianthusAdapterInfoSensor(
                 adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                key="busVoltageMinDv", label="eBUS Voltage Min",
+                key="bus_voltage_min_dv", label="eBUS Voltage Min",
                 device_class=SensorDeviceClass.VOLTAGE,
                 native_unit="V",
                 state_class=SensorStateClass.MEASUREMENT,
@@ -937,7 +937,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         sensors.append(
             HelianthusAdapterInfoSensor(
                 adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                key="restartCount", label="Adapter Restart Count",
+                key="restart_count", label="Adapter Restart Count",
                 state_class=_SENSOR_STATE_CLASS_TOTAL_INCREASING,
                 icon="mdi:counter",
             )
@@ -946,7 +946,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             sensors.append(
                 HelianthusAdapterInfoSensor(
                     adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                    key="resetCause", label="Adapter Reset Cause",
+                    key="reset_cause", label="Adapter Reset Cause",
                     icon="mdi:alert-circle-outline",
                 )
             )
@@ -954,7 +954,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             sensors.append(
                 HelianthusAdapterInfoSensor(
                     adapter_info_coordinator, entry.entry_id, adapter_device_id,
-                    key="wifiRssiDbm", label="Adapter WiFi Signal",
+                    key="wifi_rssi_dbm", label="Adapter WiFi Signal",
                     device_class=SensorDeviceClass.SIGNAL_STRENGTH,
                     native_unit="dBm",
                     state_class=SensorStateClass.MEASUREMENT,
@@ -1048,7 +1048,7 @@ class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
 
     def _boiler_state(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") or {}
+        boiler_status = payload.get("boiler_status") or {}
         return boiler_status.get("state") or {}
 
     @property
@@ -1100,7 +1100,7 @@ class HelianthusBoilerStateSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") or {}
+        boiler_status = payload.get("boiler_status") or {}
         state = boiler_status.get("state") if isinstance(boiler_status, dict) else {}
         value = state.get(self._field["key"]) if isinstance(state, dict) else None
         if value is None:
@@ -1156,7 +1156,7 @@ class HelianthusBoilerDiagnosticsSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") or {}
+        boiler_status = payload.get("boiler_status") or {}
         diagnostics = boiler_status.get("diagnostics") if isinstance(boiler_status, dict) else {}
         value = diagnostics.get(self._field["key"]) if isinstance(diagnostics, dict) else None
         if value is None:
@@ -1258,10 +1258,10 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
         attrs: dict[str, Any] = {
             "circuit_index": self._circuit_index,
         }
-        circuit_type = circuit.get("circuitType")
+        circuit_type = circuit.get("circuit_type")
         if circuit_type is not None and str(circuit_type).strip() != "":
             attrs["circuit_type"] = str(circuit_type)
-        has_mixer = circuit.get("hasMixer")
+        has_mixer = circuit.get("has_mixer")
         if isinstance(has_mixer, bool):
             attrs["has_mixer"] = has_mixer
         return attrs
@@ -1376,7 +1376,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
 
     def _device(self) -> dict[str, Any] | None:
         payload = self.coordinator.data or {}
-        for device in payload.get("radioDevices", []) or []:
+        for device in payload.get("radio_devices", []) or []:
             if not isinstance(device, dict):
                 continue
             slot = _radio_slot(device)
@@ -1393,7 +1393,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
         device = self._device()
         if device is None:
             return False
-        stale = _parse_optional_int(device.get("staleCycles")) or 0
+        stale = _parse_optional_int(device.get("stale_cycles")) or 0
         return stale < _RADIO_STALE_GRACE_CYCLES
 
     @property
@@ -1409,7 +1409,7 @@ class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
     @property
     def icon(self) -> str | None:
         """Dynamic icon for signal quality (ADR-026); static for others."""
-        if self._key == "receptionStrength":
+        if self._key == "reception_strength":
             value = self.native_value
             if value is None:
                 return "mdi:signal-cellular-outline"
@@ -1572,7 +1572,7 @@ class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
         self._parent_device_id = parent_device_id
         self._attr_name = "Temperature"
         self._attr_unique_id = f"{entry_id}-cylinder-{cylinder_index}-temperature"
-        self._attr_entity_registry_enabled_default = self._cylinder().get("temperatureC") is not None
+        self._attr_entity_registry_enabled_default = self._cylinder().get("temperature_c") is not None
 
     def _cylinder(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -1604,7 +1604,7 @@ class HelianthusCylinderSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        value = self._cylinder().get("temperatureC")
+        value = self._cylinder().get("temperature_c")
         if value is None:
             return None
         try:
@@ -1711,7 +1711,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
         self._zone_name = zone_name
         self._target_device_id = target_device_id
         self._attr_name = "Valve Position"
-        self._attr_unique_id = f"{entry_id}-zone-{zone_id}-sensor-valvePositionPct"
+        self._attr_unique_id = f"{entry_id}-zone-{zone_id}-sensor-valve_position_pct"
 
     def _zone(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -1736,7 +1736,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Any:
         zone = self._zone()
         state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
-        value = state.get("valvePositionPct") if isinstance(state, dict) else None
+        value = state.get("valve_position_pct") if isinstance(state, dict) else None
         if value is None:
             return None
         try:
@@ -1813,11 +1813,11 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
             for zone in self.coordinator.data.get("zones", []) or []:
                 if zone.get("id") == zone_id:
                     state = zone.get("state") or {}
-                    return state.get("heatingDemandPct")
+                    return state.get("heating_demand_pct")
             return None
         dhw = self.coordinator.data.get("dhw") or {}
         state = dhw.get("state") or {}
-        return state.get("heatingDemandPct")
+        return state.get("heating_demand_pct")
 
 
 class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
@@ -1856,7 +1856,7 @@ class HelianthusDHWStatusSensor(CoordinatorEntity, SensorEntity):
         payload = self.coordinator.data or {}
         dhw = payload.get("dhw") or {}
         state = dhw.get("state") if isinstance(dhw.get("state"), dict) else {}
-        value = state.get("specialFunction")
+        value = state.get("special_function")
         if value is None:
             return None
         if isinstance(value, (bool, int, float, str)):
@@ -1903,7 +1903,7 @@ class HelianthusEnergySensor(CoordinatorEntity, SensorEntity):
 
     def _series(self) -> dict[str, Any] | None:
         payload = self.coordinator.data or {}
-        totals = payload.get("energyTotals")
+        totals = payload.get("energy_totals")
         if not isinstance(totals, dict):
             return None
         channel = totals.get(self._source)
@@ -1993,7 +1993,7 @@ class HelianthusBoilerHoursTillServiceSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._boiler_device_id = boiler_device_id
-        self._attr_unique_id = f"{entry_id}-boiler-sensor-hoursTillService"
+        self._attr_unique_id = f"{entry_id}-boiler-sensor-hours_till_service"
         self._attr_name = "Hours Till Service"
 
     @property
@@ -2010,9 +2010,9 @@ class HelianthusBoilerHoursTillServiceSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+        boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
         config = boiler_status.get("config", {}) if isinstance(boiler_status, dict) else {}
-        value = config.get("hoursTillService")
+        value = config.get("hours_till_service")
         if value is None:
             return None
         try:

--- a/custom_components/helianthus/smoke_profile.py
+++ b/custom_components/helianthus/smoke_profile.py
@@ -34,11 +34,11 @@ query SmokeDevicesExtended {
   devices {
     address
     manufacturer
-    deviceId
-    serialNumber
-    macAddress
-    softwareVersion
-    hardwareVersion
+    device_id
+    serial_number
+    mac_address
+    software_version
+    hardware_version
   }
 }
 """
@@ -48,40 +48,40 @@ query SmokeDevicesBase {
   devices {
     address
     manufacturer
-    deviceId
-    softwareVersion
-    hardwareVersion
+    device_id
+    software_version
+    hardware_version
   }
 }
 """
 
 QUERY_STATUS = """
 query SmokeStatus {
-  daemonStatus {
+  daemon_status {
     status
-    firmwareVersion
-    updatesAvailable
-    initiatorAddress
+    firmware_version
+    updates_available
+    initiator_address
   }
-  adapterStatus {
+  adapter_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
 }
 """
 
 QUERY_STATUS_LEGACY = """
 query SmokeStatus {
-  daemonStatus {
+  daemon_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
-  adapterStatus {
+  adapter_status {
     status
-    firmwareVersion
-    updatesAvailable
+    firmware_version
+    updates_available
   }
 }
 """
@@ -92,32 +92,32 @@ query SmokeSemantic {
     id
     name
     state {
-      currentTempC
-      currentHumidityPct
-      hvacAction
-      specialFunction
-      heatingDemandPct
-      valvePositionPct
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
-      allowedModes
-      circuitType
-      associatedCircuit
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
     }
   }
   dhw {
     state {
-      currentTempC
-      specialFunction
-      heatingDemandPct
+      current_temp_c
+      special_function
+      heating_demand_pct
     }
     config {
-      operatingMode
+      operating_mode
       preset
-      targetTempC
+      target_temp_c
     }
   }
 }
@@ -125,7 +125,7 @@ query SmokeSemantic {
 
 QUERY_ENERGY = """
 query SmokeEnergy {
-  energyTotals {
+  energy_totals {
     gas { dhw { today yearly monthly } climate { today yearly monthly } }
     electric { dhw { today yearly monthly } climate { today yearly monthly } }
     solar { dhw { today yearly monthly } climate { today yearly monthly } }
@@ -135,7 +135,7 @@ query SmokeEnergy {
 
 QUERY_ENERGY_LEGACY = """
 query SmokeEnergy {
-  energyTotals {
+  energy_totals {
     gas { dhw { today yearly } climate { today yearly } }
     electric { dhw { today yearly } climate { today yearly } }
     solar { dhw { today yearly } climate { today yearly } }
@@ -323,7 +323,7 @@ def _check_subscriptions_fallback(execute: GraphQLExecutor) -> SmokeCheck:
     if isinstance(data, dict):
         schema = data.get("__schema", {})
         if isinstance(schema, dict):
-            subscription_type = schema.get("subscription_type")
+            subscription_type = schema.get("subscriptionType")
             if isinstance(subscription_type, dict):
                 raw_name = subscription_type.get("name")
                 if isinstance(raw_name, str):

--- a/custom_components/helianthus/smoke_profile.py
+++ b/custom_components/helianthus/smoke_profile.py
@@ -143,7 +143,7 @@ query SmokeEnergy {
 }
 """
 
-MISSING_DEVICE_FIELDS = ["serialNumber", "macAddress"]
+MISSING_DEVICE_FIELDS = ["serial_number", "mac_address"]
 INVENTORY_FIELD_COUNT = 7
 DAEMON_STATUS_FIELD_COUNT = 4
 ADAPTER_STATUS_FIELD_COUNT = 3
@@ -323,7 +323,7 @@ def _check_subscriptions_fallback(execute: GraphQLExecutor) -> SmokeCheck:
     if isinstance(data, dict):
         schema = data.get("__schema", {})
         if isinstance(schema, dict):
-            subscription_type = schema.get("subscriptionType")
+            subscription_type = schema.get("subscription_type")
             if isinstance(subscription_type, dict):
                 raw_name = subscription_type.get("name")
                 if isinstance(raw_name, str):
@@ -360,8 +360,8 @@ def _check_entity_creation(execute: GraphQLExecutor) -> SmokeCheck:
         if error:
             return SmokeCheck("entity_creation", False, error)
 
-        daemon_status = status_data.get("daemonStatus")
-        adapter_status = status_data.get("adapterStatus")
+        daemon_status = status_data.get("daemon_status")
+        adapter_status = status_data.get("adapter_status")
         if not isinstance(daemon_status, dict) or not isinstance(adapter_status, dict):
             return SmokeCheck(
                 "entity_creation",
@@ -372,7 +372,7 @@ def _check_entity_creation(execute: GraphQLExecutor) -> SmokeCheck:
         valid_devices = [
             device
             for device in devices
-            if isinstance(device, dict) and device.get("address") is not None and device.get("deviceId")
+            if isinstance(device, dict) and device.get("address") is not None and device.get("device_id")
         ]
         if len(valid_devices) == 0:
             return SmokeCheck("entity_creation", False, "no devices discovered for entity creation")
@@ -497,7 +497,7 @@ def _fetch_status(execute: GraphQLExecutor) -> tuple[dict[str, Any], str | None]
     if response is None:
         return {}, "status query returned no response"
     data, error, errors = _extract_data_with_errors(response)
-    if error and _is_missing_field_error(errors, ["initiatorAddress"]):
+    if error and _is_missing_field_error(errors, ["initiator_address"]):
         fallback, fallback_error = _execute_graphql(execute, QUERY_STATUS_LEGACY, "status_legacy")
         if fallback_error:
             return {}, fallback_error
@@ -546,14 +546,14 @@ def _fetch_energy(execute: GraphQLExecutor) -> tuple[dict[str, Any], str, str | 
         if error:
             return {}, "", f"energy legacy query failed: {error}"
         if not isinstance(data, dict):
-            return {"energyTotals": None}, "fallback_non_object", None
+            return {"energy_totals": None}, "fallback_non_object", None
         return data, "legacy", None
-    if error and _is_missing_field_error(errors, ["energyTotals"]):
-        return {"energyTotals": None}, "fallback_missing_field", None
+    if error and _is_missing_field_error(errors, ["energy_totals"]):
+        return {"energy_totals": None}, "fallback_missing_field", None
     if error:
         return {}, "", f"energy query failed: {error}"
     if not isinstance(data, dict):
-        return {"energyTotals": None}, "fallback_non_object", None
+        return {"energy_totals": None}, "fallback_non_object", None
     return data, "full", None
 
 

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -14,48 +14,48 @@ _LOGGER = logging.getLogger(__name__)
 SUBSCRIPTIONS = {
     "zones": """
     subscription {
-      zoneUpdate {
+      zone_update {
         id
         name
         state {
-          currentTempC
-          currentHumidityPct
-          hvacAction
-          specialFunction
-          heatingDemandPct
-          valvePositionPct
+          current_temp_c
+          current_humidity_pct
+          hvac_action
+          special_function
+          heating_demand_pct
+          valve_position_pct
         }
         config {
-          operatingMode
+          operating_mode
           preset
-          targetTempC
-          allowedModes
-          circuitType
-          associatedCircuit
-          roomTemperatureZoneMapping
+          target_temp_c
+          allowed_modes
+          circuit_type
+          associated_circuit
+          room_temperature_zone_mapping
         }
       }
     }
     """,
     "dhw": """
     subscription {
-      dhwUpdate {
+      dhw_update {
         state {
-          currentTempC
-          specialFunction
-          heatingDemandPct
+          current_temp_c
+          special_function
+          heating_demand_pct
         }
         config {
-          operatingMode
+          operating_mode
           preset
-          targetTempC
+          target_temp_c
         }
       }
     }
     """,
     "energy": """
     subscription {
-      energyUpdate {
+      energy_update {
         gas { dhw { today yearly } climate { today yearly } }
         electric { dhw { today yearly } climate { today yearly } }
         solar { dhw { today yearly } climate { today yearly } }
@@ -64,35 +64,35 @@ SUBSCRIPTIONS = {
     """,
     "boiler": """
     subscription {
-      boilerStatusUpdate {
+      boiler_status_update {
         state {
-          flowTemperatureC
-          returnTemperatureC
-          centralHeatingPumpActive
+          flow_temperature_c
+          return_temperature_c
+          central_heating_pump_active
         }
         diagnostics {
-          heatingStatusRaw
+          heating_status_raw
         }
       }
     }
     """,
     "radio_devices": """
     subscription {
-      radioDevicesUpdate {
+      radio_devices_update {
         group
         instance
-        slotMode
-        deviceConnected
-        deviceClassAddress
-        deviceModel
-        firmwareVersion
-        hardwareIdentifier
-        remoteControlAddress
-        devicePaired
-        receptionStrength
-        zoneAssignment
-        roomTemperatureC
-        roomHumidityPct
+        slot_mode
+        device_connected
+        device_class_address
+        device_model
+        firmware_version
+        hardware_identifier
+        remote_control_address
+        device_paired
+        reception_strength
+        zone_assignment
+        room_temperature_c
+        room_humidity_pct
       }
     }
     """,

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -241,8 +241,8 @@ async def _handle_message(
     if not isinstance(data, dict):
         return
 
-    if "zoneUpdate" in data:
-        zone = data.get("zoneUpdate")
+    if "zone_update" in data:
+        zone = data.get("zone_update")
         if not isinstance(zone, dict):
             zone = {}
         if semantic_coordinator and isinstance(semantic_coordinator.data, dict):
@@ -256,8 +256,8 @@ async def _handle_message(
                     }
                 )
 
-    if "dhwUpdate" in data:
-        dhw = data.get("dhwUpdate")
+    if "dhw_update" in data:
+        dhw = data.get("dhw_update")
         if semantic_coordinator and isinstance(semantic_coordinator.data, dict) and (
             dhw is None or isinstance(dhw, dict)
         ):
@@ -270,22 +270,22 @@ async def _handle_message(
                 }
             )
 
-    if "energyUpdate" in data and energy_coordinator:
-        energy = data.get("energyUpdate")
+    if "energy_update" in data and energy_coordinator:
+        energy = data.get("energy_update")
         if isinstance(energy, dict):
-            energy_coordinator.async_set_updated_data({"energyTotals": energy})
+            energy_coordinator.async_set_updated_data({"energy_totals": energy})
 
-    if "boilerStatusUpdate" in data and boiler_coordinator:
-        boiler = data.get("boilerStatusUpdate")
+    if "boiler_status_update" in data and boiler_coordinator:
+        boiler = data.get("boiler_status_update")
         if isinstance(boiler, dict):
             current = boiler_coordinator.data if isinstance(boiler_coordinator.data, dict) else {}
-            boiler_coordinator.async_set_updated_data(_merge_dicts(current, {"boilerStatus": boiler}))
+            boiler_coordinator.async_set_updated_data(_merge_dicts(current, {"boiler_status": boiler}))
 
-    if "radioDevicesUpdate" in data and radio_coordinator:
-        radio_devices = data.get("radioDevicesUpdate")
+    if "radio_devices_update" in data and radio_coordinator:
+        radio_devices = data.get("radio_devices_update")
         if hasattr(radio_coordinator, "apply_radio_update"):
             radio_coordinator.apply_radio_update(radio_devices)
         elif isinstance(radio_devices, list):
             radio_coordinator.async_set_updated_data(
-                {"radioDevices": radio_devices, "radioZoneCandidates": {}}
+                {"radio_devices": radio_devices, "radio_zone_candidates": {}}
             )

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -142,7 +142,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
+        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -16,7 +16,7 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
 mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
-  setCircuitConfig(index: $index, field: $field, value: $value) {
+  set_circuit_config(index: $index, field: $field, value: $value) {
     success
     error
   }
@@ -142,7 +142,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -46,7 +46,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -54,7 +54,7 @@ def _circuit_name(circuit: dict[str, Any], index: int) -> str:
 def _fm5_mode(payload: dict[str, Any] | None) -> str:
     if not isinstance(payload, dict):
         return "ABSENT"
-    mode = str(payload.get("fm5SemanticMode") or "ABSENT").strip().upper()
+    mode = str(payload.get("fm5_semantic_mode") or "ABSENT").strip().upper()
     if mode not in {"INTERPRETED", "GPIO_ONLY", "ABSENT"}:
         return "ABSENT"
     return mode
@@ -123,7 +123,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
     def is_on(self) -> bool | None:
         circuit = self._circuit()
         config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
-        value = config.get("coolingEnabled")
+        value = config.get("cooling_enabled")
         if isinstance(value, bool):
             return value
         return None
@@ -134,7 +134,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
 
         variables = {
             "index": int(self._circuit_index),
-            "field": "coolingEnabled",
+            "field": "cooling_enabled",
             "value": "true" if enabled else "false",
         }
         try:
@@ -142,7 +142,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setCircuitConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_circuit_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -44,12 +44,12 @@ class InstallerTextField:
 
 
 _SYSTEM_TEXT_FIELDS = [
-    InstallerTextField(key="installerName", label="Installer Name", max_length=12, source="system"),
-    InstallerTextField(key="installerPhone", label="Installer Phone", max_length=12, source="system", icon="mdi:phone-outline"),
+    InstallerTextField(key="installer_name", label="Installer Name", max_length=12, source="system"),
+    InstallerTextField(key="installer_phone", label="Installer Phone", max_length=12, source="system", icon="mdi:phone-outline"),
 ]
 
 _BOILER_TEXT_FIELDS = [
-    InstallerTextField(key="phoneNumber", label="Boiler Installer Phone", max_length=16, source="boiler", icon="mdi:phone-outline"),
+    InstallerTextField(key="phone_number", label="Boiler Installer Phone", max_length=16, source="boiler", icon="mdi:phone-outline"),
 ]
 
 
@@ -64,11 +64,11 @@ class InstallerMenuCodeField:
 
 
 _SYSTEM_MENU_CODE_FIELD = InstallerMenuCodeField(
-    key="installerMenuCode", label="Installer Menu Code", max_value=999, digits=3, source="system",
+    key="installer_menu_code", label="Installer Menu Code", max_value=999, digits=3, source="system",
 )
 
 _BOILER_MENU_CODE_FIELD = InstallerMenuCodeField(
-    key="installerMenuCode", label="Boiler Installer Menu Code", max_value=255, digits=3, source="boiler",
+    key="installer_menu_code", label="Boiler Installer Menu Code", max_value=255, digits=3, source="boiler",
 )
 
 
@@ -113,7 +113,7 @@ async def async_setup_entry(
                 device_id=regulator_device_id,
                 field=_SYSTEM_MENU_CODE_FIELD,
                 mutation=_SET_SYSTEM_CONFIG_MUTATION,
-                mutation_key="setSystemConfig",
+                mutation_key="set_system_config",
             )
         )
 
@@ -138,7 +138,7 @@ async def async_setup_entry(
                 device_id=boiler_device_id,
                 field=_BOILER_MENU_CODE_FIELD,
                 mutation=_SET_BOILER_CONFIG_MUTATION,
-                mutation_key="setBoilerConfig",
+                mutation_key="set_boiler_config",
             )
         )
 
@@ -179,7 +179,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
         return str(value) if value is not None else None
 
     async def async_set_value(self, value: str) -> None:
-        if self._field.key == "installerPhone":
+        if self._field.key == "installer_phone":
             allowed = set("0123456789+() ")
             for i, ch in enumerate(value):
                 if ch not in allowed:
@@ -199,7 +199,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -237,7 +237,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
     @property
     def native_value(self) -> str | None:
         payload = self.coordinator.data or {}
-        boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+        boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
         config = boiler_status.get("config", {}) if isinstance(boiler_status, dict) else {}
         value = config.get(self._field.key)
         return str(value) if value is not None else None
@@ -262,7 +262,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -319,7 +319,7 @@ class HelianthusInstallerMenuCodeText(CoordinatorEntity, TextEntity):
     def native_value(self) -> str | None:
         if self._field.source == "boiler":
             payload = self.coordinator.data or {}
-            boiler_status = payload.get("boilerStatus") if isinstance(payload, dict) else None
+            boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
             config = boiler_status.get("config", {}) if isinstance(boiler_status, dict) else {}
         else:
             payload = self.coordinator.data or {}

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -199,7 +199,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_system_config") if isinstance(payload, dict) else None
+        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -262,7 +262,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
+        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -17,7 +17,7 @@ from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_SYSTEM_CONFIG_MUTATION = """
 mutation SetSystemConfig($field: String!, $value: String!) {
-  setSystemConfig(field: $field, value: $value) {
+  set_system_config(field: $field, value: $value) {
     success
     error
   }
@@ -26,7 +26,7 @@ mutation SetSystemConfig($field: String!, $value: String!) {
 
 _SET_BOILER_CONFIG_MUTATION = """
 mutation SetBoilerConfig($field: String!, $value: String!) {
-  setBoilerConfig(field: $field, value: $value) {
+  set_boiler_config(field: $field, value: $value) {
     success
     error
   }
@@ -199,7 +199,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setSystemConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_system_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return
@@ -262,7 +262,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
         except (GraphQLClientError, GraphQLResponseError) as exc:
             raise HomeAssistantError(f"Helianthus write failed: {exc}") from exc
 
-        result = payload.get("setBoilerConfig") if isinstance(payload, dict) else None
+        result = payload.get("set_boiler_config") if isinstance(payload, dict) else None
         if isinstance(result, dict) and result.get("success"):
             await self.coordinator.async_request_refresh()
             return

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -43,7 +43,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuitType") or "").strip().lower()
+    token = str(circuit.get("circuit_type") or "").strip().lower()
     label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
     return f"Circuit {index + 1} ({label})"
 
@@ -121,7 +121,7 @@ def _coerce_position(value: object | None) -> int | None:
 def _boiler_state(payload: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {}
-    boiler_status = payload.get("boilerStatus")
+    boiler_status = payload.get("boiler_status")
     if not isinstance(boiler_status, dict):
         return {}
     state = boiler_status.get("state")
@@ -166,7 +166,7 @@ class HelianthusBoilerDiverterValve(HelianthusReadOnlyValve):
 
     @property
     def current_valve_position(self) -> int | None:
-        return _coerce_position(_boiler_state(self.coordinator.data).get("diverterValvePositionPct"))
+        return _coerce_position(_boiler_state(self.coordinator.data).get("diverter_valve_position_pct"))
 
     @property
     def is_closed(self) -> bool | None:
@@ -234,7 +234,7 @@ class HelianthusCircuitMixingValve(HelianthusReadOnlyValve):
     def current_valve_position(self) -> int | None:
         circuit = self._circuit()
         state = circuit.get("state") if isinstance(circuit.get("state"), dict) else {}
-        return _coerce_position(state.get("mixerPositionPct"))
+        return _coerce_position(state.get("mixer_position_pct"))
 
 
 class HelianthusZoneValve(HelianthusReadOnlyValve):
@@ -284,4 +284,4 @@ class HelianthusZoneValve(HelianthusReadOnlyValve):
     def current_valve_position(self) -> int | None:
         zone = self._zone()
         state = zone.get("state") if isinstance(zone.get("state"), dict) else {}
-        return _coerce_position(state.get("valvePositionPct"))
+        return _coerce_position(state.get("valve_position_pct"))

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -124,17 +124,17 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        value = self._dhw_state().get("currentTempC")
+        value = self._dhw_state().get("current_temp_c")
         return float(value) if value is not None else None
 
     @property
     def target_temperature(self) -> float | None:
-        value = self._dhw_config().get("targetTempC")
+        value = self._dhw_config().get("target_temp_c")
         return float(value) if value is not None else None
 
     @property
     def current_operation(self) -> str | None:
-        mode = str(self._dhw_config().get("operatingMode") or "").strip().lower()
+        mode = str(self._dhw_config().get("operating_mode") or "").strip().lower()
         if mode in {"off", "auto", "manual"}:
             return mode
         if mode == "heat":
@@ -161,10 +161,10 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
             attrs["preset"] = "away"
         elif preset:
             attrs["preset"] = preset
-        demand = state.get("heatingDemandPct")
+        demand = state.get("heating_demand_pct")
         if demand is not None:
             attrs["heating_demand_pct"] = demand
-        special = state.get("specialFunction")
+        special = state.get("special_function")
         if special is not None and str(special).strip() != "":
             attrs["special_function"] = special
         return attrs

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -63,7 +63,7 @@ def zone_instance_from_id(zone_id: object | None) -> int | None:
 def radio_devices_from_payload(radio_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(radio_payload, dict):
         return []
-    items = radio_payload.get("radioDevices")
+    items = radio_payload.get("radio_devices")
     if not isinstance(items, list):
         return []
     return [item for item in items if isinstance(item, dict)]
@@ -74,7 +74,7 @@ def radio_zone_candidates_from_payload(
 ) -> dict[int, list[dict[str, Any]]]:
     if not isinstance(radio_payload, dict):
         return {}
-    raw_candidates = radio_payload.get("radioZoneCandidates")
+    raw_candidates = radio_payload.get("radio_zone_candidates")
     if not isinstance(raw_candidates, dict):
         return {}
     out: dict[int, list[dict[str, Any]]] = {}
@@ -104,12 +104,12 @@ def radio_device_ids_from_payload(
             {
                 "group": device.get("group"),
                 "instance": device.get("instance"),
-                "remote_control_address": device.get("remoteControlAddress"),
+                "remote_control_address": device.get("remote_control_address"),
             }
         )
         if normalized is None:
             continue
-        bus_key = str(device.get("radioBusKey") or "").strip()
+        bus_key = str(device.get("radio_bus_key") or "").strip()
         if not bus_key:
             bus_key = build_radio_bus_key(normalized["group"], normalized["instance"])
         out[(normalized["group"], normalized["instance"])] = radio_device_identifier(entry_id, bus_key)
@@ -121,13 +121,13 @@ def build_global_radio_candidates(radio_devices: list[dict[str, Any]]) -> list[d
     for device in radio_devices:
         if not isinstance(device, dict):
             continue
-        if device.get("deviceConnected") is not True:
+        if device.get("device_connected") is not True:
             continue
         normalized = normalize_radio_slot_candidate(
             {
                 "group": device.get("group"),
                 "instance": device.get("instance"),
-                "remote_control_address": device.get("remoteControlAddress"),
+                "remote_control_address": device.get("remote_control_address"),
             }
         )
         if normalized is None:
@@ -262,7 +262,7 @@ def build_zone_parent_device_ids(
         if zone_id is None or zone_instance is None:
             continue
         config = zone.get("config")
-        mapping = parse_optional_int(config.get("roomTemperatureZoneMapping")) if isinstance(config, dict) else None
+        mapping = parse_optional_int(config.get("room_temperature_zone_mapping")) if isinstance(config, dict) else None
         parent_device_id = zone_via_device(
             zone_instance,
             mapping,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -109,13 +109,13 @@ def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
         "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
         "boiler_coordinator": _FakeCoordinator(
             {
-                "boilerStatus": {
+                "boiler_status": {
                     "state": {
-                        "flameActive": True,
-                        "gasValveActive": False,
-                        "centralHeatingPumpActive": True,
-                        "externalPumpActive": False,
-                        "circulationPumpActive": True,
+                        "flame_active": True,
+                        "gas_valve_active": False,
+                        "central_heating_pump_active": True,
+                        "external_pump_active": False,
+                        "circulation_pump_active": True,
                     }
                 }
             }
@@ -144,11 +144,11 @@ def test_async_setup_entry_adds_boiler_state_binary_sensors_on_bai00_only() -> N
     ]
 
     assert {entity._attr_unique_id for entity in boiler_entities} == {
-        "entry-1-boiler-binary-flameActive",
-        "entry-1-boiler-binary-gasValveActive",
-        "entry-1-boiler-binary-centralHeatingPumpActive",
-        "entry-1-boiler-binary-externalPumpActive",
-        "entry-1-boiler-binary-circulationPumpActive",
+        "entry-1-boiler-binary-flame_active",
+        "entry-1-boiler-binary-gas_valve_active",
+        "entry-1-boiler-binary-central_heating_pump_active",
+        "entry-1-boiler-binary-external_pump_active",
+        "entry-1-boiler-binary-circulation_pump_active",
     }
     assert {entity._attr_name for entity in boiler_entities} == {
         "Burner Flame Active",
@@ -161,8 +161,8 @@ def test_async_setup_entry_adds_boiler_state_binary_sensors_on_bai00_only() -> N
         assert entity._attr_device_class == binary_sensor_platform.BinarySensorDeviceClass.RUNNING
         assert entity.device_info["identifiers"] == {boiler_device_id}
 
-    flame = next(entity for entity in boiler_entities if entity._attr_unique_id.endswith("flameActive"))
-    gas_valve = next(entity for entity in boiler_entities if entity._attr_unique_id.endswith("gasValveActive"))
+    flame = next(entity for entity in boiler_entities if entity._attr_unique_id.endswith("flame_active"))
+    gas_valve = next(entity for entity in boiler_entities if entity._attr_unique_id.endswith("gas_valve_active"))
     assert flame.is_on is True
     assert gas_valve.is_on is False
 
@@ -191,8 +191,8 @@ def _build_zone_payload(valve_position_pct):
                 {
                     "id": "zone-1",
                     "name": "Living Room",
-                    "state": {"valvePositionPct": valve_position_pct},
-                    "config": {"roomTemperatureZoneMapping": None},
+                    "state": {"valve_position_pct": valve_position_pct},
+                    "config": {"room_temperature_zone_mapping": None},
                 },
             ],
             "dhw": None,

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -97,7 +97,7 @@ def _make_program(zone=0, hc="heating", days=None, config=None):
     return {
         "zone": zone,
         "hc": hc,
-        "config": config or {"maxSlots": 3, "hasTemperature": True},
+        "config": config or {"max_slots": 3, "has_temperature": True},
         "days": days or [],
     }
 
@@ -152,7 +152,7 @@ def test_event_returns_none_when_no_program() -> None:
 
 
 def test_make_event_with_temperature() -> None:
-    slot = {"startHour": 6, "startMinute": 0, "endHour": 22, "endMinute": 0, "temperatureC": 22.5}
+    slot = {"start_hour": 6, "start_minute": 0, "end_hour": 22, "end_minute": 0, "temperature_c": 22.5}
     program = _make_program(
         zone=0,
         hc="heating",
@@ -170,7 +170,7 @@ def test_make_event_with_temperature() -> None:
 
 
 def test_make_event_24h_end() -> None:
-    slot = {"startHour": 0, "startMinute": 0, "endHour": 24, "endMinute": 0}
+    slot = {"start_hour": 0, "start_minute": 0, "end_hour": 24, "end_minute": 0}
     program = _make_program(zone=255, hc="dhw")
     cal = _make_calendar(program, zone=255, hc="dhw")
     today = date(2026, 3, 9)
@@ -184,7 +184,7 @@ def test_make_event_24h_end() -> None:
 
 
 def test_make_event_zero_duration_returns_none() -> None:
-    slot = {"startHour": 10, "startMinute": 0, "endHour": 10, "endMinute": 0}
+    slot = {"start_hour": 10, "start_minute": 0, "end_hour": 10, "end_minute": 0}
     program = _make_program()
     cal = _make_calendar(program)
 
@@ -194,7 +194,7 @@ def test_make_event_zero_duration_returns_none() -> None:
 
 
 def test_get_day_slots_matches_weekday() -> None:
-    slot = {"startHour": 6, "startMinute": 0, "endHour": 22, "endMinute": 0}
+    slot = {"start_hour": 6, "start_minute": 0, "end_hour": 22, "end_minute": 0}
     program = _make_program(
         days=[
             {"weekday": "monday", "slots": [slot]},

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -209,7 +209,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"set_circuit_config": {"success": True, "error": None}}
+        return {"setCircuitConfig": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -209,7 +209,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setCircuitConfig": {"success": True, "error": None}}
+        return {"set_circuit_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -209,7 +209,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setCircuitConfig": {"success": True, "error": None}}
+        return {"set_circuit_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:
@@ -226,52 +226,52 @@ def _circuits() -> list[dict]:
     return [
         {
             "index": 0,
-            "circuitType": "heating",
-            "hasMixer": True,
+            "circuit_type": "heating",
+            "has_mixer": True,
             "state": {
-                "pumpActive": True,
-                "mixerPositionPct": 37.8,
-                "flowTemperatureC": 42.5,
-                "flowSetpointC": 45.0,
-                "calcFlowTempC": 44.0,
-                "circuitState": "heating",
+                "pump_active": True,
+                "mixer_position_pct": 37.8,
+                "flow_temperature_c": 42.5,
+                "flow_setpoint_c": 45.0,
+                "calc_flow_temp_c": 44.0,
+                "circuit_state": "heating",
                 "humidity": 49.2,
-                "dewPoint": 11.1,
-                "pumpHours": 120.0,
-                "pumpStarts": 55,
+                "dew_point": 11.1,
+                "pump_hours": 120.0,
+                "pump_starts": 55,
             },
             "config": {
-                "heatingCurve": 1.3,
-                "flowTempMaxC": 70.0,
-                "flowTempMinC": 20.0,
-                "summerLimitC": 22.0,
-                "frostProtC": -5.0,
-                "roomTempControl": "modulating",
+                "heating_curve": 1.3,
+                "flow_temp_max_c": 70.0,
+                "flow_temp_min_c": 20.0,
+                "summer_limit_c": 22.0,
+                "frost_prot_c": -5.0,
+                "room_temp_control": "modulating",
             },
         },
         {
             "index": 1,
-            "circuitType": "fixed_value",
-            "hasMixer": False,
+            "circuit_type": "fixed_value",
+            "has_mixer": False,
             "state": {
-                "pumpActive": False,
-                "mixerPositionPct": None,
-                "flowTemperatureC": 31.0,
-                "flowSetpointC": 33.0,
-                "calcFlowTempC": 32.5,
-                "circuitState": "standby",
+                "pump_active": False,
+                "mixer_position_pct": None,
+                "flow_temperature_c": 31.0,
+                "flow_setpoint_c": 33.0,
+                "calc_flow_temp_c": 32.5,
+                "circuit_state": "standby",
                 "humidity": None,
-                "dewPoint": None,
-                "pumpHours": 10.0,
-                "pumpStarts": 3,
+                "dew_point": None,
+                "pump_hours": 10.0,
+                "pump_starts": 3,
             },
             "config": {
-                "heatingCurve": 1.0,
-                "flowTempMaxC": 55.0,
-                "flowTempMinC": 15.0,
-                "summerLimitC": 24.0,
-                "frostProtC": -3.0,
-                "roomTempControl": "off",
+                "heating_curve": 1.0,
+                "flow_temp_max_c": 55.0,
+                "flow_temp_min_c": 15.0,
+                "summer_limit_c": 24.0,
+                "frost_prot_c": -3.0,
+                "room_temp_control": "off",
             },
         },
     ]
@@ -333,11 +333,11 @@ def test_circuit_binary_sensor_platform_adds_one_pump_per_circuit() -> None:
     ]
     assert len(pump_entities) == 2
     assert {entity._attr_unique_id for entity in pump_entities} == {
-        "entry-1-circuit-0-binary-pumpActive",
-        "entry-1-circuit-1-binary-pumpActive",
+        "entry-1-circuit-0-binary-pump_active",
+        "entry-1-circuit-1-binary-pump_active",
     }
-    first = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("0-binary-pumpActive"))
-    second = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("1-binary-pumpActive"))
+    first = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("0-binary-pump_active"))
+    second = next(entity for entity in pump_entities if entity._attr_unique_id.endswith("1-binary-pump_active"))
     assert first.is_on is True
     assert second.is_on is False
 
@@ -360,7 +360,7 @@ def test_circuit_sensor_platform_adds_expected_sensors_without_zone_link_attrs()
     state_sensor = next(
         entity
         for entity in circuit_entities
-        if entity._attr_unique_id == "entry-1-circuit-0-sensor-circuitState"
+        if entity._attr_unique_id == "entry-1-circuit-0-sensor-circuit_state"
     )
     attrs = state_sensor.extra_state_attributes
     assert attrs["circuit_index"] == 0
@@ -384,7 +384,7 @@ def test_circuit_number_select_entities_call_circuit_config_mutation_without_coo
     heating_curve = next(
         entity
         for entity in number_entities
-        if isinstance(entity, number_platform.HelianthusCircuitNumber) and entity._field.key == "heatingCurve"
+        if isinstance(entity, number_platform.HelianthusCircuitNumber) and entity._field.key == "heating_curve"
     )
     room_temp_control = next(
         entity
@@ -397,6 +397,6 @@ def test_circuit_number_select_entities_call_circuit_config_mutation_without_coo
     asyncio.run(room_temp_control.async_select_option("thermostat"))
 
     fields_written = [call["variables"]["field"] for call in client.calls]
-    assert fields_written == ["heatingCurve", "roomTempControl"]
+    assert fields_written == ["heating_curve", "room_temp_control"]
     assert switch_entities == []
     assert circuit_coordinator.refresh_requests == 2

--- a/tests/test_climate_quickveto.py
+++ b/tests/test_climate_quickveto.py
@@ -146,25 +146,25 @@ def _make_entity(
     qv_active: bool = False,
 ) -> tuple[HelianthusZoneClimate, _FakeClient, _FakeCoordinator]:
     config = {
-        "operatingMode": "auto",
+        "operating_mode": "auto",
         "preset": preset,
-        "targetTempC": target_temp,
-        "allowedModes": ["off", "auto", "heat"],
-        "circuitType": "heating",
-        "associatedCircuit": 0,
-        "roomTemperatureZoneMapping": 1,
-        "quickVeto": qv_active,
+        "target_temp_c": target_temp,
+        "allowed_modes": ["off", "auto", "heat"],
+        "circuit_type": "heating",
+        "associated_circuit": 0,
+        "room_temperature_zone_mapping": 1,
+        "quick_veto": qv_active,
     }
     if qv_setpoint is not None:
-        config["quickVetoSetpoint"] = qv_setpoint
+        config["quick_veto_setpoint"] = qv_setpoint
     if qv_duration is not None:
-        config["quickVetoDuration"] = qv_duration
+        config["quick_veto_duration"] = qv_duration
     zone_data = {
         "zones": [
             {
                 "id": "zone-1",
                 "name": "Living Room",
-                "state": {"currentTempC": 20.0},
+                "state": {"current_temp_c": 20.0},
                 "config": config,
             }
         ],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -158,7 +158,7 @@ def _build_fm5_coordinator(client: _ScriptedClient) -> HelianthusFM5Coordinator:
 
 def _energy_totals_payload(today: float = 3.5) -> dict[str, dict]:
     return {
-        "energyTotals": {
+        "energy_totals": {
             "gas": {
                 "dhw": {"today": today, "yearly": [120.0, 240.0]},
                 "climate": {"today": 0.0, "yearly": [0.0, 0.0]},
@@ -179,16 +179,16 @@ def test_v3_falls_back_to_v3_without_part_number() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "partNumber" on type "Device".'}]
+                [{"message": 'Cannot query field "part_number" on type "Device".'}]
             ),
             {
                 "devices": [
                     {
                         "address": 8,
                         "manufacturer": "Vaillant",
-                        "displayName": "sensoCOMFORT",
-                        "productFamily": "sensoCOMFORT",
-                        "productModel": "VRC 720f/2",
+                        "display_name": "sensoCOMFORT",
+                        "product_family": "sensoCOMFORT",
+                        "product_model": "VRC 720f/2",
                     }
                 ]
             },
@@ -199,7 +199,7 @@ def test_v3_falls_back_to_v3_without_part_number() -> None:
     data = asyncio.run(coordinator._async_update_data())
 
     assert len(data) == 1
-    assert data[0]["displayName"] == "sensoCOMFORT"
+    assert data[0]["display_name"] == "sensoCOMFORT"
     assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_PART]
 
 
@@ -214,7 +214,7 @@ def test_v3_falls_back_when_addresses_field_missing() -> None:
                     {
                         "address": 8,
                         "manufacturer": "Vaillant",
-                        "deviceId": "BASV2",
+                        "device_id": "BASV2",
                     }
                 ]
             },
@@ -233,7 +233,7 @@ def test_v2_fallback_wraps_transport_error_as_update_failed() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "displayName" on type "Device".'}]
+                [{"message": 'Cannot query field "display_name" on type "Device".'}]
             ),
             GraphQLClientError("timeout while reading response"),
         ]
@@ -254,7 +254,7 @@ def test_v2_fallback_drops_addresses_when_missing() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "displayName" on type "Device".'}]
+                [{"message": 'Cannot query field "display_name" on type "Device".'}]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "addresses" on type "Device".'}]
@@ -264,7 +264,7 @@ def test_v2_fallback_drops_addresses_when_missing() -> None:
                     {
                         "address": 21,
                         "manufacturer": "Vaillant",
-                        "deviceId": "BASV2",
+                        "device_id": "BASV2",
                     }
                 ]
             },
@@ -283,16 +283,16 @@ def test_status_query_uses_initiator_field_when_available() -> None:
     client = _ScriptedClient(
         [
             {
-                "daemonStatus": {
+                "daemon_status": {
                     "status": "running",
-                    "firmwareVersion": "0.3.10",
-                    "updatesAvailable": False,
-                    "initiatorAddress": "0xF7",
+                    "firmware_version": "0.3.10",
+                    "updates_available": False,
+                    "initiator_address": "0xF7",
                 },
-                "adapterStatus": {
+                "adapter_status": {
                     "status": "ok",
-                    "firmwareVersion": "3.0",
-                    "updatesAvailable": False,
+                    "firmware_version": "3.0",
+                    "updates_available": False,
                 },
             }
         ]
@@ -301,7 +301,7 @@ def test_status_query_uses_initiator_field_when_available() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data["daemon"]["initiatorAddress"] == "0xF7"
+    assert data["daemon"]["initiator_address"] == "0xF7"
     assert client.calls == [QUERY_STATUS]
 
 
@@ -309,18 +309,18 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "initiatorAddress" on type "ServiceStatus".'}]
+                [{"message": 'Cannot query field "initiator_address" on type "ServiceStatus".'}]
             ),
             {
-                "daemonStatus": {
+                "daemon_status": {
                     "status": "running",
-                    "firmwareVersion": "0.3.10",
-                    "updatesAvailable": False,
+                    "firmware_version": "0.3.10",
+                    "updates_available": False,
                 },
-                "adapterStatus": {
+                "adapter_status": {
                     "status": "ok",
-                    "firmwareVersion": "3.0",
-                    "updatesAvailable": False,
+                    "firmware_version": "3.0",
+                    "updates_available": False,
                 },
             },
         ]
@@ -330,7 +330,7 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     data = asyncio.run(coordinator._async_update_data())
 
     assert data["daemon"]["status"] == "running"
-    assert "initiatorAddress" not in data["daemon"]
+    assert "initiator_address" not in data["daemon"]
     assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]
 
 
@@ -340,10 +340,10 @@ def test_adapter_info_query_missing_root_field_reprobes_after_backoff(
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
+                [{"message": 'Cannot query field "adapter_hardware_info" on type "Query".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "adapterHardwareInfo" on type "Query".'}]
+                [{"message": 'Cannot query field "adapter_hardware_info" on type "Query".'}]
             ),
         ]
     )
@@ -367,24 +367,24 @@ def test_adapter_info_query_missing_root_field_reprobes_after_backoff(
 def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
     client = _ScriptedClient(
         [
-            GraphQLResponseError([{"message": 'boom on "adapterStatus"'}]),
+            GraphQLResponseError([{"message": 'boom on "adapter_status"'}]),
             {
-                "adapterHardwareInfo": {
-                    "firmwareVersion": "2.0.0",
-                    "infoSupported": True,
-                    "isWifi": True,
-                    "isEthernet": False,
-                    "versionResponseLen": 8,
+                "adapter_hardware_info": {
+                    "firmware_version": "2.0.0",
+                    "info_supported": True,
+                    "is_wifi": True,
+                    "is_ethernet": False,
+                    "version_response_len": 8,
                 }
             },
             {
-                "adapterHardwareInfo": {
-                    "firmwareVersion": "2.0.1",
-                    "infoSupported": True,
-                    "isWifi": True,
-                    "isEthernet": False,
-                    "versionResponseLen": 8,
-                    "temperatureC": 31.5,
+                "adapter_hardware_info": {
+                    "firmware_version": "2.0.1",
+                    "info_supported": True,
+                    "is_wifi": True,
+                    "is_ethernet": False,
+                    "version_response_len": 8,
+                    "temperature_c": 31.5,
                 }
             },
         ]
@@ -394,10 +394,10 @@ def test_adapter_info_query_unrelated_error_does_not_stick_to_minimal() -> None:
     first = asyncio.run(coordinator._async_update_data())
     second = asyncio.run(coordinator._async_update_data())
 
-    assert first["firmwareVersion"] == "2.0.0"
-    assert first["isWifi"] is True
-    assert second["firmwareVersion"] == "2.0.1"
-    assert second["temperatureC"] == 31.5
+    assert first["firmware_version"] == "2.0.0"
+    assert first["is_wifi"] is True
+    assert second["firmware_version"] == "2.0.1"
+    assert second["temperature_c"] == 31.5
     assert coordinator._hardware_info_supported is None  # type: ignore[attr-defined]
     assert client.calls == [
         QUERY_ADAPTER_HARDWARE_INFO,
@@ -410,25 +410,25 @@ def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() ->
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "bootloaderVersion" on type "AdapterHardwareInfo".'}]
+                [{"message": 'Cannot query field "bootloader_version" on type "AdapterHardwareInfo".'}]
             ),
             {
-                "adapterHardwareInfo": {
-                    "firmwareVersion": "2.0.0",
-                    "infoSupported": True,
-                    "isWifi": True,
-                    "isEthernet": False,
-                    "versionResponseLen": 8,
+                "adapter_hardware_info": {
+                    "firmware_version": "2.0.0",
+                    "info_supported": True,
+                    "is_wifi": True,
+                    "is_ethernet": False,
+                    "version_response_len": 8,
                 }
             },
             {
-                "adapterHardwareInfo": {
-                    "firmwareVersion": "2.0.1",
-                    "infoSupported": True,
-                    "isWifi": True,
-                    "isEthernet": False,
-                    "versionResponseLen": 8,
-                    "temperatureC": 31.5,
+                "adapter_hardware_info": {
+                    "firmware_version": "2.0.1",
+                    "info_supported": True,
+                    "is_wifi": True,
+                    "is_ethernet": False,
+                    "version_response_len": 8,
+                    "temperature_c": 31.5,
                 }
             },
         ]
@@ -438,10 +438,10 @@ def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() ->
     first = asyncio.run(coordinator._async_update_data())
     second = asyncio.run(coordinator._async_update_data())
 
-    assert first["firmwareVersion"] == "2.0.0"
-    assert first["isWifi"] is True
-    assert second["firmwareVersion"] == "2.0.1"
-    assert second["temperatureC"] == 31.5
+    assert first["firmware_version"] == "2.0.0"
+    assert first["is_wifi"] is True
+    assert second["firmware_version"] == "2.0.1"
+    assert second["temperature_c"] == 31.5
     assert coordinator._hardware_info_supported is False  # type: ignore[attr-defined]
     assert client.calls == [
         QUERY_ADAPTER_HARDWARE_INFO,
@@ -452,14 +452,14 @@ def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() ->
 
 def test_boiler_query_returns_status_payload() -> None:
     payload = {
-        "boilerStatus": {
+        "boiler_status": {
             "state": {
-                "flowTemperatureC": 63.0,
-                "returnTemperatureC": None,
-                "centralHeatingPumpActive": True,
+                "flow_temperature_c": 63.0,
+                "return_temperature_c": None,
+                "central_heating_pump_active": True,
             },
             "diagnostics": {
-                "heatingStatusRaw": 4,
+                "heating_status_raw": 4,
             },
         }
     }
@@ -468,7 +468,7 @@ def test_boiler_query_returns_status_payload() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data["boilerStatus"]["state"]["flowTemperatureC"] == 63.0
+    assert data["boiler_status"]["state"]["flow_temperature_c"] == 63.0
     assert client.calls[0] == QUERY_BOILER
 
 
@@ -476,7 +476,7 @@ def test_boiler_query_missing_field_falls_back_to_none() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "boilerStatus" on type "Query".'}]
+                [{"message": 'Cannot query field "boiler_status" on type "Query".'}]
             )
         ]
     )
@@ -484,7 +484,7 @@ def test_boiler_query_missing_field_falls_back_to_none() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data == {"boilerStatus": None}
+    assert data == {"boiler_status": None}
     assert client.calls[0] == QUERY_BOILER
     assert coordinator.boiler_supported is False
 
@@ -493,7 +493,7 @@ def test_boiler_query_missing_nested_field_falls_back_to_none() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "centralHeatingPumpActive" on type "BoilerState".'}]
+                [{"message": 'Cannot query field "central_heating_pump_active" on type "BoilerState".'}]
             )
         ]
     )
@@ -501,7 +501,7 @@ def test_boiler_query_missing_nested_field_falls_back_to_none() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data == {"boilerStatus": None}
+    assert data == {"boiler_status": None}
     assert client.calls[0] == QUERY_BOILER
     assert coordinator.boiler_supported is False
 
@@ -511,15 +511,15 @@ def test_circuit_query_returns_circuit_payload() -> None:
         "circuits": [
             {
                 "index": 0,
-                "circuitType": "heating",
-                "hasMixer": True,
-                "managingDevice": {
+                "circuit_type": "heating",
+                "has_mixer": True,
+                "managing_device": {
                     "role": "FUNCTION_MODULE",
-                    "deviceId": "VR_71",
+                    "device_id": "VR_71",
                     "address": 0x26,
                 },
-                "state": {"pumpActive": True},
-                "config": {"coolingEnabled": False},
+                "state": {"pump_active": True},
+                "config": {"cooling_enabled": False},
             }
         ]
     }
@@ -552,16 +552,16 @@ def test_system_query_returns_system_payload() -> None:
     payload = {
         "system": {
             "state": {
-                "systemWaterPressure": 1.7,
-                "maintenanceDue": False,
+                "system_water_pressure": 1.7,
+                "maintenance_due": False,
             },
             "config": {
-                "adaptiveHeatingCurve": True,
-                "maxRoomHumidity": 60,
+                "adaptive_heating_curve": True,
+                "max_room_humidity": 60,
             },
             "properties": {
-                "systemScheme": 3,
-                "moduleConfigurationVR71": 1,
+                "system_scheme": 3,
+                "module_configuration_vr71": 1,
             },
         }
     }
@@ -570,9 +570,9 @@ def test_system_query_returns_system_payload() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data["state"]["systemWaterPressure"] == 1.7
-    assert data["config"]["adaptiveHeatingCurve"] is True
-    assert data["properties"]["systemScheme"] == 3
+    assert data["state"]["system_water_pressure"] == 1.7
+    assert data["config"]["adaptive_heating_curve"] is True
+    assert data["properties"]["system_scheme"] == 3
     assert client.calls[0] == QUERY_SYSTEM
 
 
@@ -594,29 +594,29 @@ def test_system_query_missing_field_falls_back_to_empty_payload() -> None:
 
 def test_radio_query_builds_candidates_and_inventory_slot() -> None:
     payload = {
-        "radioDevices": [
+        "radio_devices": [
             {
                 "group": 0x09,
                 "instance": 1,
-                "deviceConnected": True,
-                "deviceClassAddress": 0x15,
-                "zoneAssignment": 2,
-                "remoteControlAddress": 0,
+                "device_connected": True,
+                "device_class_address": 0x15,
+                "zone_assignment": 2,
+                "remote_control_address": 0,
             },
             {
                 "group": 0x09,
                 "instance": 2,
-                "deviceConnected": False,
-                "deviceClassAddress": 0x15,
-                "zoneAssignment": 3,
+                "device_connected": False,
+                "device_class_address": 0x15,
+                "zone_assignment": 3,
             },
             {
                 "group": 0x0C,
                 "instance": 1,
-                "deviceConnected": False,
-                "deviceClassAddress": 0x26,
-                "firmwareVersion": "0805",
-                "hardwareIdentifier": 0x1234,
+                "device_connected": False,
+                "device_class_address": 0x26,
+                "firmware_version": "0805",
+                "hardware_identifier": 0x1234,
             },
         ]
     }
@@ -625,11 +625,11 @@ def test_radio_query_builds_candidates_and_inventory_slot() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    slots = {(int(item["group"]), int(item["instance"])) for item in data["radioDevices"]}
+    slots = {(int(item["group"]), int(item["instance"])) for item in data["radio_devices"]}
     assert slots == {(0x09, 1), (0x0C, 1)}
-    assert 1 in data["radioZoneCandidates"]
-    assert data["radioZoneCandidates"][1][0]["group"] == 0x09
-    assert data["radioZoneCandidates"][1][0]["instance"] == 1
+    assert 1 in data["radio_zone_candidates"]
+    assert data["radio_zone_candidates"][1][0]["group"] == 0x09
+    assert data["radio_zone_candidates"][1][0]["instance"] == 1
     assert client.calls == [QUERY_RADIO_DEVICES]
 
 
@@ -637,12 +637,12 @@ def test_radio_query_uses_stale_grace_cycles_for_disconnected_slot() -> None:
     client = _ScriptedClient(
         [
             {
-                "radioDevices": [
+                "radio_devices": [
                     {
                         "group": 0x09,
                         "instance": 1,
-                        "deviceConnected": True,
-                        "deviceClassAddress": 0x15,
+                        "device_connected": True,
+                        "device_class_address": 0x15,
                     }
                 ]
             }
@@ -650,28 +650,28 @@ def test_radio_query_uses_stale_grace_cycles_for_disconnected_slot() -> None:
     )
     coordinator = _build_radio_coordinator(client)
     first = asyncio.run(coordinator._async_update_data())
-    assert len(first["radioDevices"]) == 1
+    assert len(first["radio_devices"]) == 1
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
     )
-    assert coordinator.data["radioDevices"][0]["staleCycles"] == 1  # type: ignore[index]
+    assert coordinator.data["radio_devices"][0]["stale_cycles"] == 1  # type: ignore[index]
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
     )
-    assert coordinator.data["radioDevices"][0]["staleCycles"] == 2  # type: ignore[index]
+    assert coordinator.data["radio_devices"][0]["stale_cycles"] == 2  # type: ignore[index]
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "deviceConnected": False, "deviceClassAddress": 0x15}]
+        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
     )
-    assert coordinator.data["radioDevices"][0]["staleCycles"] == 3  # type: ignore[index]
+    assert coordinator.data["radio_devices"][0]["stale_cycles"] == 3  # type: ignore[index]
 
 
 def test_fm5_query_suppresses_interpreted_payload_when_gpio_only() -> None:
     client = _ScriptedClient(
         [
             {
-                "fm5SemanticMode": "GPIO_ONLY",
-                "solar": {"collectorTemperatureC": 70.0},
-                "cylinders": [{"index": 0, "temperatureC": 48.0}],
+                "fm5_semantic_mode": "GPIO_ONLY",
+                "solar": {"collector_temperature_c": 70.0},
+                "cylinders": [{"index": 0, "temperature_c": 48.0}],
             }
         ]
     )
@@ -679,7 +679,7 @@ def test_fm5_query_suppresses_interpreted_payload_when_gpio_only() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data["fm5SemanticMode"] == "GPIO_ONLY"
+    assert data["fm5_semantic_mode"] == "GPIO_ONLY"
     assert data["solar"] is None
     assert data["cylinders"] == []
     assert client.calls == [QUERY_FM5]
@@ -689,9 +689,9 @@ def test_fm5_query_returns_interpreted_payload() -> None:
     client = _ScriptedClient(
         [
             {
-                "fm5SemanticMode": "INTERPRETED",
-                "solar": {"collectorTemperatureC": 70.0},
-                "cylinders": [{"index": 0, "temperatureC": 48.0}],
+                "fm5_semantic_mode": "INTERPRETED",
+                "solar": {"collector_temperature_c": 70.0},
+                "cylinders": [{"index": 0, "temperature_c": 48.0}],
             }
         ]
     )
@@ -699,8 +699,8 @@ def test_fm5_query_returns_interpreted_payload() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data["fm5SemanticMode"] == "INTERPRETED"
-    assert data["solar"]["collectorTemperatureC"] == 70.0
+    assert data["fm5_semantic_mode"] == "INTERPRETED"
+    assert data["solar"]["collector_temperature_c"] == 70.0
     assert data["cylinders"][0]["index"] == 0
 
 
@@ -708,7 +708,7 @@ def test_energy_query_uses_root_energy_totals_and_caches_last_good() -> None:
     client = _ScriptedClient(
         [
             _energy_totals_payload(today=3.5),
-            {"energyTotals": None},
+            {"energy_totals": None},
         ]
     )
     coordinator = _build_energy_coordinator(client)
@@ -716,8 +716,8 @@ def test_energy_query_uses_root_energy_totals_and_caches_last_good() -> None:
     first = asyncio.run(coordinator._async_update_data())
     second = asyncio.run(coordinator._async_update_data())
 
-    assert first["energyTotals"]["gas"]["dhw"]["today"] == 3.5
-    assert second["energyTotals"]["gas"]["dhw"]["today"] == 3.5
+    assert first["energy_totals"]["gas"]["dhw"]["today"] == 3.5
+    assert second["energy_totals"]["gas"]["dhw"]["today"] == 3.5
     assert client.calls == [QUERY_ENERGY, QUERY_ENERGY]
 
 
@@ -725,7 +725,7 @@ def test_energy_query_returns_unavailable_before_first_valid_sample() -> None:
     client = _ScriptedClient(
         [
             GraphQLClientError("temporary upstream timeout"),
-            {"energyTotals": None},
+            {"energy_totals": None},
         ]
     )
     coordinator = _build_energy_coordinator(client)
@@ -733,8 +733,8 @@ def test_energy_query_returns_unavailable_before_first_valid_sample() -> None:
     first = asyncio.run(coordinator._async_update_data())
     second = asyncio.run(coordinator._async_update_data())
 
-    assert first == {"energyTotals": None}
-    assert second == {"energyTotals": None}
+    assert first == {"energy_totals": None}
+    assert second == {"energy_totals": None}
 
 
 def test_energy_query_falls_back_to_legacy_when_monthly_unsupported() -> None:
@@ -752,8 +752,8 @@ def test_energy_query_falls_back_to_legacy_when_monthly_unsupported() -> None:
     first = asyncio.run(coordinator._async_update_data())
     second = asyncio.run(coordinator._async_update_data())
 
-    assert first["energyTotals"]["gas"]["dhw"]["today"] == 5.0
-    assert second["energyTotals"]["gas"]["dhw"]["today"] == 6.0
+    assert first["energy_totals"]["gas"]["dhw"]["today"] == 5.0
+    assert second["energy_totals"]["gas"]["dhw"]["today"] == 6.0
     assert client.calls == [QUERY_ENERGY, QUERY_ENERGY_LEGACY, QUERY_ENERGY_LEGACY]
     assert coordinator._monthly_supported is False
 
@@ -772,9 +772,9 @@ def test_schedule_coordinator_returns_programs() -> None:
                 {
                     "zone": 0,
                     "hc": "heating",
-                    "config": {"maxSlots": 12, "hasTemperature": True},
+                    "config": {"max_slots": 12, "has_temperature": True},
                     "days": [
-                        {"weekday": "monday", "slots": [{"startHour": 6, "endHour": 22}]}
+                        {"weekday": "monday", "slots": [{"start_hour": 6, "end_hour": 22}]}
                     ],
                 }
             ]
@@ -825,13 +825,13 @@ def _build_semantic_coordinator(client: _ScriptedClient) -> HelianthusSemanticCo
 
 def _semantic_payload(**config_overrides: object) -> dict:
     config = {
-        "operatingMode": "auto",
+        "operating_mode": "auto",
         "preset": "schedule",
-        "targetTempC": 21.5,
-        "allowedModes": ["off", "auto", "heat"],
-        "circuitType": "heating",
-        "associatedCircuit": 0,
-        "roomTemperatureZoneMapping": 1,
+        "target_temp_c": 21.5,
+        "allowed_modes": ["off", "auto", "heat"],
+        "circuit_type": "heating",
+        "associated_circuit": 0,
+        "room_temperature_zone_mapping": 1,
     }
     config.update(config_overrides)
     return {
@@ -839,7 +839,7 @@ def _semantic_payload(**config_overrides: object) -> dict:
             {
                 "id": "zone-1",
                 "name": "Living Room",
-                "state": {"currentTempC": 20.0},
+                "state": {"current_temp_c": 20.0},
                 "config": config,
             }
         ],
@@ -849,7 +849,7 @@ def _semantic_payload(**config_overrides: object) -> dict:
 
 def test_semantic_full_query_succeeds() -> None:
     payload = _semantic_payload(
-        quickVeto=False, quickVetoSetpoint=16.0, quickVetoDuration=3.0
+        quick_veto=False, quick_veto_setpoint=16.0, quick_veto_duration=3.0
     )
     client = _ScriptedClient([payload])
     coordinator = _build_semantic_coordinator(client)
@@ -857,7 +857,7 @@ def test_semantic_full_query_succeeds() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert len(result["zones"]) == 1
-    assert result["zones"][0]["config"]["quickVeto"] is False
+    assert result["zones"][0]["config"]["quick_veto"] is False
     assert client.calls == [QUERY_SEMANTIC]
 
 
@@ -865,7 +865,7 @@ def test_semantic_falls_back_to_no_holiday() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "holidayStartDate" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
             ),
             _semantic_payload(),
         ]
@@ -882,10 +882,10 @@ def test_semantic_falls_back_to_no_qv() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quickVeto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quickVeto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
             ),
             _semantic_payload(),
         ]
@@ -902,15 +902,15 @@ def test_semantic_falls_back_to_legacy() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quickVeto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quickVeto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
                 [
                     {
-                        "message": 'Cannot query field "roomTemperatureZoneMapping" on type "ZoneConfig".'
+                        "message": 'Cannot query field "room_temperature_zone_mapping" on type "ZoneConfig".'
                     }
                 ]
             ),

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -110,7 +110,7 @@ def test_managing_device_identifier_routes_to_regulator_from_explicit_role() -> 
             regulator_device_id=regulator,
             vr71_device_id=vr71,
             adapter_device_id=adapter,
-            managing_device={"role": "REGULATOR", "deviceId": "BASV2", "address": 0x15},
+            managing_device={"role": "REGULATOR", "device_id": "BASV2", "address": 0x15},
         )
         == regulator
     )
@@ -128,7 +128,7 @@ def test_managing_device_identifier_routes_to_vr71_from_explicit_function_module
             regulator_device_id=regulator,
             vr71_device_id=vr71,
             adapter_device_id=adapter,
-            managing_device={"role": "FUNCTION_MODULE", "deviceId": "VR_71", "address": 0x26},
+            managing_device={"role": "FUNCTION_MODULE", "device_id": "VR_71", "address": 0x26},
         )
         == vr71
     )

--- a/tests/test_dhw_status.py
+++ b/tests/test_dhw_status.py
@@ -132,14 +132,14 @@ def test_sensor_platform_adds_dhw_status_sensor() -> None:
                 "zones": [],
                 "dhw": {
                     "state": {
-                        "currentTempC": 48.1,
-                        "specialFunction": "charging",
-                        "heatingDemandPct": 67,
+                        "current_temp_c": 48.1,
+                        "special_function": "charging",
+                        "heating_demand_pct": 67,
                     },
                     "config": {
-                        "operatingMode": "auto",
+                        "operating_mode": "auto",
                         "preset": "schedule",
-                        "targetTempC": 50.0,
+                        "target_temp_c": 50.0,
                     },
                 },
             }

--- a/tests/test_entity_icon_gate.py
+++ b/tests/test_entity_icon_gate.py
@@ -349,7 +349,7 @@ def test_valve_base_has_dynamic_icon_property() -> None:
 
 
 def test_valve_icon_at_zero_is_closed() -> None:
-    coord = _FakeCoordinator({"boilerStatus": {"state": {"diverterValvePositionPct": 0}}})
+    coord = _FakeCoordinator({"boiler_status": {"state": {"diverter_valve_position_pct": 0}}})
     valve = HelianthusBoilerDiverterValve(
         coordinator=coord,
         entry_id="test",
@@ -361,7 +361,7 @@ def test_valve_icon_at_zero_is_closed() -> None:
 
 
 def test_valve_icon_at_100_is_open() -> None:
-    coord = _FakeCoordinator({"boilerStatus": {"state": {"diverterValvePositionPct": 100}}})
+    coord = _FakeCoordinator({"boiler_status": {"state": {"diverter_valve_position_pct": 100}}})
     valve = HelianthusBoilerDiverterValve(
         coordinator=coord,
         entry_id="test",
@@ -373,7 +373,7 @@ def test_valve_icon_at_100_is_open() -> None:
 
 
 def test_valve_icon_intermediate() -> None:
-    coord = _FakeCoordinator({"boilerStatus": {"state": {"diverterValvePositionPct": 42}}})
+    coord = _FakeCoordinator({"boiler_status": {"state": {"diverter_valve_position_pct": 42}}})
     valve = HelianthusBoilerDiverterValve(
         coordinator=coord,
         entry_id="test",
@@ -385,7 +385,7 @@ def test_valve_icon_intermediate() -> None:
 
 
 def test_valve_icon_none_position() -> None:
-    coord = _FakeCoordinator({"boilerStatus": {"state": {}}})
+    coord = _FakeCoordinator({"boiler_status": {"state": {}}})
     valve = HelianthusBoilerDiverterValve(
         coordinator=coord,
         entry_id="test",
@@ -397,7 +397,7 @@ def test_valve_icon_none_position() -> None:
 
 
 def test_mixing_valve_icon_dynamic() -> None:
-    coord = _FakeCoordinator({"circuits": [{"index": 0, "state": {"mixerPositionPct": 0}}]})
+    coord = _FakeCoordinator({"circuits": [{"index": 0, "state": {"mixer_position_pct": 0}}]})
     valve = HelianthusCircuitMixingValve(
         coordinator=coord,
         entry_id="test",
@@ -409,7 +409,7 @@ def test_mixing_valve_icon_dynamic() -> None:
 
 
 def test_zone_valve_icon_dynamic() -> None:
-    coord = _FakeCoordinator({"zones": [{"id": "zone-1", "name": "Living", "state": {"valvePositionPct": 100}}]})
+    coord = _FakeCoordinator({"zones": [{"id": "zone-1", "name": "Living", "state": {"valve_position_pct": 100}}]})
     valve = HelianthusZoneValve(
         coordinator=coord,
         entry_id="test",
@@ -486,13 +486,13 @@ def test_circuit_counter_icon_is_mdi_counter() -> None:
 
 def test_circuit_mixer_position_has_valve_icon() -> None:
     for field in CIRCUIT_SENSOR_FIELDS:
-        if field.key == "mixerPositionPct":
+        if field.key == "mixer_position_pct":
             assert field.icon == "mdi:valve"
 
 
 def test_circuit_state_has_info_icon() -> None:
     for field in CIRCUIT_SENSOR_FIELDS:
-        if field.key == "circuitState":
+        if field.key == "circuit_state":
             assert field.icon == "mdi:information-outline"
 
 
@@ -511,11 +511,11 @@ def test_boiler_state_fields_have_icons() -> None:
 
 def test_boiler_state_specific_icons() -> None:
     expected = {
-        "modulationPct": "mdi:gas-burner",
-        "fanSpeedRpm": "mdi:fan",
-        "ionisationVoltageUa": "mdi:flash-triangle-outline",
-        "storageLoadPumpPct": "mdi:pump",
-        "diverterValvePositionPct": "mdi:valve",
+        "modulation_pct": "mdi:gas-burner",
+        "fan_speed_rpm": "mdi:fan",
+        "ionisation_voltage_ua": "mdi:flash-triangle-outline",
+        "storage_load_pump_pct": "mdi:pump",
+        "diverter_valve_position_pct": "mdi:valve",
     }
     for field in BOILER_STATE_SENSOR_FIELDS:
         key = field["key"]
@@ -547,9 +547,9 @@ def test_daemon_status_fields_have_icons() -> None:
 def test_status_specific_icons() -> None:
     expected = {
         "status": "mdi:information-outline",
-        "firmwareVersion": "mdi:tag-text-outline",
-        "updatesAvailable": "mdi:update",
-        "initiatorAddress": "mdi:chip",
+        "firmware_version": "mdi:tag-text-outline",
+        "updates_available": "mdi:update",
+        "initiator_address": "mdi:chip",
     }
     for field in DAEMON_STATUS_FIELDS:
         if field.key in expected:
@@ -565,7 +565,7 @@ def test_status_specific_icons() -> None:
 
 def test_system_scheme_has_icon() -> None:
     for field in SYSTEM_SENSOR_FIELDS:
-        if field.key == "systemScheme":
+        if field.key == "system_scheme":
             assert field.icon == "mdi:sitemap-outline"
 
 
@@ -583,9 +583,9 @@ def test_cylinder_config_fields_have_icons() -> None:
 
 def test_cylinder_config_specific_icons() -> None:
     expected = {
-        "maxSetpointC": "mdi:thermometer-high",
-        "chargeHysteresisC": "mdi:thermometer",
-        "chargeOffsetC": "mdi:thermometer",
+        "max_setpoint_c": "mdi:thermometer-high",
+        "charge_hysteresis_c": "mdi:thermometer",
+        "charge_offset_c": "mdi:thermometer",
     }
     for field in CYLINDER_CONFIG_SENSOR_FIELDS:
         key = field["key"]
@@ -630,7 +630,7 @@ def test_radio_sensor_has_dynamic_icon_property() -> None:
 
 def test_radio_signal_icon_low() -> None:
     coord = _FakeCoordinator({
-        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 15}],
+        "radio_devices": [{"group": 0x0C, "instance": 1, "reception_strength": 15}],
     })
     sensor = HelianthusRadioSensor(
         coordinator=coord,
@@ -640,7 +640,7 @@ def test_radio_signal_icon_low() -> None:
         radio_name="Test Radio",
         group=0x0C,
         instance=1,
-        key="receptionStrength",
+        key="reception_strength",
         label="Signal Quality",
         icon=None,
     )
@@ -649,7 +649,7 @@ def test_radio_signal_icon_low() -> None:
 
 def test_radio_signal_icon_medium() -> None:
     coord = _FakeCoordinator({
-        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 50}],
+        "radio_devices": [{"group": 0x0C, "instance": 1, "reception_strength": 50}],
     })
     sensor = HelianthusRadioSensor(
         coordinator=coord,
@@ -659,7 +659,7 @@ def test_radio_signal_icon_medium() -> None:
         radio_name="Test Radio",
         group=0x0C,
         instance=1,
-        key="receptionStrength",
+        key="reception_strength",
         label="Signal Quality",
         icon=None,
     )
@@ -668,7 +668,7 @@ def test_radio_signal_icon_medium() -> None:
 
 def test_radio_signal_icon_high() -> None:
     coord = _FakeCoordinator({
-        "radioDevices": [{"group": 0x0C, "instance": 1, "receptionStrength": 90}],
+        "radio_devices": [{"group": 0x0C, "instance": 1, "reception_strength": 90}],
     })
     sensor = HelianthusRadioSensor(
         coordinator=coord,
@@ -678,7 +678,7 @@ def test_radio_signal_icon_high() -> None:
         radio_name="Test Radio",
         group=0x0C,
         instance=1,
-        key="receptionStrength",
+        key="reception_strength",
         label="Signal Quality",
         icon=None,
     )
@@ -687,7 +687,7 @@ def test_radio_signal_icon_high() -> None:
 
 def test_radio_signal_icon_none() -> None:
     coord = _FakeCoordinator({
-        "radioDevices": [{"group": 0x0C, "instance": 1}],
+        "radio_devices": [{"group": 0x0C, "instance": 1}],
     })
     sensor = HelianthusRadioSensor(
         coordinator=coord,
@@ -697,7 +697,7 @@ def test_radio_signal_icon_none() -> None:
         radio_name="Test Radio",
         group=0x0C,
         instance=1,
-        key="receptionStrength",
+        key="reception_strength",
         label="Signal Quality",
         icon=None,
     )
@@ -707,7 +707,7 @@ def test_radio_signal_icon_none() -> None:
 def test_radio_metadata_sensor_static_icon() -> None:
     """Non-signal radio sensors should use their static icon."""
     coord = _FakeCoordinator({
-        "radioDevices": [{"group": 0x0C, "instance": 1, "hardwareIdentifier": "ABC123"}],
+        "radio_devices": [{"group": 0x0C, "instance": 1, "hardware_identifier": "ABC123"}],
     })
     sensor = HelianthusRadioSensor(
         coordinator=coord,
@@ -717,7 +717,7 @@ def test_radio_metadata_sensor_static_icon() -> None:
         radio_name="Test Radio",
         group=0x0C,
         instance=1,
-        key="hardwareIdentifier",
+        key="hardware_identifier",
         label="Hardware ID",
         icon="mdi:identifier",
     )
@@ -772,13 +772,13 @@ def test_schedule_binary_sensor_icons() -> None:
 def test_boiler_state_binary_sensor_icons() -> None:
     """Boiler binary sensors must have correct icons by key."""
     expected = {
-        "flameActive": "mdi:fire",
-        "gasValveActive": "mdi:gas-cylinder",
-        "centralHeatingPumpActive": "mdi:pump",
-        "externalPumpActive": "mdi:pump",
-        "circulationPumpActive": "mdi:pump",
+        "flame_active": "mdi:fire",
+        "gas_valve_active": "mdi:gas-cylinder",
+        "central_heating_pump_active": "mdi:pump",
+        "external_pump_active": "mdi:pump",
+        "circulation_pump_active": "mdi:pump",
     }
-    coord = _FakeCoordinator({"boilerStatus": {"state": {}}})
+    coord = _FakeCoordinator({"boiler_status": {"state": {}}})
     for key, expected_icon in expected.items():
         sensor = HelianthusBoilerStateBinarySensor(
             coordinator=coord,
@@ -796,11 +796,11 @@ def test_boiler_state_binary_sensor_icons() -> None:
 def test_solar_binary_sensor_icons() -> None:
     """Solar binary sensors must have correct icons by key."""
     expected = {
-        "pumpActive": "mdi:pump",
-        "solarEnabled": "mdi:solar-power",
-        "functionMode": "mdi:solar-panel",
+        "pump_active": "mdi:pump",
+        "solar_enabled": "mdi:solar-power",
+        "function_mode": "mdi:solar-panel",
     }
-    coord = _FakeCoordinator({"fm5SemanticMode": "INTERPRETED", "solar": {}})
+    coord = _FakeCoordinator({"fm5_semantic_mode": "INTERPRETED", "solar": {}})
     for key, expected_icon in expected.items():
         sensor = HelianthusSolarBinarySensor(
             coordinator=coord,
@@ -818,14 +818,14 @@ def test_solar_binary_sensor_icons() -> None:
 
 
 def test_system_binary_adaptive_heating_curve_icon() -> None:
-    coord = _FakeCoordinator({"config": {"adaptiveHeatingCurve": True}})
+    coord = _FakeCoordinator({"config": {"adaptive_heating_curve": True}})
     sensor = HelianthusSystemBinarySensor(
         coordinator=coord,
         entry_id="test",
         manufacturer="V",
         regulator_device_id=("r", "x"),
         source="config",
-        key="adaptiveHeatingCurve",
+        key="adaptive_heating_curve",
         label="Adaptive Heating Curve",
         device_class=None,
         entity_category="diagnostic",
@@ -834,15 +834,15 @@ def test_system_binary_adaptive_heating_curve_icon() -> None:
 
 
 def test_system_binary_maintenance_due_no_icon_override() -> None:
-    """maintenanceDue has PROBLEM device_class — should NOT override icon."""
-    coord = _FakeCoordinator({"state": {"maintenanceDue": False}})
+    """maintenance_due has PROBLEM device_class — should NOT override icon."""
+    coord = _FakeCoordinator({"state": {"maintenance_due": False}})
     sensor = HelianthusSystemBinarySensor(
         coordinator=coord,
         entry_id="test",
         manufacturer="V",
         regulator_device_id=("r", "x"),
         source="state",
-        key="maintenanceDue",
+        key="maintenance_due",
         label="Maintenance Due",
         device_class="problem",
         entity_category="diagnostic",
@@ -868,11 +868,11 @@ def test_circuit_number_fields_all_have_icons() -> None:
 
 def test_circuit_number_specific_icons() -> None:
     expected = {
-        "heatingCurve": "mdi:chart-bell-curve-cumulative",
-        "flowTempMaxC": "mdi:thermometer-chevron-up",
-        "flowTempMinC": "mdi:thermometer-chevron-down",
-        "summerLimitC": "mdi:weather-sunny",
-        "frostProtC": "mdi:snowflake-thermometer",
+        "heating_curve": "mdi:chart-bell-curve-cumulative",
+        "flow_temp_max_c": "mdi:thermometer-chevron-up",
+        "flow_temp_min_c": "mdi:thermometer-chevron-down",
+        "summer_limit_c": "mdi:weather-sunny",
+        "frost_prot_c": "mdi:snowflake-thermometer",
     }
     for field in _CIRCUIT_NUMBER_FIELDS:
         if field.key in expected:
@@ -890,11 +890,11 @@ def test_system_number_fields_all_have_icons() -> None:
 
 def test_system_number_specific_icons() -> None:
     expected = {
-        "hcBivalencePointC": "mdi:thermometer",
-        "dhwBivalencePointC": "mdi:thermometer",
-        "hcEmergencyTempC": "mdi:thermometer-alert",
-        "hwcMaxFlowTempC": "mdi:thermometer-chevron-up",
-        "maxRoomHumidityPct": "mdi:water-percent",
+        "hc_bivalence_point_c": "mdi:thermometer",
+        "dhw_bivalence_point_c": "mdi:thermometer",
+        "hc_emergency_temp_c": "mdi:thermometer-alert",
+        "hwc_max_flow_temp_c": "mdi:thermometer-chevron-up",
+        "max_room_humidity_pct": "mdi:water-percent",
     }
     for field in _SYSTEM_NUMBER_FIELDS:
         if field.mutation_field in expected:
@@ -919,10 +919,10 @@ def test_boiler_number_fields_all_have_icons() -> None:
 
 def test_boiler_number_specific_icons() -> None:
     expected = {
-        "flowsetHcMaxC": "mdi:thermometer-chevron-up",
-        "flowsetHwcMaxC": "mdi:thermometer-chevron-up",
-        "partloadHcKW": "mdi:lightning-bolt",
-        "partloadHwcKW": "mdi:lightning-bolt",
+        "flowset_hc_max_c": "mdi:thermometer-chevron-up",
+        "flowset_hwc_max_c": "mdi:thermometer-chevron-up",
+        "partload_hc_kw": "mdi:lightning-bolt",
+        "partload_hwc_kw": "mdi:lightning-bolt",
     }
     for field in _BOILER_NUMBER_FIELDS:
         if field.key in expected:

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -115,17 +115,17 @@ def _payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
         "fm5_coordinator": None,
         "boiler_coordinator": _FakeCoordinator(
             {
-                "boilerStatus": {
+                "boiler_status": {
                     "state": {
-                        "centralHeatingPumpActive": True,
-                        "externalPumpActive": False,
-                        "circulationPumpActive": True,
-                        "storageLoadPumpPct": 42.4,
-                        "flameActive": True,
-                        "modulationPct": 37.6,
-                        "gasValveActive": True,
-                        "fanSpeedRpm": 1860,
-                        "ionisationVoltageUa": 91,
+                        "central_heating_pump_active": True,
+                        "external_pump_active": False,
+                        "circulation_pump_active": True,
+                        "storage_load_pump_pct": 42.4,
+                        "flame_active": True,
+                        "modulation_pct": 37.6,
+                        "gas_valve_active": True,
+                        "fan_speed_rpm": 1860,
+                        "ionisation_voltage_ua": 91,
                     }
                 }
             }

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -72,8 +72,8 @@ def test_verify_gateway_identity_uses_fallback_address() -> None:
             _FakeResponse(
                 payload={
                     "data": {
-                        "gatewayIdentity": {
-                            "instanceGuid": INSTANCE_GUID,
+                        "gateway_identity": {
+                            "instance_guid": INSTANCE_GUID,
                         }
                     }
                 }
@@ -114,8 +114,8 @@ def test_verify_gateway_identity_rejects_guid_mismatch() -> None:
             _FakeResponse(
                 payload={
                     "data": {
-                        "gatewayIdentity": {
-                            "instanceGuid": "ccccccee-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                        "gateway_identity": {
+                            "instance_guid": "ccccccee-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
                         }
                     }
                 }
@@ -146,7 +146,7 @@ def test_verify_gateway_identity_requires_gateway_upgrade_on_graphql_error() -> 
             _FakeResponse(
                 payload={
                     "errors": [
-                        {"message": 'Cannot query field "gatewayIdentity" on type "Query".'}
+                        {"message": 'Cannot query field "gateway_identity" on type "Query".'}
                     ]
                 }
             )
@@ -175,8 +175,8 @@ def test_verify_gateway_identity_reports_missing_guid() -> None:
             _FakeResponse(
                 payload={
                     "data": {
-                        "gatewayIdentity": {
-                            "instanceGuid": "",
+                        "gateway_identity": {
+                            "instance_guid": "",
                         }
                     }
                 }

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -31,17 +31,17 @@ def test_clean_label_returns_none_for_empty_text() -> None:
 
 
 def test_canonical_bus_display_name_maps_basv_and_vr71() -> None:
-    assert _canonical_bus_display_name({"deviceId": "BASV2"}) == "sensoCOMFORT RF"
-    assert _canonical_bus_display_name({"deviceId": "VR_71"}) == "FM5 Control Centre"
-    assert _canonical_bus_display_name({"deviceId": "BAI00"}) == "ecoTEC plus"
-    assert _canonical_bus_display_name({"deviceId": "NETX3"}) == "myVaillant Connect"
+    assert _canonical_bus_display_name({"device_id": "BASV2"}) == "sensoCOMFORT RF"
+    assert _canonical_bus_display_name({"device_id": "VR_71"}) == "FM5 Control Centre"
+    assert _canonical_bus_display_name({"device_id": "BAI00"}) == "ecoTEC plus"
+    assert _canonical_bus_display_name({"device_id": "NETX3"}) == "myVaillant Connect"
 
 
 def test_canonical_bus_model_name_includes_ebus_code() -> None:
-    basv = _canonical_bus_model_name({"deviceId": "BASV2", "productModel": "VRC 720f/2"})
-    vr71 = _canonical_bus_model_name({"deviceId": "VR_71", "productModel": "VR 71"})
-    bai = _canonical_bus_model_name({"deviceId": "BAI00"})
-    netx3 = _canonical_bus_model_name({"deviceId": "NETX3"})
+    basv = _canonical_bus_model_name({"device_id": "BASV2", "product_model": "VRC 720f/2"})
+    vr71 = _canonical_bus_model_name({"device_id": "VR_71", "product_model": "VR 71"})
+    bai = _canonical_bus_model_name({"device_id": "BAI00"})
+    netx3 = _canonical_bus_model_name({"device_id": "NETX3"})
     assert basv == "VRC 720f/2 (eBUS: BASV)"
     assert vr71 == "VR 71 (eBUS: VR_71)"
     assert bai == "VUW (eBUS: BAI00)"
@@ -49,8 +49,8 @@ def test_canonical_bus_model_name_includes_ebus_code() -> None:
 
 
 def test_stable_bus_identity_model_uses_known_family_mapping_across_sparse_payloads() -> None:
-    enriched = _stable_bus_identity_model({"deviceId": "BAI00", "productModel": "VUW 32CS/1-5 (N-INT2)"})
-    sparse = _stable_bus_identity_model({"deviceId": "BAI00"})
+    enriched = _stable_bus_identity_model({"device_id": "BAI00", "product_model": "VUW 32CS/1-5 (N-INT2)"})
+    sparse = _stable_bus_identity_model({"device_id": "BAI00"})
     assert enriched == "VUW"
     assert sparse == "VUW"
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -98,7 +98,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"set_boiler_config": {"success": True, "error": None}}
+        return {"setBoilerConfig": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -98,7 +98,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setBoilerConfig": {"success": True, "error": None}}
+        return {"set_boiler_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:
@@ -114,12 +114,12 @@ class _FakeHass:
 def _payload(*, boiler_device_id: tuple[str, str] | None):
     boiler_coordinator = _FakeCoordinator(
         {
-            "boilerStatus": {
+            "boiler_status": {
                 "config": {
-                    "flowsetHcMaxC": 70.0,
-                    "flowsetHwcMaxC": 59.0,
-                    "partloadHcKW": 18.5,
-                    "partloadHwcKW": 22.0,
+                    "flowset_hc_max_c": 70.0,
+                    "flowset_hwc_max_c": 59.0,
+                    "partload_hc_kw": 18.5,
+                    "partload_hwc_kw": 22.0,
                 }
             }
         }
@@ -184,15 +184,15 @@ def test_boiler_number_entities_write_set_boiler_config_mutation() -> None:
     boiler_numbers = [
         entity for entity in entities if isinstance(entity, number_platform.HelianthusBoilerNumber)
     ]
-    ch_max = next(entity for entity in boiler_numbers if entity._field.key == "flowsetHcMaxC")
-    dhw_partload = next(entity for entity in boiler_numbers if entity._field.key == "partloadHwcKW")
+    ch_max = next(entity for entity in boiler_numbers if entity._field.key == "flowset_hc_max_c")
+    dhw_partload = next(entity for entity in boiler_numbers if entity._field.key == "partload_hwc_kw")
 
     asyncio.run(ch_max.async_set_native_value(68.0))
     asyncio.run(dhw_partload.async_set_native_value(21.5))
 
     assert [call["variables"]["field"] for call in client.calls] == [
-        "flowsetHcMaxC",
-        "partloadHwcKW",
+        "flowset_hc_max_c",
+        "partload_hwc_kw",
     ]
     assert [call["variables"]["value"] for call in client.calls] == ["68.0", "21.5"]
     assert boiler_coordinator.refresh_requests == 2

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -98,7 +98,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setBoilerConfig": {"success": True, "error": None}}
+        return {"set_boiler_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -173,7 +173,7 @@ def _base_payload(radio_devices: list[dict]) -> dict:
         "energy_coordinator": None,
         "circuit_coordinator": None,
         "radio_coordinator": _FakeCoordinator(
-            {"radioDevices": radio_devices, "radioZoneCandidates": {}}
+            {"radio_devices": radio_devices, "radio_zone_candidates": {}}
         ),
         "system_coordinator": None,
         "boiler_coordinator": None,
@@ -192,24 +192,24 @@ def test_radio_sensor_entities_cover_room_and_inventory_devices() -> None:
         {
             "group": 0x09,
             "instance": 1,
-            "radioBusKey": "g09-i01",
-            "deviceClassAddress": 0x15,
-            "deviceConnected": True,
-            "receptionStrength": 84,
-            "roomTemperatureC": 21.5,
-            "roomHumidityPct": 45.0,
-            "staleCycles": 0,
+            "radio_bus_key": "g09-i01",
+            "device_class_address": 0x15,
+            "device_connected": True,
+            "reception_strength": 84,
+            "room_temperature_c": 21.5,
+            "room_humidity_pct": 45.0,
+            "stale_cycles": 0,
         },
         {
             "group": 0x0C,
             "instance": 2,
-            "radioBusKey": "g0c-i02",
-            "deviceClassAddress": 0x99,
-            "deviceConnected": False,
-            "hardwareIdentifier": 0x2233,
-            "remoteControlAddress": 17,
-            "zoneAssignment": 0,
-            "staleCycles": 0,
+            "radio_bus_key": "g0c-i02",
+            "device_class_address": 0x99,
+            "device_connected": False,
+            "hardware_identifier": 0x2233,
+            "remote_control_address": 17,
+            "zone_assignment": 0,
+            "stale_cycles": 0,
         },
     ]
     hass = _FakeHass(_base_payload(radio_devices))
@@ -222,11 +222,11 @@ def test_radio_sensor_entities_cover_room_and_inventory_devices() -> None:
         entity for entity in entities if isinstance(entity, sensor_platform.HelianthusRadioSensor)
     ]
     unique_ids = {entity._attr_unique_id for entity in radio_entities}
-    assert "entry-1-radio-09-01-sensor-roomTemperatureC" in unique_ids
-    assert "entry-1-radio-09-01-sensor-roomHumidityPct" in unique_ids
-    assert "entry-1-radio-09-01-sensor-receptionStrength" in unique_ids
-    assert "entry-1-radio-0c-02-sensor-deviceClassAddress" in unique_ids
-    assert "entry-1-radio-0c-02-sensor-hardwareIdentifier" in unique_ids
+    assert "entry-1-radio-09-01-sensor-room_temperature_c" in unique_ids
+    assert "entry-1-radio-09-01-sensor-room_humidity_pct" in unique_ids
+    assert "entry-1-radio-09-01-sensor-reception_strength" in unique_ids
+    assert "entry-1-radio-0c-02-sensor-device_class_address" in unique_ids
+    assert "entry-1-radio-0c-02-sensor-hardware_identifier" in unique_ids
 
 
 def test_radio_connected_entity_becomes_unavailable_after_third_stale_cycle() -> None:
@@ -234,10 +234,10 @@ def test_radio_connected_entity_becomes_unavailable_after_third_stale_cycle() ->
         {
             "group": 0x09,
             "instance": 1,
-            "radioBusKey": "g09-i01",
-            "deviceClassAddress": 0x15,
-            "deviceConnected": True,
-            "staleCycles": 0,
+            "radio_bus_key": "g09-i01",
+            "device_class_address": 0x15,
+            "device_connected": True,
+            "stale_cycles": 0,
         }
     ]
     payload = _base_payload(radio_devices)
@@ -256,15 +256,15 @@ def test_radio_connected_entity_becomes_unavailable_after_third_stale_cycle() ->
     assert connected_entity.is_on is True
 
     payload["radio_coordinator"].data = {
-        "radioDevices": [{**radio_devices[0], "deviceConnected": False, "staleCycles": 2}],
-        "radioZoneCandidates": {},
+        "radio_devices": [{**radio_devices[0], "device_connected": False, "stale_cycles": 2}],
+        "radio_zone_candidates": {},
     }
     assert connected_entity.available is True
     assert connected_entity.is_on is False
 
     payload["radio_coordinator"].data = {
-        "radioDevices": [{**radio_devices[0], "deviceConnected": False, "staleCycles": 3}],
-        "radioZoneCandidates": {},
+        "radio_devices": [{**radio_devices[0], "device_connected": False, "stale_cycles": 3}],
+        "radio_zone_candidates": {},
     }
     assert connected_entity.available is False
 
@@ -282,8 +282,8 @@ def test_subscription_dispatches_radio_updates_to_radio_coordinator() -> None:
         "type": "next",
         "payload": {
             "data": {
-                "radioDevicesUpdate": [
-                    {"group": 0x09, "instance": 1, "deviceConnected": True}
+                "radio_devices_update": [
+                    {"group": 0x09, "instance": 1, "device_connected": True}
                 ]
             }
         },
@@ -307,9 +307,9 @@ def test_subscription_ignores_null_frames_without_crashing() -> None:
     class _FakeBoilerCoordinator:
         def __init__(self) -> None:
             self.data = {
-                "boilerStatus": {
-                    "state": {"flowTemperatureC": 60.0, "centralHeatingPumpActive": False},
-                    "diagnostics": {"heatingStatusRaw": 1},
+                "boiler_status": {
+                    "state": {"flow_temperature_c": 60.0, "central_heating_pump_active": False},
+                    "diagnostics": {"heating_status_raw": 1},
                 }
             }
 
@@ -328,21 +328,21 @@ def test_subscription_ignores_null_frames_without_crashing() -> None:
         )
     )
 
-    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 60.0
-    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
+    assert boiler.data["boiler_status"]["state"]["flow_temperature_c"] == 60.0
+    assert boiler.data["boiler_status"]["diagnostics"]["heating_status_raw"] == 1
 
 
 def test_subscription_merges_partial_boiler_updates_non_destructively() -> None:
     class _FakeBoilerCoordinator:
         def __init__(self) -> None:
             self.data = {
-                "boilerStatus": {
+                "boiler_status": {
                     "state": {
-                        "flowTemperatureC": 60.0,
-                        "returnTemperatureC": 41.5,
-                        "centralHeatingPumpActive": False,
+                        "flow_temperature_c": 60.0,
+                        "return_temperature_c": 41.5,
+                        "central_heating_pump_active": False,
                     },
-                    "diagnostics": {"heatingStatusRaw": 1},
+                    "diagnostics": {"heating_status_raw": 1},
                 }
             }
 
@@ -357,8 +357,8 @@ def test_subscription_merges_partial_boiler_updates_non_destructively() -> None:
                 "type": "next",
                 "payload": {
                     "data": {
-                        "boilerStatusUpdate": {
-                            "state": {"flowTemperatureC": 63.5},
+                        "boiler_status_update": {
+                            "state": {"flow_temperature_c": 63.5},
                         }
                     }
                 },
@@ -370,22 +370,22 @@ def test_subscription_merges_partial_boiler_updates_non_destructively() -> None:
         )
     )
 
-    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 63.5
-    assert boiler.data["boilerStatus"]["state"]["returnTemperatureC"] == 41.5
-    assert boiler.data["boilerStatus"]["state"]["centralHeatingPumpActive"] is False
-    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
+    assert boiler.data["boiler_status"]["state"]["flow_temperature_c"] == 63.5
+    assert boiler.data["boiler_status"]["state"]["return_temperature_c"] == 41.5
+    assert boiler.data["boiler_status"]["state"]["central_heating_pump_active"] is False
+    assert boiler.data["boiler_status"]["diagnostics"]["heating_status_raw"] == 1
 
 
 def test_subscription_keeps_nested_boiler_diagnostics_on_explicit_null() -> None:
     class _FakeBoilerCoordinator:
         def __init__(self) -> None:
             self.data = {
-                "boilerStatus": {
+                "boiler_status": {
                     "state": {
-                        "flowTemperatureC": 60.0,
-                        "centralHeatingPumpActive": False,
+                        "flow_temperature_c": 60.0,
+                        "central_heating_pump_active": False,
                     },
-                    "diagnostics": {"heatingStatusRaw": 1},
+                    "diagnostics": {"heating_status_raw": 1},
                 }
             }
 
@@ -400,7 +400,7 @@ def test_subscription_keeps_nested_boiler_diagnostics_on_explicit_null() -> None
                 "type": "next",
                 "payload": {
                     "data": {
-                        "boilerStatusUpdate": {
+                        "boiler_status_update": {
                             "diagnostics": None,
                         }
                     }
@@ -413,8 +413,8 @@ def test_subscription_keeps_nested_boiler_diagnostics_on_explicit_null() -> None
         )
     )
 
-    assert boiler.data["boilerStatus"]["diagnostics"]["heatingStatusRaw"] == 1
-    assert boiler.data["boilerStatus"]["state"]["flowTemperatureC"] == 60.0
+    assert boiler.data["boiler_status"]["diagnostics"]["heating_status_raw"] == 1
+    assert boiler.data["boiler_status"]["state"]["flow_temperature_c"] == 60.0
 
 
 def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_entries() -> None:
@@ -426,18 +426,18 @@ def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_en
                     {
                         "id": "zone-1",
                         "name": "Living",
-                        "state": {"currentTempC": 20.0},
+                        "state": {"current_temp_c": 20.0},
                         "config": {
-                            "operatingMode": "auto",
-                            "roomTemperatureZoneMapping": 2,
-                            "targetTempC": 21.0,
+                            "operating_mode": "auto",
+                            "room_temperature_zone_mapping": 2,
+                            "target_temp_c": 21.0,
                         },
                     },
                     {
                         "id": "zone-2",
                         "name": "Etaj",
-                        "state": {"currentTempC": 19.0},
-                        "config": {"roomTemperatureZoneMapping": 3},
+                        "state": {"current_temp_c": 19.0},
+                        "config": {"room_temperature_zone_mapping": 3},
                     },
                 ],
                 "dhw": None,
@@ -454,9 +454,9 @@ def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_en
                 "type": "next",
                 "payload": {
                     "data": {
-                        "zoneUpdate": {
+                        "zone_update": {
                             "id": "zone-1",
-                            "state": {"currentTempC": 21.5},
+                            "state": {"current_temp_c": 21.5},
                         }
                     }
                 },
@@ -470,9 +470,9 @@ def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_en
 
     assert semantic.data["zones"][0] == "legacy-slot"
     merged_zone = semantic.data["zones"][1]
-    assert merged_zone["state"]["currentTempC"] == 21.5
-    assert merged_zone["config"]["roomTemperatureZoneMapping"] == 2
-    assert merged_zone["config"]["targetTempC"] == 21.0
+    assert merged_zone["state"]["current_temp_c"] == 21.5
+    assert merged_zone["config"]["room_temperature_zone_mapping"] == 2
+    assert merged_zone["config"]["target_temp_c"] == 21.0
     assert semantic.data["zones"][2]["id"] == "zone-2"
 
 
@@ -488,29 +488,29 @@ def test_radio_zone_candidates_update_on_reassignment() -> None:
             {
                 "group": 0x09,
                 "instance": 1,
-                "deviceConnected": True,
-                "deviceClassAddress": 0x15,
-                "zoneAssignment": 1,
-                "remoteControlAddress": 0,
+                "device_connected": True,
+                "device_class_address": 0x15,
+                "zone_assignment": 1,
+                "remote_control_address": 0,
             }
         ]
     )
-    assert 0 in coordinator.data["radioZoneCandidates"]
+    assert 0 in coordinator.data["radio_zone_candidates"]
 
     coordinator.apply_radio_update(
         [
             {
                 "group": 0x09,
                 "instance": 1,
-                "deviceConnected": True,
-                "deviceClassAddress": 0x15,
-                "zoneAssignment": 2,
-                "remoteControlAddress": 0,
+                "device_connected": True,
+                "device_class_address": 0x15,
+                "zone_assignment": 2,
+                "remote_control_address": 0,
             }
         ]
     )
-    assert 1 in coordinator.data["radioZoneCandidates"]
-    assert 0 not in coordinator.data["radioZoneCandidates"]
+    assert 1 in coordinator.data["radio_zone_candidates"]
+    assert 0 not in coordinator.data["radio_zone_candidates"]
 
 
 # ---------------------------------------------------------------------------
@@ -534,11 +534,11 @@ def test_adr027_merged_group_0c_sensor_entities_suppressed() -> None:
         {
             "group": 0x0C,
             "instance": 1,
-            "radioBusKey": "g0c-i01",
-            "deviceClassAddress": 38,
-            "deviceConnected": True,
-            "hardwareIdentifier": 0x1704,
-            "staleCycles": 0,
+            "radio_bus_key": "g0c-i01",
+            "device_class_address": 38,
+            "device_connected": True,
+            "hardware_identifier": 0x1704,
+            "stale_cycles": 0,
         },
     ]
     merge_targets = {"g0c-i01": _VR71_BUS_DEVICE_ID}
@@ -553,8 +553,8 @@ def test_adr027_merged_group_0c_sensor_entities_suppressed() -> None:
         if isinstance(e, sensor_platform.HelianthusRadioSensor)
     }
     # Redundant sensors must NOT be created for merged slots.
-    assert "entry-1-radio-0c-01-sensor-deviceClassAddress" not in radio_sensor_uids
-    assert "entry-1-radio-0c-01-sensor-hardwareIdentifier" not in radio_sensor_uids
+    assert "entry-1-radio-0c-01-sensor-device_class_address" not in radio_sensor_uids
+    assert "entry-1-radio-0c-01-sensor-hardware_identifier" not in radio_sensor_uids
 
 
 def test_adr027_unmerged_group_0c_sensor_entities_created() -> None:
@@ -563,11 +563,11 @@ def test_adr027_unmerged_group_0c_sensor_entities_created() -> None:
         {
             "group": 0x0C,
             "instance": 2,
-            "radioBusKey": "g0c-i02",
-            "deviceClassAddress": 0x99,
-            "deviceConnected": False,
-            "hardwareIdentifier": 0x2233,
-            "staleCycles": 0,
+            "radio_bus_key": "g0c-i02",
+            "device_class_address": 0x99,
+            "device_connected": False,
+            "hardware_identifier": 0x2233,
+            "stale_cycles": 0,
         },
     ]
     # No merge targets — bus device at 0x99 doesn't exist.
@@ -581,8 +581,8 @@ def test_adr027_unmerged_group_0c_sensor_entities_created() -> None:
         for e in entities
         if isinstance(e, sensor_platform.HelianthusRadioSensor)
     }
-    assert "entry-1-radio-0c-02-sensor-deviceClassAddress" in radio_sensor_uids
-    assert "entry-1-radio-0c-02-sensor-hardwareIdentifier" in radio_sensor_uids
+    assert "entry-1-radio-0c-02-sensor-device_class_address" in radio_sensor_uids
+    assert "entry-1-radio-0c-02-sensor-hardware_identifier" in radio_sensor_uids
 
 
 def test_adr027_merged_binary_sensor_reparented_to_bus_device() -> None:
@@ -591,10 +591,10 @@ def test_adr027_merged_binary_sensor_reparented_to_bus_device() -> None:
         {
             "group": 0x0C,
             "instance": 1,
-            "radioBusKey": "g0c-i01",
-            "deviceClassAddress": 38,
-            "deviceConnected": True,
-            "staleCycles": 0,
+            "radio_bus_key": "g0c-i01",
+            "device_class_address": 38,
+            "device_connected": True,
+            "stale_cycles": 0,
         },
     ]
     merge_targets = {"g0c-i01": _VR71_BUS_DEVICE_ID}
@@ -622,10 +622,10 @@ def test_adr027_unmerged_binary_sensor_stays_on_radio_device() -> None:
         {
             "group": 0x09,
             "instance": 1,
-            "radioBusKey": "g09-i01",
-            "deviceClassAddress": 0x15,
-            "deviceConnected": True,
-            "staleCycles": 0,
+            "radio_bus_key": "g09-i01",
+            "device_class_address": 0x15,
+            "device_connected": True,
+            "stale_cycles": 0,
         },
     ]
     hass = _FakeHass(_merge_payload(radio_devices, {}))
@@ -652,22 +652,22 @@ def test_adr027_idempotency_multiple_runs_same_result() -> None:
         {
             "group": 0x0C,
             "instance": 1,
-            "radioBusKey": "g0c-i01",
-            "deviceClassAddress": 38,
-            "deviceConnected": True,
-            "hardwareIdentifier": 0x1704,
-            "staleCycles": 0,
+            "radio_bus_key": "g0c-i01",
+            "device_class_address": 38,
+            "device_connected": True,
+            "hardware_identifier": 0x1704,
+            "stale_cycles": 0,
         },
         {
             "group": 0x09,
             "instance": 1,
-            "radioBusKey": "g09-i01",
-            "deviceClassAddress": 0x15,
-            "deviceConnected": True,
-            "receptionStrength": 7,
-            "roomTemperatureC": 21.5,
-            "roomHumidityPct": 45.0,
-            "staleCycles": 0,
+            "radio_bus_key": "g09-i01",
+            "device_class_address": 0x15,
+            "device_connected": True,
+            "reception_strength": 7,
+            "room_temperature_c": 21.5,
+            "room_humidity_pct": 45.0,
+            "stale_cycles": 0,
         },
     ]
     merge_targets = {"g0c-i01": _VR71_BUS_DEVICE_ID}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -133,22 +133,22 @@ def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
         "energy_coordinator": None,
         "boiler_coordinator": _FakeCoordinator(
             {
-                "boilerStatus": {
+                "boiler_status": {
                     "state": {
-                        "flowTemperatureC": 63.1,
-                        "returnTemperatureC": 51.0,
-                        "dhwTemperatureC": 49.5,
-                        "dhwStorageTemperatureC": 46.2,
+                        "flow_temperature_c": 63.1,
+                        "return_temperature_c": 51.0,
+                        "dhw_temperature_c": 49.5,
+                        "dhw_storage_temperature_c": 46.2,
                     },
                     "diagnostics": {
-                        "centralHeatingHours": 13150.0,
-                        "dhwHours": 116.0,
-                        "centralHeatingStarts": 64,
-                        "dhwStarts": 50,
-                        "pumpHours": 134.0,
-                        "fanHours": 108.0,
-                        "deactivationsIFC": 52,
-                        "deactivationsTemplimiter": 0,
+                        "central_heating_hours": 13150.0,
+                        "dhw_hours": 116.0,
+                        "central_heating_starts": 64,
+                        "dhw_starts": 50,
+                        "pump_hours": 134.0,
+                        "fan_hours": 108.0,
+                        "deactivations_ifc": 52,
+                        "deactivations_templimiter": 0,
                     }
                 }
             }
@@ -181,10 +181,10 @@ def test_async_setup_entry_adds_reduced_boiler_temperature_sensors_on_bai00_only
 
     assert len(boiler_entities) == 4
     assert {entity._attr_unique_id for entity in boiler_entities} == {
-        "entry-1-boiler-flowTemperatureC",
-        "entry-1-boiler-returnTemperatureC",
-        "entry-1-boiler-dhwTemperatureC",
-        "entry-1-boiler-dhwStorageTemperatureC",
+        "entry-1-boiler-flow_temperature_c",
+        "entry-1-boiler-return_temperature_c",
+        "entry-1-boiler-dhw_temperature_c",
+        "entry-1-boiler-dhw_storage_temperature_c",
     }
     assert {entity._attr_name for entity in boiler_entities} == {
         "Flow Temperature",
@@ -245,44 +245,44 @@ def test_async_setup_entry_adds_boiler_diagnostic_sensors() -> None:
 
     assert len(diag_entities) == 8
     assert {entity._attr_unique_id for entity in diag_entities} == {
-        "entry-1-boiler-diag-centralHeatingHours",
-        "entry-1-boiler-diag-dhwHours",
-        "entry-1-boiler-diag-pumpHours",
-        "entry-1-boiler-diag-fanHours",
-        "entry-1-boiler-diag-centralHeatingStarts",
-        "entry-1-boiler-diag-dhwStarts",
-        "entry-1-boiler-diag-deactivationsIFC",
-        "entry-1-boiler-diag-deactivationsTemplimiter",
+        "entry-1-boiler-diag-central_heating_hours",
+        "entry-1-boiler-diag-dhw_hours",
+        "entry-1-boiler-diag-pump_hours",
+        "entry-1-boiler-diag-fan_hours",
+        "entry-1-boiler-diag-central_heating_starts",
+        "entry-1-boiler-diag-dhw_starts",
+        "entry-1-boiler-diag-deactivations_ifc",
+        "entry-1-boiler-diag-deactivations_templimiter",
     }
     values = {entity._attr_unique_id: entity.native_value for entity in diag_entities}
-    assert values["entry-1-boiler-diag-centralHeatingHours"] == 13150.0
-    assert values["entry-1-boiler-diag-dhwHours"] == 116.0
-    assert values["entry-1-boiler-diag-centralHeatingStarts"] == 64
-    assert values["entry-1-boiler-diag-dhwStarts"] == 50
-    assert values["entry-1-boiler-diag-pumpHours"] == 134.0
-    assert values["entry-1-boiler-diag-fanHours"] == 108.0
-    assert values["entry-1-boiler-diag-deactivationsIFC"] == 52
-    assert values["entry-1-boiler-diag-deactivationsTemplimiter"] == 0
+    assert values["entry-1-boiler-diag-central_heating_hours"] == 13150.0
+    assert values["entry-1-boiler-diag-dhw_hours"] == 116.0
+    assert values["entry-1-boiler-diag-central_heating_starts"] == 64
+    assert values["entry-1-boiler-diag-dhw_starts"] == 50
+    assert values["entry-1-boiler-diag-pump_hours"] == 134.0
+    assert values["entry-1-boiler-diag-fan_hours"] == 108.0
+    assert values["entry-1-boiler-diag-deactivations_ifc"] == 52
+    assert values["entry-1-boiler-diag-deactivations_templimiter"] == 0
 
     for entity in diag_entities:
         assert entity.device_info["identifiers"] == {boiler_device_id}
 
     # Verify metadata on duration counter
-    hours_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-centralHeatingHours")
+    hours_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-central_heating_hours")
     assert hours_entity._attr_device_class == "duration"
     assert hours_entity._attr_native_unit_of_measurement == "h"
     assert hours_entity._attr_state_class == "total_increasing"
     assert hours_entity._attr_entity_category == "diagnostic"
 
     # Verify metadata on starts counter
-    starts_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-centralHeatingStarts")
+    starts_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-central_heating_starts")
     assert not hasattr(starts_entity, "_attr_device_class") or starts_entity._attr_device_class is None
     assert not hasattr(starts_entity, "_attr_native_unit_of_measurement")
     assert starts_entity._attr_state_class == "total_increasing"
     assert starts_entity._attr_entity_category == "diagnostic"
 
     # Verify metadata on deactivation counter
-    deact_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-deactivationsIFC")
+    deact_entity = next(e for e in diag_entities if e._attr_unique_id == "entry-1-boiler-diag-deactivations_ifc")
     assert not hasattr(deact_entity, "_attr_device_class") or deact_entity._attr_device_class is None
     assert not hasattr(deact_entity, "_attr_state_class") or deact_entity._attr_state_class is None
     assert deact_entity._attr_entity_category == "diagnostic"
@@ -306,7 +306,7 @@ def test_async_setup_entry_skips_diagnostics_without_boiler() -> None:
 
 def test_energy_sensor_is_unavailable_without_valid_payload() -> None:
     entity = sensor_platform.HelianthusEnergySensor(
-        coordinator=_FakeCoordinator({"energyTotals": None}),
+        coordinator=_FakeCoordinator({"energy_totals": None}),
         entry_id="entry-1",
         via_device=("helianthus", "entry-1-bus-BASV2-15"),
         manufacturer="Vaillant",
@@ -321,7 +321,7 @@ def test_energy_sensor_uses_last_valid_series_without_zero_fallback() -> None:
     entity = sensor_platform.HelianthusEnergySensor(
         coordinator=_FakeCoordinator(
             {
-                "energyTotals": {
+                "energy_totals": {
                     "gas": {
                         "dhw": {"today": 3.5, "yearly": [120.0, 240.0]},
                         "climate": {"today": 0.0, "yearly": [0.0, 0.0]},
@@ -349,7 +349,7 @@ def test_energy_sensor_uses_last_valid_series_without_zero_fallback() -> None:
 
 def test_energy_sensor_has_total_increasing_state_class() -> None:
     entity = sensor_platform.HelianthusEnergySensor(
-        coordinator=_FakeCoordinator({"energyTotals": None}),
+        coordinator=_FakeCoordinator({"energy_totals": None}),
         entry_id="entry-1",
         via_device=("helianthus", "entry-1-bus-BASV2-15"),
         manufacturer="Vaillant",

--- a/tests/test_smoke_profile.py
+++ b/tests/test_smoke_profile.py
@@ -45,7 +45,7 @@ def _success_responses() -> dict[str, dict]:
     return {
         "SmokeConnection": {"data": {"__typename": "Query"}},
         "SmokeSubscriptionIntrospection": {
-            "data": {"__schema": {"subscriptionType": {"name": "Subscription"}}}
+            "data": {"__schema": {"subscription_type": {"name": "Subscription"}}}
         },
         "SmokeDevicesExtended": {
             "data": {
@@ -53,30 +53,30 @@ def _success_responses() -> dict[str, dict]:
                     {
                         "address": 8,
                         "manufacturer": "Vaillant",
-                        "deviceId": "BAI00",
-                        "serialNumber": "SER123",
-                        "macAddress": "AA:BB:CC:DD:EE:FF",
-                        "softwareVersion": "0102",
-                        "hardwareVersion": "7603",
+                        "device_id": "BAI00",
+                        "serial_number": "SER123",
+                        "mac_address": "AA:BB:CC:DD:EE:FF",
+                        "software_version": "0102",
+                        "hardware_version": "7603",
                     }
                 ]
             }
         },
         "SmokeStatus": {
             "data": {
-                "daemonStatus": {"status": "ok", "initiatorAddress": "0xF7"},
-                "adapterStatus": {"status": "ok"},
+                "daemon_status": {"status": "ok", "initiator_address": "0xF7"},
+                "adapter_status": {"status": "ok"},
             }
         },
         "SmokeSemantic": {
             "data": {
                 "zones": [{"id": "z1", "name": "Living", "state": {}, "config": {}}],
-                "dhw": {"state": {}, "config": {"operatingMode": "auto"}},
+                "dhw": {"state": {}, "config": {"operating_mode": "auto"}},
             }
         },
         "SmokeEnergy": {
             "data": {
-                "energyTotals": {
+                "energy_totals": {
                     "gas": {
                         "dhw": {"today": 0.0, "yearly": [0.0, 0.0]},
                         "climate": {"today": 0.0, "yearly": [0.0, 0.0]},
@@ -119,9 +119,9 @@ def test_run_smoke_profile_uses_fallback_paths() -> None:
     executor = FakeExecutor(
         {
             "SmokeConnection": {"data": {"__typename": "Query"}},
-            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscriptionType": None}}},
+            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscription_type": None}}},
             "SmokeDevicesExtended": {
-                "errors": [{'message': 'Cannot query field "serialNumber" on type "Device".'}]
+                "errors": [{'message': 'Cannot query field "serial_number" on type "Device".'}]
             },
             "SmokeDevicesBase": {
                 "data": {
@@ -129,24 +129,24 @@ def test_run_smoke_profile_uses_fallback_paths() -> None:
                         {
                             "address": 21,
                             "manufacturer": "Vaillant",
-                            "deviceId": "BASV2",
-                            "softwareVersion": "0101",
-                            "hardwareVersion": "7603",
+                            "device_id": "BASV2",
+                            "software_version": "0101",
+                            "hardware_version": "7603",
                         }
                     ]
                 }
             },
             "SmokeStatus": {
                 "data": {
-                    "daemonStatus": {"status": "ok"},
-                    "adapterStatus": {"status": "ok"},
+                    "daemon_status": {"status": "ok"},
+                    "adapter_status": {"status": "ok"},
                 }
             },
             "SmokeSemantic": {
                 "errors": [{'message': 'Cannot query field "zones" on type "Query".'}]
             },
             "SmokeEnergy": {
-                "errors": [{'message': 'Cannot query field "energyTotals" on type "Query".'}]
+                "errors": [{'message': 'Cannot query field "energy_totals" on type "Query".'}]
             },
         }
     )
@@ -165,16 +165,16 @@ def test_run_smoke_profile_fails_when_no_devices() -> None:
     executor = FakeExecutor(
         {
             "SmokeConnection": {"data": {"__typename": "Query"}},
-            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscriptionType": None}}},
+            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscription_type": None}}},
             "SmokeDevicesExtended": {"data": {"devices": []}},
             "SmokeStatus": {
                 "data": {
-                    "daemonStatus": {"status": "ok"},
-                    "adapterStatus": {"status": "ok"},
+                    "daemon_status": {"status": "ok"},
+                    "adapter_status": {"status": "ok"},
                 }
             },
             "SmokeSemantic": {"data": {"zones": [], "dhw": None}},
-            "SmokeEnergy": {"data": {"energyTotals": None}},
+            "SmokeEnergy": {"data": {"energy_totals": None}},
         }
     )
 
@@ -199,23 +199,23 @@ def test_run_smoke_profile_subscription_introspection_error_uses_polling_fallbac
                         {
                             "address": 8,
                             "manufacturer": "Vaillant",
-                            "deviceId": "BAI00",
-                            "serialNumber": "SER123",
-                            "macAddress": "AA:BB:CC:DD:EE:FF",
-                            "softwareVersion": "0102",
-                            "hardwareVersion": "7603",
+                            "device_id": "BAI00",
+                            "serial_number": "SER123",
+                            "mac_address": "AA:BB:CC:DD:EE:FF",
+                            "software_version": "0102",
+                            "hardware_version": "7603",
                         }
                     ]
                 }
             },
             "SmokeStatus": {
                 "data": {
-                    "daemonStatus": {"status": "ok"},
-                    "adapterStatus": {"status": "ok"},
+                    "daemon_status": {"status": "ok"},
+                    "adapter_status": {"status": "ok"},
                 }
             },
             "SmokeSemantic": {"data": {"zones": [], "dhw": None}},
-            "SmokeEnergy": {"data": {"energyTotals": None}},
+            "SmokeEnergy": {"data": {"energy_totals": None}},
         }
     )
 
@@ -232,18 +232,18 @@ def test_run_smoke_profile_handles_entity_creation_executor_error() -> None:
     executor = FakeExecutor(
         {
             "SmokeConnection": {"data": {"__typename": "Query"}},
-            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscriptionType": None}}},
+            "SmokeSubscriptionIntrospection": {"data": {"__schema": {"subscription_type": None}}},
             "SmokeDevicesExtended": {
                 "data": {
                     "devices": [
                         {
                             "address": 8,
                             "manufacturer": "Vaillant",
-                            "deviceId": "BAI00",
-                            "serialNumber": "SER123",
-                            "macAddress": "AA:BB:CC:DD:EE:FF",
-                            "softwareVersion": "0102",
-                            "hardwareVersion": "7603",
+                            "device_id": "BAI00",
+                            "serial_number": "SER123",
+                            "mac_address": "AA:BB:CC:DD:EE:FF",
+                            "software_version": "0102",
+                            "hardware_version": "7603",
                         }
                     ]
                 }

--- a/tests/test_smoke_profile.py
+++ b/tests/test_smoke_profile.py
@@ -45,7 +45,7 @@ def _success_responses() -> dict[str, dict]:
     return {
         "SmokeConnection": {"data": {"__typename": "Query"}},
         "SmokeSubscriptionIntrospection": {
-            "data": {"__schema": {"subscription_type": {"name": "Subscription"}}}
+            "data": {"__schema": {"subscriptionType": {"name": "Subscription"}}}
         },
         "SmokeDevicesExtended": {
             "data": {

--- a/tests/test_solar_cylinder.py
+++ b/tests/test_solar_cylinder.py
@@ -202,23 +202,23 @@ def _payload(mode: str) -> dict:
         "radio_coordinator": None,
         "fm5_coordinator": _FakeCoordinator(
             {
-                "fm5SemanticMode": mode,
+                "fm5_semantic_mode": mode,
                 "solar": {
-                    "collectorTemperatureC": 72.0,
-                    "returnTemperatureC": 41.0,
-                    "pumpActive": True,
-                    "currentYield": 1.2,
-                    "pumpHours": 123.0,
-                    "solarEnabled": True,
-                    "functionMode": False,
+                    "collector_temperature_c": 72.0,
+                    "return_temperature_c": 41.0,
+                    "pump_active": True,
+                    "current_yield": 1.2,
+                    "pump_hours": 123.0,
+                    "solar_enabled": True,
+                    "function_mode": False,
                 },
                 "cylinders": [
                     {
                         "index": 0,
-                        "temperatureC": 49.0,
-                        "maxSetpointC": 62.0,
-                        "chargeHysteresisC": 6.0,
-                        "chargeOffsetC": 3.0,
+                        "temperature_c": 49.0,
+                        "max_setpoint_c": 62.0,
+                        "charge_hysteresis_c": 6.0,
+                        "charge_offset_c": 3.0,
                     }
                 ],
             }

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -161,7 +161,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"set_system_config": {"success": True, "error": None}}
+        return {"setSystemConfig": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -161,7 +161,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setSystemConfig": {"success": True, "error": None}}
+        return {"set_system_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -161,7 +161,7 @@ class _FakeClient:
 
     async def mutation(self, query: str, variables: dict):  # noqa: ANN201
         self.calls.append({"query": query, "variables": variables})
-        return {"setSystemConfig": {"success": True, "error": None}}
+        return {"set_system_config": {"success": True, "error": None}}
 
 
 class _FakeEntry:
@@ -178,25 +178,25 @@ def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
     system_coordinator = _FakeCoordinator(
         {
             "state": {
-                "systemWaterPressure": 1.8,
-                "outdoorTemperature": 6.2,
-                "outdoorTemperatureAvg24h": 4.1,
-                "systemFlowTemperature": 48.0,
-                "hwcCylinderTemperatureTop": 46.5,
-                "hwcCylinderTemperatureBottom": 38.0,
-                "maintenanceDue": True,
+                "system_water_pressure": 1.8,
+                "outdoor_temperature": 6.2,
+                "outdoor_temperature_avg24h": 4.1,
+                "system_flow_temperature": 48.0,
+                "hwc_cylinder_temperature_top": 46.5,
+                "hwc_cylinder_temperature_bottom": 38.0,
+                "maintenance_due": True,
             },
             "config": {
-                "adaptiveHeatingCurve": False,
-                "heatingCircuitBivalencePoint": -2.0,
-                "dhwBivalencePoint": 5.0,
-                "hcEmergencyTemperature": 55.0,
-                "hwcMaxFlowTempDesired": 62.0,
-                "maxRoomHumidity": 65,
+                "adaptive_heating_curve": False,
+                "heating_circuit_bivalence_point": -2.0,
+                "dhw_bivalence_point": 5.0,
+                "hc_emergency_temperature": 55.0,
+                "hwc_max_flow_temp_desired": 62.0,
+                "max_room_humidity": 65,
             },
             "properties": {
-                "systemScheme": 3,
-                "moduleConfigurationVR71": 1,
+                "system_scheme": 3,
+                "module_configuration_vr71": 1,
             },
         }
     )
@@ -232,23 +232,23 @@ def test_system_sensor_entities_attach_to_basv2_device() -> None:
     ]
     assert len(system_entities) == len(sensor_platform.SYSTEM_SENSOR_FIELDS)
     assert {entity._attr_unique_id for entity in system_entities} == {
-        "entry-1-system-sensor-systemWaterPressure",
-        "entry-1-system-sensor-outdoorTemperature",
-        "entry-1-system-sensor-outdoorTemperatureAvg24h",
-        "entry-1-system-sensor-systemFlowTemperature",
-        "entry-1-system-sensor-hwcCylinderTemperatureTop",
-        "entry-1-system-sensor-hwcCylinderTemperatureBottom",
-        "entry-1-system-sensor-systemScheme",
+        "entry-1-system-sensor-system_water_pressure",
+        "entry-1-system-sensor-outdoor_temperature",
+        "entry-1-system-sensor-outdoor_temperature_avg24h",
+        "entry-1-system-sensor-system_flow_temperature",
+        "entry-1-system-sensor-hwc_cylinder_temperature_top",
+        "entry-1-system-sensor-hwc_cylinder_temperature_bottom",
+        "entry-1-system-sensor-system_scheme",
     }
     pressure = next(
         entity
         for entity in system_entities
-        if entity._attr_unique_id == "entry-1-system-sensor-systemWaterPressure"
+        if entity._attr_unique_id == "entry-1-system-sensor-system_water_pressure"
     )
     scheme = next(
         entity
         for entity in system_entities
-        if entity._attr_unique_id == "entry-1-system-sensor-systemScheme"
+        if entity._attr_unique_id == "entry-1-system-sensor-system_scheme"
     )
     assert pressure.native_value == 1.8
     assert scheme.native_value == 3
@@ -273,12 +273,12 @@ def test_system_binary_sensors_expose_maintenance_and_adaptive_flags() -> None:
     maintenance = next(
         entity
         for entity in system_entities
-        if entity._attr_unique_id == "entry-1-system-binary-maintenanceDue"
+        if entity._attr_unique_id == "entry-1-system-binary-maintenance_due"
     )
     adaptive = next(
         entity
         for entity in system_entities
-        if entity._attr_unique_id == "entry-1-system-binary-adaptiveHeatingCurve"
+        if entity._attr_unique_id == "entry-1-system-binary-adaptive_heating_curve"
     )
     assert maintenance.is_on is True
     assert adaptive.is_on is False
@@ -301,18 +301,18 @@ def test_system_number_entities_write_set_system_config_mutation() -> None:
     assert len(system_numbers) == 5
 
     hc_bivalence = next(
-        entity for entity in system_numbers if entity._field.mutation_field == "hcBivalencePointC"
+        entity for entity in system_numbers if entity._field.mutation_field == "hc_bivalence_point_c"
     )
     max_humidity = next(
-        entity for entity in system_numbers if entity._field.mutation_field == "maxRoomHumidityPct"
+        entity for entity in system_numbers if entity._field.mutation_field == "max_room_humidity_pct"
     )
 
     asyncio.run(hc_bivalence.async_set_native_value(-1.0))
     asyncio.run(max_humidity.async_set_native_value(70.0))
 
     assert [call["variables"]["field"] for call in client.calls] == [
-        "hcBivalencePointC",
-        "maxRoomHumidityPct",
+        "hc_bivalence_point_c",
+        "max_room_humidity_pct",
     ]
     assert [call["variables"]["value"] for call in client.calls] == ["-1.0", "70"]
     assert system_coordinator.refresh_requests == 2

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -105,18 +105,18 @@ def _payload(*, boiler_device_id: tuple[str, str] | None, position: float | None
                 "circuits": [
                     {
                         "index": 0,
-                        "hasMixer": True,
-                        "state": {"mixerPositionPct": 42.0},
+                        "has_mixer": True,
+                        "state": {"mixer_position_pct": 42.0},
                         "config": {},
                     }
                 ]
             }
         ),
         "semantic_coordinator": _FakeCoordinator(
-            {"zones": [{"id": "zone-1", "name": "Living", "state": {"valvePositionPct": 73.4}}], "dhw": None}
+            {"zones": [{"id": "zone-1", "name": "Living", "state": {"valve_position_pct": 73.4}}], "dhw": None}
         ),
         "boiler_coordinator": _FakeCoordinator(
-            {"boilerStatus": {"state": {"diverterValvePositionPct": position}}}
+            {"boiler_status": {"state": {"diverter_valve_position_pct": position}}}
         ),
         "boiler_device_id": boiler_device_id,
         "boiler_via_device_id": boiler_device_id,

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -187,20 +187,20 @@ def test_zone_via_device_prefers_expected_radio_candidates() -> None:
         {
             "group": 0x09,
             "instance": 1,
-            "remoteControlAddress": 0,
-            "deviceConnected": True,
+            "remote_control_address": 0,
+            "device_connected": True,
         },
         {
             "group": 0x0A,
             "instance": 1,
-            "remoteControlAddress": 1,
-            "deviceConnected": True,
+            "remote_control_address": 1,
+            "device_connected": True,
         },
         {
             "group": 0x0A,
             "instance": 2,
-            "remoteControlAddress": 2,
-            "deviceConnected": True,
+            "remote_control_address": 2,
+            "device_connected": True,
         },
     ]
     regulator = ("helianthus", "entry-1-bus-BASV-15")
@@ -218,15 +218,15 @@ def test_climate_attributes_include_radio_and_room_mapping_metadata() -> None:
                 {
                     "id": "zone-1",
                     "name": "Living",
-                    "state": {"valvePositionPct": 45.0},
+                    "state": {"valve_position_pct": 45.0},
                     "config": {
-                        "operatingMode": "auto",
+                        "operating_mode": "auto",
                         "preset": "schedule",
-                        "targetTempC": 21.0,
-                        "allowedModes": ["off", "auto", "heat"],
-                        "circuitType": "heating",
-                        "associatedCircuit": 0,
-                        "roomTemperatureZoneMapping": 2,
+                        "target_temp_c": 21.0,
+                        "allowed_modes": ["off", "auto", "heat"],
+                        "circuit_type": "heating",
+                        "associated_circuit": 0,
+                        "room_temperature_zone_mapping": 2,
                     },
                 }
             ],
@@ -235,15 +235,15 @@ def test_climate_attributes_include_radio_and_room_mapping_metadata() -> None:
     )
     radio_coordinator = _FakeCoordinator(
         {
-            "radioDevices": [
+            "radio_devices": [
                 {
                     "group": 0x0A,
                     "instance": 1,
-                    "radioBusKey": "g0a-i01",
-                    "deviceModel": "VR92f",
+                    "radio_bus_key": "g0a-i01",
+                    "device_model": "VR92f",
                 }
             ],
-            "radioZoneCandidates": {
+            "radio_zone_candidates": {
                 0: [{"group": 0x0A, "instance": 1, "remote_control_address": 1}]
             },
         }
@@ -288,13 +288,13 @@ def test_climate_attributes_use_global_regulator_fallback_for_parter_like_runtim
                     "name": "Parter",
                     "state": {},
                     "config": {
-                        "operatingMode": "heat",
+                        "operating_mode": "heat",
                         "preset": "manual",
-                        "targetTempC": 12.0,
-                        "allowedModes": ["off", "auto", "heat"],
-                        "circuitType": "underfloor",
-                        "associatedCircuit": 0,
-                        "roomTemperatureZoneMapping": 1,
+                        "target_temp_c": 12.0,
+                        "allowed_modes": ["off", "auto", "heat"],
+                        "circuit_type": "underfloor",
+                        "associated_circuit": 0,
+                        "room_temperature_zone_mapping": 1,
                     },
                 }
             ],
@@ -303,18 +303,18 @@ def test_climate_attributes_use_global_regulator_fallback_for_parter_like_runtim
     )
     radio_coordinator = _FakeCoordinator(
         {
-            "radioDevices": [
+            "radio_devices": [
                 {
                     "group": 0x09,
                     "instance": 1,
-                    "radioBusKey": "g09-i01",
-                    "deviceModel": "VRC720",
-                    "deviceConnected": True,
-                    "remoteControlAddress": 0,
-                    "zoneAssignment": 2,
+                    "radio_bus_key": "g09-i01",
+                    "device_model": "VRC720",
+                    "device_connected": True,
+                    "remote_control_address": 0,
+                    "zone_assignment": 2,
                 }
             ],
-            "radioZoneCandidates": {},
+            "radio_zone_candidates": {},
         }
     )
     payload = {
@@ -351,8 +351,8 @@ def test_zone_valve_position_sensors_are_created_per_zone() -> None:
         "semantic_coordinator": _FakeCoordinator(
             {
                 "zones": [
-                    {"id": "zone-1", "name": "Living", "state": {"valvePositionPct": 100}},
-                    {"id": "zone-2", "name": "Bedroom", "state": {"valvePositionPct": 0}},
+                    {"id": "zone-1", "name": "Living", "state": {"valve_position_pct": 100}},
+                    {"id": "zone-2", "name": "Bedroom", "state": {"valve_position_pct": 0}},
                 ],
                 "dhw": None,
             }
@@ -383,8 +383,8 @@ def test_zone_valve_position_sensors_are_created_per_zone() -> None:
     ]
     assert len(valve_entities) == 2
     assert {entity._attr_unique_id for entity in valve_entities} == {
-        "entry-1-zone-zone-1-sensor-valvePositionPct",
-        "entry-1-zone-zone-2-sensor-valvePositionPct",
+        "entry-1-zone-zone-1-sensor-valve_position_pct",
+        "entry-1-zone-zone-2-sensor-valve_position_pct",
     }
     assert {entity.native_value for entity in valve_entities} == {0.0, 100.0}
     assert all(
@@ -400,20 +400,20 @@ def test_build_zone_parent_device_ids_flags_mapped_zone_without_physical_parent(
             {
                 "id": "zone-2",
                 "name": "Etaj",
-                "config": {"roomTemperatureZoneMapping": 2},
+                "config": {"room_temperature_zone_mapping": 2},
             }
         ],
         {
-            "radioDevices": [
+            "radio_devices": [
                 {
                     "group": 0x09,
                     "instance": 1,
-                    "radioBusKey": "g09-i01",
-                    "deviceConnected": True,
-                    "remoteControlAddress": 0,
+                    "radio_bus_key": "g09-i01",
+                    "device_connected": True,
+                    "remote_control_address": 0,
                 }
             ],
-            "radioZoneCandidates": {},
+            "radio_zone_candidates": {},
         },
         ("helianthus", "entry-1-bus-BASV-15"),
     )
@@ -427,56 +427,56 @@ def test_build_zone_parent_device_ids_recovers_once_live_radio_payload_is_availa
         {
             "id": "zone-1",
             "name": "Parter",
-            "config": {"roomTemperatureZoneMapping": 1},
+            "config": {"room_temperature_zone_mapping": 1},
         },
         {
             "id": "zone-2",
             "name": "Etaj",
-            "config": {"roomTemperatureZoneMapping": 2},
+            "config": {"room_temperature_zone_mapping": 2},
         },
     ]
     regulator = ("helianthus", "entry-1-bus-BASV-15")
     sparse_payload = {
-        "radioDevices": [
+        "radio_devices": [
             {
                 "group": 0x09,
                 "instance": 1,
-                "radioBusKey": "g09-i01",
-                "deviceConnected": False,
-                "remoteControlAddress": 0,
-                "zoneAssignment": 1,
+                "radio_bus_key": "g09-i01",
+                "device_connected": False,
+                "remote_control_address": 0,
+                "zone_assignment": 1,
             },
             {
                 "group": 0x0A,
                 "instance": 1,
-                "radioBusKey": "g0a-i01",
-                "deviceConnected": False,
-                "remoteControlAddress": 1,
-                "zoneAssignment": 2,
+                "radio_bus_key": "g0a-i01",
+                "device_connected": False,
+                "remote_control_address": 1,
+                "zone_assignment": 2,
             },
         ],
-        "radioZoneCandidates": {},
+        "radio_zone_candidates": {},
     }
     live_payload = {
-        "radioDevices": [
+        "radio_devices": [
             {
                 "group": 0x09,
                 "instance": 1,
-                "radioBusKey": "g09-i01",
-                "deviceConnected": True,
-                "remoteControlAddress": 0,
-                "zoneAssignment": 1,
+                "radio_bus_key": "g09-i01",
+                "device_connected": True,
+                "remote_control_address": 0,
+                "zone_assignment": 1,
             },
             {
                 "group": 0x0A,
                 "instance": 1,
-                "radioBusKey": "g0a-i01",
-                "deviceConnected": True,
-                "remoteControlAddress": 1,
-                "zoneAssignment": 2,
+                "radio_bus_key": "g0a-i01",
+                "device_connected": True,
+                "remote_control_address": 1,
+                "zone_assignment": 2,
             },
         ],
-        "radioZoneCandidates": {},
+        "radio_zone_candidates": {},
     }
 
     sparse_parent_ids, sparse_unresolved = build_zone_parent_device_ids(
@@ -510,13 +510,13 @@ def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
                         "id": "zone-1",
                         "name": "Parter",
                         "state": {},
-                        "config": {"roomTemperatureZoneMapping": 1},
+                        "config": {"room_temperature_zone_mapping": 1},
                     }
                 ],
                 "dhw": None,
             }
         ),
-        "radio_coordinator": _FakeCoordinator({"radioDevices": [], "radioZoneCandidates": {}}),
+        "radio_coordinator": _FakeCoordinator({"radio_devices": [], "radio_zone_candidates": {}}),
         "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
         "zone_parent_device_ids": {},
         "adapter_device_id": ("helianthus", "adapter-entry-1"),


### PR DESCRIPTION
## Summary
- Migrate all GraphQL queries from camelCase to snake_case field names (gateway now dual-serves both)
- Update 17 platform files: field key definitions + `.get()` patterns
- Add `_migrate_unique_ids_to_snake_case()` in `__init__.py` — 83-entry rename map preserving entity history via `async_update_entity(new_unique_id=...)`
- Update 18 test files (232/232 pass)

## Test plan
- [x] `pytest tests/` — 232/232 pass
- [x] Zero camelCase field keys remaining in platform files
- [x] E2E: deploy to RPi4, verify entities load with preserved history
- [x] Verify unique_id migration runs on existing install

Closes #183
Depends on: gateway PR #493 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)