### PR TITLE
feat(helianthus/vaillant_b503): M4_HA — boiler_active_error diagnostic sensor (TDD)

### DIFF
--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -964,6 +964,34 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     async_add_entities(sensors)
 
+    # M4_HA (execution-plans#19): Vaillant B503 diagnostic sensor.
+    # Entity lifecycle follows plan AD11 (3-poll NOT_SUPPORTED hysteresis)
+    # and AD15 (state=None on healthy, state=unavailable on transient reasons,
+    # entity absent on persistent NOT_SUPPORTED). Production wiring is
+    # gated on the M5 BENCH-REPLACE live-bus ratification for the MCP
+    # stub dispatcher — until then, the capability probe resolves to
+    # UNKNOWN and the sensor renders as unavailable rather than serving
+    # stub data.
+    try:
+        from .vaillant_b503 import async_setup_b503
+
+        b503_client = data.get("graphql_client")
+        b503_device_id = boiler_device_id or regulator_device_id
+        if b503_client is not None and b503_device_id is not None:
+            await async_setup_b503(
+                hass,
+                entry,
+                async_add_entities,
+                client=b503_client,
+                device_id=b503_device_id,
+                scan_interval=30,
+            )
+    except Exception:  # noqa: BLE001
+        # B503 sensor is optional diagnostic; any wiring failure must not
+        # block the rest of the integration from loading.
+        _b503_logger = __import__("logging").getLogger(__name__)
+        _b503_logger.exception("Vaillant B503 sensor wiring failed; continuing without it")
+
 
 class HelianthusBusAddressSensor(CoordinatorEntity, SensorEntity):
     """eBUS address sensor for a physical bus device."""

--- a/custom_components/helianthus/vaillant_b503.py
+++ b/custom_components/helianthus/vaillant_b503.py
@@ -1,0 +1,278 @@
+"""B503 boiler active-error diagnostic sensor (plan §M4_HA).
+
+Surfaces :code:`vaillantErrors.firstActiveError` as a HA sensor entity
+gated by :code:`vaillantCapabilities.b503.reason`. Follows the lifecycle
+rules from plan AD11 (3-poll hysteresis on NOT_SUPPORTED flips) and
+AD15 (state transitions per capability reason). No F.xxx translation
+(AD05) — native_value is the raw decimal integer from GraphQL.
+
+This module is test-surface oriented: the coordinator exposes
+``async_refresh_once()`` and ``should_create_entity()`` so unit tests
+can drive the lifecycle without spinning up a full HA loop. Production
+``async_setup_entry`` wiring will be added by the platform integration
+step; the sensor + coordinator classes here are the load-bearing
+pieces.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# Plan AD11 — number of consecutive NOT_SUPPORTED polls required to
+# destroy the entity after it has been created. The first two polls
+# keep the entity alive (state=unavailable) so a transient capability
+# flip does not churn the entity registry.
+NOT_SUPPORTED_HYSTERESIS_POLLS = 3
+
+# Capability reason enum values that keep the entity alive but report
+# state=unavailable per plan AD15.
+_UNAVAILABLE_REASONS = frozenset({"TRANSPORT_DOWN", "UNKNOWN", "SESSION_BUSY"})
+_AVAILABLE_REASON = "AVAILABLE"
+_NOT_SUPPORTED_REASON = "NOT_SUPPORTED"
+
+QUERY_B503_STATE = """
+query VaillantB503State {
+  vaillantCapabilities {
+    b503 {
+      reason
+    }
+  }
+  vaillantErrors {
+    firstActiveError
+    slots
+  }
+}
+"""
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Coerce to int; return None for bools, None, or non-numeric values."""
+    if isinstance(value, bool):
+        return None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_slots(raw: Any) -> list[int | None]:
+    """Normalize the 5-slot error history array.
+
+    Always returns a list of 5 entries (int or None). Non-list input
+    collapses to all-None. Extra entries are truncated; shorter lists
+    are padded with None.
+    """
+    out: list[int | None] = [None, None, None, None, None]
+    if not isinstance(raw, list):
+        return out
+    for idx, entry in enumerate(raw[:5]):
+        out[idx] = _coerce_int(entry)
+    return out
+
+
+class VaillantB503Coordinator:
+    """Coordinator for B503 capability + error telemetry.
+
+    Not a DataUpdateCoordinator subclass in the unit-test surface so we
+    can drive it synchronously without HA's event loop scaffolding. The
+    contract exposed to the sensor entity is:
+
+    - :py:attr:`data` — the most recent normalized payload, or None.
+    - :py:meth:`should_create_entity` — honors plan AD11 hysteresis.
+    - :py:meth:`async_refresh_once` — fetches one poll and updates
+      state. Production wiring can subclass or adapt this into a
+      :class:`DataUpdateCoordinator`.
+    """
+
+    def __init__(self, hass: Any, client: Any, scan_interval: int) -> None:
+        self.hass = hass
+        self._client = client
+        self.update_interval = timedelta(seconds=max(1, scan_interval))
+        self.data: dict[str, Any] | None = None
+        # Hysteresis state machine:
+        # - _entity_ever_created: once we observe a non-NOT_SUPPORTED reason,
+        #   the entity is created and stays until 3 consecutive NOT_SUPPORTED
+        #   polls elapse.
+        # - _not_supported_streak: count of consecutive NOT_SUPPORTED polls
+        #   since the last non-NOT_SUPPORTED observation.
+        # - _entity_destroyed: sticky flag set when the streak reaches
+        #   NOT_SUPPORTED_HYSTERESIS_POLLS.
+        self._entity_ever_created = False
+        self._not_supported_streak = 0
+        self._entity_destroyed = False
+
+    # ------------------------------------------------------------------
+    # Polling
+    # ------------------------------------------------------------------
+
+    async def async_refresh_once(self) -> None:
+        """Execute one poll and update lifecycle state."""
+        try:
+            payload = await self._client.execute(QUERY_B503_STATE)
+        except Exception as exc:  # noqa: BLE001 — keep entity alive on transport errors
+            _LOGGER.debug("B503 poll failed: %s", exc)
+            # Treat transport failure as UNKNOWN — entity stays, state=unavailable.
+            self._apply_reason("UNKNOWN")
+            self.data = {"reason": "UNKNOWN", "first_active_error": None, "slots": [None] * 5}
+            return
+
+        reason = _extract_reason(payload)
+        errors = payload.get("vaillantErrors") if isinstance(payload, dict) else None
+        first_active: int | None = None
+        slots: list[int | None] = [None, None, None, None, None]
+        if isinstance(errors, dict):
+            first_active = _coerce_int(errors.get("firstActiveError"))
+            slots = _normalize_slots(errors.get("slots"))
+
+        self._apply_reason(reason)
+        self.data = {
+            "reason": reason,
+            "first_active_error": first_active,
+            "slots": slots,
+        }
+
+    def _apply_reason(self, reason: str) -> None:
+        if reason == _NOT_SUPPORTED_REASON:
+            if self._entity_ever_created and not self._entity_destroyed:
+                self._not_supported_streak += 1
+                if self._not_supported_streak >= NOT_SUPPORTED_HYSTERESIS_POLLS:
+                    self._entity_destroyed = True
+            # If the entity was never created (cold-start NOT_SUPPORTED),
+            # leave all lifecycle flags untouched — no entity is born.
+            return
+        # Any non-NOT_SUPPORTED reason creates the entity (if not already)
+        # and resets the hysteresis counter.
+        self._entity_ever_created = True
+        self._not_supported_streak = 0
+        # NOTE: once destroyed, we do NOT resurrect the entity mid-runtime.
+        # A fresh config-entry reload is required to re-probe capability.
+
+    # ------------------------------------------------------------------
+    # Lifecycle predicate
+    # ------------------------------------------------------------------
+
+    def should_create_entity(self) -> bool:
+        """Return True iff the entity should exist in the registry."""
+        if not self._entity_ever_created:
+            return False
+        if self._entity_destroyed:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # State views consumed by the sensor entity
+    # ------------------------------------------------------------------
+
+    def current_reason(self) -> str:
+        if not isinstance(self.data, dict):
+            return "UNKNOWN"
+        reason = self.data.get("reason")
+        return str(reason) if isinstance(reason, str) else "UNKNOWN"
+
+    def current_first_active(self) -> int | None:
+        if not isinstance(self.data, dict):
+            return None
+        return _coerce_int(self.data.get("first_active_error"))
+
+    def current_slots(self) -> list[int | None]:
+        if not isinstance(self.data, dict):
+            return [None, None, None, None, None]
+        slots = self.data.get("slots")
+        if isinstance(slots, list):
+            return list(slots)
+        return [None, None, None, None, None]
+
+
+def _extract_reason(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "UNKNOWN"
+    caps = payload.get("vaillantCapabilities")
+    if not isinstance(caps, dict):
+        return "UNKNOWN"
+    b503 = caps.get("b503")
+    if not isinstance(b503, dict):
+        return "UNKNOWN"
+    reason = b503.get("reason")
+    if isinstance(reason, str) and reason:
+        return reason
+    return "UNKNOWN"
+
+
+class BoilerActiveErrorSensor(CoordinatorEntity, SensorEntity):
+    """HA diagnostic sensor exposing the boiler's first active error.
+
+    Plan §M4_HA: state = decimal int (or None when healthy); attribute
+    ``error_history`` = 5-slot array; attribute ``capability_reason`` =
+    current capability enum string.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:alert-circle-outline"
+    _attr_has_entity_name = True
+    _attr_name = "Boiler Active Error"
+
+    def __init__(
+        self,
+        coordinator: VaillantB503Coordinator,
+        entry_id: str,
+        boiler_device_id: tuple[str, str] | None = None,
+    ) -> None:
+        CoordinatorEntity.__init__(self, coordinator)
+        self._coordinator = coordinator
+        self._entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}-boiler-active-error"
+        if boiler_device_id is not None:
+            self._attr_device_info = DeviceInfo(identifiers={boiler_device_id})
+
+    # ------------------------------------------------------------------
+    # HA entity surface
+    # ------------------------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        reason = self._coordinator.current_reason()
+        if reason == _AVAILABLE_REASON:
+            return True
+        # NOT_SUPPORTED during hysteresis window, TRANSPORT_DOWN, UNKNOWN,
+        # SESSION_BUSY all render state=unavailable per AD15.
+        return False
+
+    @property
+    def native_value(self) -> int | None:
+        if not self.available:
+            return None
+        return self._coordinator.current_first_active()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "error_history": self._coordinator.current_slots(),
+            "capability_reason": self._coordinator.current_reason(),
+        }
+
+
+__all__ = [
+    "BoilerActiveErrorSensor",
+    "NOT_SUPPORTED_HYSTERESIS_POLLS",
+    "QUERY_B503_STATE",
+    "VaillantB503Coordinator",
+]
+
+
+# Suppress unused-import warning for DOMAIN in static analysis; the const
+# is re-exported for integration wiring downstream.
+_ = DOMAIN

--- a/custom_components/helianthus/vaillant_b503.py
+++ b/custom_components/helianthus/vaillant_b503.py
@@ -217,6 +217,12 @@ async def async_setup_b503(
 
     inner = VaillantB503Coordinator(hass, client, scan_interval=scan_interval)
 
+    # The DUC delegates state-read methods to the inner coordinator so
+    # BoilerActiveErrorSensor can call current_reason()/current_first_active()/
+    # current_slots() on its coordinator (whether constructed with the DUC in
+    # production or VaillantB503Coordinator directly in tests). Without
+    # these delegations, HA raises AttributeError on the first state
+    # evaluation because DataUpdateCoordinator has no such methods.
     class _B503DUC(DataUpdateCoordinator):
         def __init__(self) -> None:
             super().__init__(
@@ -225,14 +231,44 @@ async def async_setup_b503(
                 name="helianthus_vaillant_b503",
                 update_interval=inner.update_interval,
             )
+            self.b503_inner = inner
+            # Production-teardown hook: set by async_setup_b503 after the
+            # entity is added so runtime NOT_SUPPORTED hysteresis can
+            # remove the entity.
+            self._b503_entity = None  # type: Any
 
         async def _async_update_data(self) -> dict[str, Any] | None:
             await inner.async_refresh_once()
+            # AD11 runtime teardown: if the hysteresis streak destroyed
+            # the entity, fire an async removal. Initial-setup uses
+            # should_create_entity() to skip add; this path handles the
+            # runtime flip to NOT_SUPPORTED after the entity already
+            # exists.
+            if (
+                inner._entity_destroyed  # noqa: SLF001
+                and self._b503_entity is not None
+            ):
+                entity = self._b503_entity
+                self._b503_entity = None
+                try:
+                    await entity.async_remove(force_remove=True)
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("B503 entity async_remove failed", exc_info=True)
             return inner.data
 
+        # --- state-read delegations to inner coordinator (so a sensor
+        #     constructed against this DUC can read VaillantB503Coordinator-
+        #     shaped methods directly) ---
+        def current_reason(self) -> str:
+            return inner.current_reason()
+
+        def current_first_active(self) -> int | None:
+            return inner.current_first_active()
+
+        def current_slots(self) -> list[int | None]:
+            return inner.current_slots()
+
     duc = _B503DUC()
-    # Expose the hysteresis controller so the entity can consult it.
-    duc.b503_inner = inner  # type: ignore[attr-defined]
 
     await duc.async_config_entry_first_refresh()
 
@@ -240,9 +276,9 @@ async def async_setup_b503(
         # Cold-start NOT_SUPPORTED → entity absent (plan AD11).
         return
 
-    async_add_entities(
-        [BoilerActiveErrorSensor(duc, entry.entry_id, device_id)]
-    )
+    entity = BoilerActiveErrorSensor(duc, entry.entry_id, device_id)
+    duc._b503_entity = entity  # noqa: SLF001 — teardown hook for AD11 runtime flip
+    async_add_entities([entity])
 
 
 def _extract_reason(payload: Any) -> str:

--- a/custom_components/helianthus/vaillant_b503.py
+++ b/custom_components/helianthus/vaillant_b503.py
@@ -197,6 +197,54 @@ class VaillantB503Coordinator:
         return [None, None, None, None, None]
 
 
+async def async_setup_b503(
+    hass: Any,
+    entry: Any,
+    async_add_entities: Any,
+    client: Any,
+    device_id: tuple,
+    scan_interval: int = 30,
+) -> None:
+    """Production wiring for the B503 diagnostic sensor.
+
+    Call from sensor.py async_setup_entry. Uses a DataUpdateCoordinator
+    subclass that delegates to VaillantB503Coordinator.async_refresh_once.
+
+    Honors plan AD11 hysteresis via should_create_entity() — if the cold-
+    start poll returns NOT_SUPPORTED the entity is simply not added.
+    """
+    from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+    inner = VaillantB503Coordinator(hass, client, scan_interval=scan_interval)
+
+    class _B503DUC(DataUpdateCoordinator):
+        def __init__(self) -> None:
+            super().__init__(
+                hass,
+                _LOGGER,
+                name="helianthus_vaillant_b503",
+                update_interval=inner.update_interval,
+            )
+
+        async def _async_update_data(self) -> dict[str, Any] | None:
+            await inner.async_refresh_once()
+            return inner.data
+
+    duc = _B503DUC()
+    # Expose the hysteresis controller so the entity can consult it.
+    duc.b503_inner = inner  # type: ignore[attr-defined]
+
+    await duc.async_config_entry_first_refresh()
+
+    if not inner.should_create_entity():
+        # Cold-start NOT_SUPPORTED → entity absent (plan AD11).
+        return
+
+    async_add_entities(
+        [BoilerActiveErrorSensor(duc, entry.entry_id, device_id)]
+    )
+
+
 def _extract_reason(payload: Any) -> str:
     if not isinstance(payload, dict):
         return "UNKNOWN"

--- a/tests/test_vaillant_b503_sensor.py
+++ b/tests/test_vaillant_b503_sensor.py
@@ -1,0 +1,262 @@
+"""Tests for the B503 boiler_active_error diagnostic sensor.
+
+Covers plan §M4_HA + AD11 (3-poll hysteresis) + AD15 (lifecycle) + AD05
+(no F.xxx translation). GraphQL-driven: ``vaillantCapabilities.b503`` +
+``vaillantErrors``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    sensor_module = sys.modules.setdefault(
+        "homeassistant.components.sensor",
+        types.ModuleType("homeassistant.components.sensor"),
+    )
+    if not hasattr(sensor_module, "SensorEntity"):
+        class _SensorEntity:
+            pass
+
+        sensor_module.SensorEntity = _SensorEntity
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    if not hasattr(const_module, "EntityCategory"):
+        class _EntityCategory:
+            DIAGNOSTIC = "diagnostic"
+
+        const_module.EntityCategory = _EntityCategory
+    if not hasattr(const_module, "STATE_UNAVAILABLE"):
+        const_module.STATE_UNAVAILABLE = "unavailable"
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+    if not hasattr(device_registry_module, "DeviceInfo"):
+        class _DeviceInfo(dict):
+            def __init__(self, **kwargs) -> None:  # noqa: ANN003
+                super().__init__(**kwargs)
+
+        device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+    if not hasattr(update_coordinator_module, "CoordinatorEntity"):
+        class _CoordinatorEntity:
+            def __init__(self, coordinator) -> None:  # noqa: ANN001
+                self.coordinator = coordinator
+
+        update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import vaillant_b503  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraphQLClient:
+    """Records calls and returns scripted payloads."""
+
+    def __init__(self, responses):
+        # responses: list of payloads; popleft-like semantics
+        self._responses = list(responses)
+        self.calls = []
+
+    async def execute(self, query, variables=None):
+        self.calls.append((query, variables))
+        if not self._responses:
+            raise RuntimeError("No more scripted responses")
+        payload = self._responses.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+
+def _payload(reason, first_active=None, slots=None):
+    """Build a canonical GraphQL reply for vaillantCapabilities.b503 + vaillantErrors."""
+    return {
+        "vaillantCapabilities": {
+            "b503": {"reason": reason},
+        },
+        "vaillantErrors": {
+            "firstActiveError": first_active,
+            "slots": slots if slots is not None else [None, None, None, None, None],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cold-start lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_available_creates_entity() -> None:
+    client = _FakeGraphQLClient([_payload("AVAILABLE")])
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+
+    asyncio.run(coordinator.async_refresh_once())
+
+    assert coordinator.should_create_entity() is True
+
+
+def test_cold_start_not_supported_no_entity() -> None:
+    client = _FakeGraphQLClient([_payload("NOT_SUPPORTED")])
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+
+    asyncio.run(coordinator.async_refresh_once())
+
+    assert coordinator.should_create_entity() is False
+
+
+# ---------------------------------------------------------------------------
+# State semantics
+# ---------------------------------------------------------------------------
+
+
+def test_available_no_active_error_state_none() -> None:
+    client = _FakeGraphQLClient([_payload("AVAILABLE", first_active=None, slots=[None, None, None, None, None])])
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+    asyncio.run(coordinator.async_refresh_once())
+    entity = vaillant_b503.BoilerActiveErrorSensor(coordinator=coordinator, entry_id="entry-1")
+
+    assert entity.available is True
+    assert entity.native_value is None
+    assert entity.extra_state_attributes["error_history"] == [None, None, None, None, None]
+    assert entity.extra_state_attributes["capability_reason"] == "AVAILABLE"
+
+
+def test_available_with_active_error() -> None:
+    client = _FakeGraphQLClient(
+        [_payload("AVAILABLE", first_active=281, slots=[281, 42, None, None, None])]
+    )
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+    asyncio.run(coordinator.async_refresh_once())
+    entity = vaillant_b503.BoilerActiveErrorSensor(coordinator=coordinator, entry_id="entry-1")
+
+    assert entity.available is True
+    assert entity.native_value == 281
+    assert entity.extra_state_attributes["error_history"] == [281, 42, None, None, None]
+    assert entity.extra_state_attributes["capability_reason"] == "AVAILABLE"
+
+
+# ---------------------------------------------------------------------------
+# Transient unavailable semantics
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_transport_down_entity_unavailable() -> None:
+    client = _FakeGraphQLClient(
+        [
+            _payload("AVAILABLE"),
+            _payload("TRANSPORT_DOWN"),
+        ]
+    )
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+    asyncio.run(coordinator.async_refresh_once())
+    asyncio.run(coordinator.async_refresh_once())
+    entity = vaillant_b503.BoilerActiveErrorSensor(coordinator=coordinator, entry_id="entry-1")
+
+    # Entity preserved but reports unavailable
+    assert coordinator.should_create_entity() is True
+    assert entity.available is False
+    assert entity.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# 3-poll hysteresis on NOT_SUPPORTED flip
+# ---------------------------------------------------------------------------
+
+
+def test_not_supported_flip_hysteresis() -> None:
+    client = _FakeGraphQLClient(
+        [
+            _payload("AVAILABLE"),
+            _payload("NOT_SUPPORTED"),
+            _payload("NOT_SUPPORTED"),
+            _payload("NOT_SUPPORTED"),
+        ]
+    )
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+
+    asyncio.run(coordinator.async_refresh_once())  # AVAILABLE — entity created
+    assert coordinator.should_create_entity() is True
+
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #1
+    assert coordinator.should_create_entity() is True
+    entity = vaillant_b503.BoilerActiveErrorSensor(coordinator=coordinator, entry_id="entry-1")
+    assert entity.available is False
+
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #2
+    assert coordinator.should_create_entity() is True
+
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #3 — destroy
+    assert coordinator.should_create_entity() is False
+
+
+def test_not_supported_flip_counter_resets() -> None:
+    client = _FakeGraphQLClient(
+        [
+            _payload("AVAILABLE"),
+            _payload("NOT_SUPPORTED"),
+            _payload("NOT_SUPPORTED"),
+            _payload("AVAILABLE"),
+            _payload("NOT_SUPPORTED"),
+            _payload("NOT_SUPPORTED"),
+        ]
+    )
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+
+    asyncio.run(coordinator.async_refresh_once())  # AVAILABLE
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #1
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #2
+    assert coordinator.should_create_entity() is True
+
+    asyncio.run(coordinator.async_refresh_once())  # AVAILABLE — reset
+    assert coordinator.should_create_entity() is True
+
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #1 (post-reset)
+    asyncio.run(coordinator.async_refresh_once())  # NOT_SUPPORTED #2 (post-reset)
+    # Only 2 consecutive NOT_SUPPORTED — entity must remain.
+    assert coordinator.should_create_entity() is True
+
+
+# ---------------------------------------------------------------------------
+# AD05 — no F.xxx translation
+# ---------------------------------------------------------------------------
+
+
+def test_no_fxxx_translation() -> None:
+    client = _FakeGraphQLClient(
+        [_payload("AVAILABLE", first_active=281, slots=[281, None, None, None, None])]
+    )
+    coordinator = vaillant_b503.VaillantB503Coordinator(hass=None, client=client, scan_interval=1)
+    asyncio.run(coordinator.async_refresh_once())
+    entity = vaillant_b503.BoilerActiveErrorSensor(coordinator=coordinator, entry_id="entry-1")
+
+    assert entity.native_value == 281
+    assert not isinstance(entity.native_value, str)
+    # History never contains an "F.281" string transform either.
+    for slot in entity.extra_state_attributes["error_history"]:
+        assert not isinstance(slot, str)


### PR DESCRIPTION
Closes #187.
Tracks cruise-run [execution-plans#19](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/19) — plan `vaillant-b503-namespace-w17-26.implementing`, milestone **M4_HA** (complexity 4). **Last code milestone in the plan.**

Predecessors (merged): M0/M1/M2a/M5/M2b + M3 (in review).

## Summary

HA diagnostic sensor `sensor.boiler_active_error` consuming M2b GraphQL `vaillantCapabilities.b503` + `vaillantErrors`. TDD strict: RED `5314989` + IMPL `caf458e` + wiring `94ffc89`.

## Lifecycle (plan AD11, AD15)

- `AVAILABLE` + active error → state=decimal, attribute `error_history` populated
- `AVAILABLE` + healthy (5×0xFFFF) → state=None (HA `unknown`) — **not** `unavailable`
- `TRANSPORT_DOWN` / `UNKNOWN` / `SESSION_BUSY` → entity present, state=unavailable
- `NOT_SUPPORTED` cold-start → entity **absent**
- `NOT_SUPPORTED` runtime flip → 3-poll hysteresis (entity preserved until 3 consecutive confirmations; counter resets on any non-NOT_SUPPORTED poll)

## Invariants

- AD05 — no F.xxx translation, raw decimal
- AD07 — no service-history entity in v1

## Tests (8/8 pass; 7/7 existing sensor suite regression-clean)

- `test_cold_start_available_creates_entity`
- `test_cold_start_not_supported_no_entity`
- `test_available_no_active_error_state_none`
- `test_available_with_active_error` (firstActiveError=281)
- `test_runtime_transport_down_entity_unavailable`
- `test_not_supported_flip_hysteresis` (3-poll rule)
- `test_not_supported_flip_counter_resets`
- `test_no_fxxx_translation`

## Production wiring

`vaillant_b503.async_setup_b503()` wraps the test-surface coordinator in a DataUpdateCoordinator subclass; `sensor.async_setup_entry` invokes it after the main sensor batch. Wrapped in try/except so any B503 wiring failure surfaces as a log entry rather than blocking integration load (B503 is optional diagnostic surface).

## Publication gate

M4 entity currently renders as `unavailable` / `unknown` in production because the M2a stub dispatcher returns upstream errors that classify as UNKNOWN. Meaningful data will start surfacing once the M5 BENCH-REPLACE flip lands the production raw-frame bridge.

This PR completes the 7-milestone implementation of the cruise-run plan. Final remaining work across the plan: M5 BENCH-REPLACE + operator attestation (live-bus).