### PR TITLE
Consume source-selection admission in HA

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -7,6 +7,11 @@ import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from .admission import (
+    REPAIR_EMPTY_INVENTORY_UNTRUSTED,
+    status_admission_trusted,
+    update_effective_admission,
+)
 from .const import (
     CONF_DHW_SCHEDULE_HELPER,
     CONF_INSTANCE_GUID,
@@ -969,8 +974,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if index is not None and index >= 0:
             known_cylinder_indexes.add(index)
 
-    daemon_data = status_coordinator.data.get("daemon", {}) if status_coordinator.data else {}
-    daemon_source_addr = _parse_bus_address(daemon_data.get("initiator_address"))
+    admission = update_effective_admission(status_coordinator, devices)
+
+    cleanup_counts = hass.data.setdefault(DOMAIN, {}).setdefault("_admission_cleanup_counts", {})
+    cleanup_allowed = False
+    cleanup_ran = False
+
+    def record_cleanup_evidence(current_devices: list[dict]) -> bool:
+        nonlocal cleanup_allowed
+        update_effective_admission(status_coordinator, current_devices)
+        if status_admission_trusted(status_coordinator) and current_devices:
+            cleanup_counts[entry.entry_id] = int(cleanup_counts.get(entry.entry_id) or 0) + 1
+        else:
+            cleanup_counts[entry.entry_id] = 0
+        cleanup_allowed = cleanup_counts.get(entry.entry_id, 0) >= 2
+        return cleanup_allowed
+
+    record_cleanup_evidence(devices)
 
     semantic = semantic_coordinator.data or {}
     semantic_zones = [
@@ -1210,7 +1230,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             schedule_reload("sparse entities became live")
 
-    cleanup_obsolete_entity_registry_entries()
+    def run_trusted_cleanup(reason: str) -> None:
+        nonlocal cleanup_ran
+        if cleanup_ran:
+            return
+        if not cleanup_allowed:
+            _LOGGER.info(
+                "Helianthus cleanup skipped for entry %s until admission and inventory are trusted (%s)",
+                entry.entry_id,
+                admission.get("repair_code") or REPAIR_EMPTY_INVENTORY_UNTRUSTED,
+            )
+            return
+        cleanup_obsolete_entity_registry_entries()
+        auto_enable_sparse_entities(reason)
+        cleanup_obsolete_devices(reason)
+        cleanup_ran = True
 
     def current_zone_parent_device_ids() -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
         payload = semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
@@ -1262,6 +1296,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ).strip()
 
     async def apply_zone_schedule(zone_id: str) -> None:
+        if not status_admission_trusted(status_coordinator):
+            _LOGGER.warning("Zone schedule helper ignored: source admission is not trusted")
+            return
         if regulator_bus_address is None:
             _LOGGER.warning("Zone schedule helper ignored: regulator address missing")
             return
@@ -1269,11 +1306,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if instance is None:
             _LOGGER.warning("Zone schedule helper ignored: invalid zone id %s", zone_id)
             return
-        source = daemon_source_addr if daemon_source_addr is not None else 0x31
         variables = {
             "address": int(regulator_bus_address),
             "params": {
-                "source": int(source),
                 "opcode": 0x02,
                 "group": 0x03,
                 "instance": int(instance),
@@ -1292,14 +1327,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning("Zone schedule helper write failed for %s: %s", zone_id, exc)
 
     async def apply_dhw_schedule() -> None:
+        if not status_admission_trusted(status_coordinator):
+            _LOGGER.warning("DHW schedule helper ignored: source admission is not trusted")
+            return
         if regulator_bus_address is None:
             _LOGGER.warning("DHW schedule helper ignored: regulator address missing")
             return
-        source = daemon_source_addr if daemon_source_addr is not None else 0x31
         variables = {
             "address": int(regulator_bus_address),
             "params": {
-                "source": int(source),
                 "opcode": 0x02,
                 "group": 0x01,
                 "instance": 0x00,
@@ -1317,20 +1353,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as exc:  # pragma: no cover - defensive runtime guard
             _LOGGER.warning("DHW schedule helper write failed: %s", exc)
 
-    def handle_device_update() -> None:
-        current = device_coordinator.data or []
-        if not current:
-            return
+    def current_bus_device_ids(current: list[dict]) -> set[str]:
         current_ids: set[str] = set()
         for dev in current:
             bus_key = resolved_bus_device_key(dev)
             if bus_key:
                 current_ids.add(bus_key)
+        return current_ids
+
+    def handle_device_update() -> None:
+        current = device_coordinator.data or []
+        record_cleanup_evidence(current)
+        if not current:
+            return
+        current_ids = current_bus_device_ids(current)
         if not current_ids:
             return
         if current_ids.issubset(known_bus_devices):
+            if cleanup_allowed:
+                run_trusted_cleanup("trusted non-empty inventory refresh")
             return
         schedule_reload("new bus devices discovered")
+
+    def handle_status_update() -> None:
+        current = device_coordinator.data or []
+        record_cleanup_evidence(current)
+        current_ids = current_bus_device_ids(current)
+        if current_ids and not current_ids.issubset(known_bus_devices):
+            schedule_reload("new bus devices discovered")
+            return
+        if cleanup_allowed and current_ids:
+            run_trusted_cleanup("trusted admission status refresh")
 
     def handle_semantic_update() -> None:
         payload = semantic_coordinator.data or {}
@@ -1409,6 +1462,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         auto_enable_sparse_entities("fm5 update")
 
     unsub_listeners: list[Callable[[], None]] = []
+    unsub_listeners.append(status_coordinator.async_add_listener(handle_status_update))
     unsub_listeners.append(device_coordinator.async_add_listener(handle_device_update))
     unsub_listeners.append(semantic_coordinator.async_add_listener(handle_semantic_update))
     unsub_listeners.append(circuit_coordinator.async_add_listener(handle_circuit_update))
@@ -1493,7 +1547,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "vr71_device_id": vr71_device,
         "regulator_manufacturer": regulator_manufacturer,
         "regulator_bus_address": regulator_bus_address,
-        "daemon_source_address": daemon_source_addr,
+        "admission_repair_code": admission.get("repair_code"),
+        "source_selection": admission.get("source_selection"),
         "boiler_physical_device_id": boiler_physical_device_id,
         "boiler_via_device_id": boiler_via_device_id,
         "boiler_burner_device_id": boiler_burner_device_id,
@@ -1507,9 +1562,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     # Run stale cleanup again after platform setup so registry-backed entities
     # created by prior installs are removed from the fully materialized registry.
-    cleanup_obsolete_entity_registry_entries()
-    auto_enable_sparse_entities("post-platform setup")
-    cleanup_obsolete_devices("post-platform setup")
+    run_trusted_cleanup("post-platform setup")
 
     return True
 
@@ -1519,6 +1572,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok and DOMAIN in hass.data:
         data = hass.data[DOMAIN].pop(entry.entry_id, None)
+        cleanup_counts = hass.data[DOMAIN].get("_admission_cleanup_counts")
+        if isinstance(cleanup_counts, dict):
+            cleanup_counts.pop(entry.entry_id, None)
         task = None if data is None else data.get("subscription_task")
         if task:
             task.cancel()

--- a/custom_components/helianthus/admission.py
+++ b/custom_components/helianthus/admission.py
@@ -1,0 +1,142 @@
+"""Source-selection admission helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+REPAIR_SCHEMA_INCOMPATIBLE = "schema_incompatible"
+REPAIR_ADMISSION_DEGRADED = "admission_degraded"
+REPAIR_EMPTY_INVENTORY_UNTRUSTED = "empty_inventory_untrusted"
+
+
+def _parse_bus_address(value: object | None) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 0 <= value <= 0xFF else None
+    try:
+        parsed = int(str(value).strip(), 0)
+    except (TypeError, ValueError):
+        return None
+    return parsed if 0 <= parsed <= 0xFF else None
+
+
+def _source_selection_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    bus_summary = payload.get("busSummary")
+    if not isinstance(bus_summary, dict):
+        bus_summary = payload.get("bus_summary")
+    if not isinstance(bus_summary, dict):
+        return None
+    status = bus_summary.get("status")
+    if not isinstance(status, dict):
+        return None
+    admission = status.get("bus_admission")
+    if not isinstance(admission, dict):
+        return None
+    source_selection = admission.get("source_selection")
+    return source_selection if isinstance(source_selection, dict) else None
+
+
+def source_selection_from_status_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract HA-facing source-selection admission state from a GraphQL payload."""
+    source_selection = _source_selection_from_payload(payload)
+    if source_selection is None:
+        return schema_incompatible_admission()
+    return normalize_source_selection(source_selection)
+
+
+def schema_incompatible_admission() -> dict[str, Any]:
+    """Return a fail-closed admission state for old or incompatible GraphQL schemas."""
+    return {
+        "source_selection": None,
+        "trusted": False,
+        "repair_code": REPAIR_SCHEMA_INCOMPATIBLE,
+        "selected_source": None,
+        "state": "degraded",
+        "reason": REPAIR_SCHEMA_INCOMPATIBLE,
+    }
+
+
+def normalize_source_selection(source_selection: dict[str, Any]) -> dict[str, Any]:
+    """Normalize source-selection status into fields HA can safely consume."""
+    state = str(source_selection.get("state") or "").strip().lower()
+    outcome = str(source_selection.get("outcome") or "").strip().lower()
+    selected_source = _parse_bus_address(source_selection.get("selected_source"))
+    trusted = state == "active" and outcome == "active_probe_passed" and selected_source is not None
+    repair_code = None if trusted else REPAIR_ADMISSION_DEGRADED
+    return {
+        "source_selection": source_selection,
+        "trusted": trusted,
+        "repair_code": repair_code,
+        "selected_source": selected_source,
+        "state": state or None,
+        "reason": source_selection.get("reason") or repair_code,
+    }
+
+
+def apply_empty_inventory_guard(admission: dict[str, Any], devices: list[Any]) -> dict[str, Any]:
+    """Mark healthy-looking empty inventory as untrusted before cleanup or writes."""
+    if not admission.get("trusted") or devices:
+        return admission
+    guarded = dict(admission)
+    guarded["trusted"] = False
+    guarded["repair_code"] = REPAIR_EMPTY_INVENTORY_UNTRUSTED
+    guarded["reason"] = REPAIR_EMPTY_INVENTORY_UNTRUSTED
+    return guarded
+
+
+def daemon_status_with_admission(
+    daemon_status: dict[str, Any],
+    admission: dict[str, Any],
+) -> dict[str, Any]:
+    """Flatten admission diagnostics onto daemon status sensors."""
+    out = dict(daemon_status)
+    out["admission_trusted"] = bool(admission.get("trusted"))
+    out["admission_repair_code"] = admission.get("repair_code")
+    out["source_selection_state"] = admission.get("state")
+    out["source_selection_reason"] = admission.get("reason")
+    selected_source = admission.get("selected_source")
+    out["source_selection_selected_source"] = (
+        f"0x{selected_source:02X}" if isinstance(selected_source, int) else None
+    )
+    return out
+
+
+def status_admission_trusted(status_coordinator: object | None) -> bool:
+    """Return the latest trusted admission bit from a status coordinator."""
+    if getattr(status_coordinator, "last_update_success", True) is False:
+        return False
+    data = getattr(status_coordinator, "data", None)
+    if not isinstance(data, dict):
+        return False
+    admission = data.get("admission")
+    return isinstance(admission, dict) and bool(admission.get("trusted"))
+
+
+def update_effective_admission(
+    status_coordinator: object | None,
+    devices: list[Any],
+) -> dict[str, Any]:
+    """Recompute effective admission from raw status and current inventory."""
+    data = getattr(status_coordinator, "data", None)
+    if not isinstance(data, dict):
+        return schema_incompatible_admission()
+    raw_admission = data.get("raw_admission")
+    if not isinstance(raw_admission, dict):
+        raw_admission = data.get("admission")
+    if not isinstance(raw_admission, dict):
+        raw_admission = schema_incompatible_admission()
+    effective = apply_empty_inventory_guard(raw_admission, devices)
+    daemon = data.get("daemon")
+    if not isinstance(daemon, dict):
+        daemon = {}
+    data["raw_admission"] = raw_admission
+    data["admission"] = effective
+    data["daemon"] = daemon_status_with_admission(daemon, effective)
+    return effective
+
+
+def assert_admission_trusted(admission_trusted: bool) -> None:
+    """Raise a HA-neutral error when a mutating path is not admitted."""
+    if not admission_trusted:
+        raise RuntimeError("Helianthus source admission is not trusted")

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import build_radio_bus_key, radio_device_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
@@ -136,7 +137,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
     regulator_bus_address = data.get("regulator_bus_address")
-    source_address = data.get("daemon_source_address")
+    status_coordinator = data.get("status_coordinator")
 
     zones = coordinator.data.get("zones", []) if coordinator.data else []
     entities = []
@@ -163,13 +164,22 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 manufacturer,
                 client,
                 regulator_bus_address,
-                source_address,
+                status_coordinator,
                 zone_id,
                 zone.get("name"),
                 is_dedicated_device=is_dedicated_device,
             )
         )
-    async_add_entities([entity for entity in entities if entity.zone_id])
+    entities = [entity for entity in entities if entity.zone_id]
+    async_add_entities(entities)
+    if entities and hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            for entity in entities:
+                if hasattr(entity, "async_write_ha_state"):
+                    entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
 
 
 class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
@@ -190,7 +200,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         manufacturer: str,
         client: GraphQLClient | None,
         regulator_bus_address: int | None,
-        source_address: int | None,
+        status_coordinator: object | None,
         zone_id: str | None,
         name: str | None,
         *,
@@ -203,7 +213,7 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         self._manufacturer = manufacturer
         self._client = client
         self._regulator_bus_address = regulator_bus_address
-        self._source_address = source_address
+        self._status_coordinator = status_coordinator
         self._zone_id = _normalize_zone_id(zone_id)
         self._zone_instance = _zone_instance(self._zone_id)
         self._zone_name = name or _zone_default_name(self._zone_id)
@@ -235,6 +245,11 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         if zone_name is not None and str(zone_name).strip():
             return f"{str(zone_name).strip()} Thermostat"
         return self._attr_name
+
+    @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -536,12 +551,14 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
             raise HomeAssistantError("Regulator address is unavailable")
         if self._zone_instance is None:
             raise HomeAssistantError(f"Invalid zone id: {self._zone_id}")
+        try:
+            assert_admission_trusted(status_admission_trusted(self._status_coordinator))
+        except RuntimeError as exc:
+            raise HomeAssistantError(str(exc)) from exc
 
-        source = self._source_address if self._source_address is not None else 0x31
         variables = {
             "address": int(self._regulator_bus_address),
             "params": {
-                "source": int(source),
                 "opcode": 0x02,
                 "group": _ZONE_GROUP,
                 "instance": int(self._zone_instance),

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -11,6 +11,11 @@ from typing import Any
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .admission import (
+    daemon_status_with_admission,
+    schema_incompatible_admission,
+    source_selection_from_status_payload,
+)
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 
@@ -180,11 +185,101 @@ query Devices {
 
 QUERY_STATUS = """
 query Status {
+  busSummary {
+    status {
+      bus_admission {
+        source_selection {
+          state
+          mode
+          outcome
+          reason
+          selected_source
+          failed_source
+          companion_target
+          active_probe {
+            target
+            opcode
+            status
+          }
+          retryable
+          next_action
+          last_successful_source
+          automatic_retry_scheduled
+          rejected_candidates {
+            source
+            reason
+            occupancy_state
+            evidence_provenance
+          }
+        }
+      }
+    }
+  }
   daemon_status {
     status
     firmware_version
     updates_available
     initiator_address
+  }
+  adapter_status {
+    status
+    firmware_version
+    updates_available
+  }
+}
+"""
+
+QUERY_STATUS_NO_INITIATOR = """
+query Status {
+  busSummary {
+    status {
+      bus_admission {
+        source_selection {
+          state
+          mode
+          outcome
+          reason
+          selected_source
+          failed_source
+          companion_target
+          active_probe {
+            target
+            opcode
+            status
+          }
+          retryable
+          next_action
+          last_successful_source
+          automatic_retry_scheduled
+          rejected_candidates {
+            source
+            reason
+            occupancy_state
+            evidence_provenance
+          }
+        }
+      }
+    }
+  }
+  daemon_status {
+    status
+    firmware_version
+    updates_available
+  }
+  adapter_status {
+    status
+    firmware_version
+    updates_available
+  }
+}
+"""
+
+QUERY_STATUS_MINIMAL = """
+query Status {
+  daemon_status {
+    status
+    firmware_version
+    updates_available
   }
   adapter_status {
     status
@@ -378,6 +473,30 @@ query Semantic {
 _HOLIDAY_FIELDS = ["holiday_start_date", "holiday_end_date", "holiday_setpoint", "holiday_start_time", "holiday_end_time"]
 _QV_FIELDS = ["quick_veto", "quick_veto_setpoint", "quick_veto_duration", "quick_veto_expiry"]
 _SEMANTIC_RECOVERABLE_FIELDS = _HOLIDAY_FIELDS + _QV_FIELDS + ["room_temperature_zone_mapping"]
+_STATUS_SCHEMA_FIELDS = [
+    "busSummary",
+    "status",
+    "bus_admission",
+    "source_selection",
+    "state",
+    "mode",
+    "outcome",
+    "reason",
+    "selected_source",
+    "failed_source",
+    "companion_target",
+    "active_probe",
+    "target",
+    "opcode",
+    "retryable",
+    "next_action",
+    "last_successful_source",
+    "automatic_retry_scheduled",
+    "rejected_candidates",
+    "source",
+    "occupancy_state",
+    "evidence_provenance",
+]
 
 QUERY_CIRCUITS = """
 query Circuits {
@@ -638,15 +757,38 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
         self._client = client
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
+        force_schema_incompatible = False
         try:
             payload = await self._client.execute(QUERY_STATUS)
         except GraphQLResponseError as exc:
             if _is_missing_field_error(exc.errors, ["initiator_address"]):
                 try:
-                    payload = await self._client.execute(QUERY_STATUS_LEGACY)
+                    payload = await self._client.execute(QUERY_STATUS_NO_INITIATOR)
+                except GraphQLResponseError as nested:
+                    if not _is_missing_field_error(
+                        nested.errors,
+                        _STATUS_SCHEMA_FIELDS,
+                    ):
+                        raise UpdateFailed(str(nested)) from nested
+                    try:
+                        payload = await self._client.execute(QUERY_STATUS_MINIMAL)
+                        force_schema_incompatible = True
+                    except GraphQLResponseError as legacy:
+                        raise UpdateFailed(str(legacy)) from legacy
+                    except GraphQLClientError as legacy:
+                        raise UpdateFailed(str(legacy)) from legacy
                 except GraphQLClientError as nested:
                     raise UpdateFailed(str(nested)) from nested
+            elif _is_missing_field_error(
+                exc.errors,
+                _STATUS_SCHEMA_FIELDS,
+            ):
+                try:
+                    payload = await self._client.execute(QUERY_STATUS_MINIMAL)
+                    force_schema_incompatible = True
                 except GraphQLResponseError as nested:
+                    raise UpdateFailed(str(nested)) from nested
+                except GraphQLClientError as nested:
                     raise UpdateFailed(str(nested)) from nested
             else:
                 raise UpdateFailed(str(exc)) from exc
@@ -654,10 +796,24 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
             raise UpdateFailed(str(exc)) from exc
 
         if not isinstance(payload, dict):
-            return {"daemon": {}, "adapter": {}}
+            admission = schema_incompatible_admission()
+            return {
+                "daemon": daemon_status_with_admission({}, admission),
+                "adapter": {},
+                "admission": admission,
+                "raw_admission": admission,
+            }
+        raw_admission = (
+            schema_incompatible_admission()
+            if force_schema_incompatible
+            else source_selection_from_status_payload(payload)
+        )
+        daemon = daemon_status_with_admission(payload.get("daemon_status", {}) or {}, raw_admission)
         return {
-            "daemon": payload.get("daemon_status", {}) or {},
+            "daemon": daemon,
             "adapter": payload.get("adapter_status", {}) or {},
+            "admission": raw_admission,
+            "raw_admission": raw_admission,
         }
 
 

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
@@ -39,6 +40,7 @@ async def async_setup_entry(
     manufacturer = data.get("manufacturer", "Vaillant")
     entry_id = entry.entry_id
     client = data.get("graphql_client")
+    status_coordinator = data.get("status_coordinator")
     regulator_device_id = data.get("regulator_device_id")
 
     entities: list[DateEntity] = []
@@ -50,11 +52,27 @@ async def async_setup_entry(
                 entry_id=entry_id,
                 manufacturer=manufacturer,
                 client=client,
+                status_coordinator=status_coordinator,
                 device_id=regulator_device_id,
             )
         )
 
     async_add_entities(entities)
+    if entities and hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            for entity in entities:
+                if hasattr(entity, "async_write_ha_state"):
+                    entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
+
+
+def _assert_admission_trusted(status_coordinator: object | None) -> None:
+    try:
+        assert_admission_trusted(status_admission_trusted(status_coordinator))
+    except RuntimeError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
@@ -64,10 +82,20 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:calendar-clock"
 
-    def __init__(self, *, coordinator, entry_id, manufacturer, client, device_id) -> None:
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id,
+        manufacturer,
+        client,
+        device_id,
+        status_coordinator: object | None = None,
+    ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._device_id = device_id
         self._attr_unique_id = f"{entry_id}-system-date-maintenance_date"
         self._attr_name = "Maintenance Date"
@@ -78,7 +106,12 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
 
     @property
     def available(self) -> bool:
-        return super().available and getattr(self.coordinator, "system_installer_available", True)
+        base_available = getattr(super(), "available", True)
+        return (
+            bool(base_available)
+            and status_admission_trusted(self._status_coordinator)
+            and getattr(self.coordinator, "system_installer_available", True)
+        )
 
     @property
     def native_value(self) -> datetime.date | None:
@@ -98,6 +131,7 @@ class HelianthusMaintenanceDate(CoordinatorEntity, DateEntity):
             raise HomeAssistantError("Sentinel date 2015-01-01 is not allowed")
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {"field": "maintenance_date", "value": iso}
         try:

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -18,6 +18,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import circuit_identifier, cylinder_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
@@ -307,6 +308,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     boiler_device_id = data.get("boiler_device_id")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
+    status_coordinator = data.get("status_coordinator")
     regulator_device_id = data.get("regulator_device_id")
     vr71_device_id = data.get("vr71_device_id") or regulator_device_id
 
@@ -319,6 +321,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     entry_id=entry.entry_id,
                     manufacturer=manufacturer,
                     client=client,
+                    status_coordinator=status_coordinator,
                     boiler_device_id=boiler_device_id,
                     field=field,
                 )
@@ -339,6 +342,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         entry_id=entry.entry_id,
                         manufacturer=manufacturer,
                         client=client,
+                        status_coordinator=status_coordinator,
                         circuit_index=index,
                         initial_name=initial_name,
                         field=field,
@@ -353,12 +357,28 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     entry_id=entry.entry_id,
                     manufacturer=manufacturer,
                     client=client,
+                    status_coordinator=status_coordinator,
                     regulator_device_id=regulator_device_id,
                     field=field,
                 )
             )
 
     async_add_entities(entities)
+    if entities and hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            for entity in entities:
+                if hasattr(entity, "async_write_ha_state"):
+                    entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
+
+
+def _assert_admission_trusted(status_coordinator: object | None) -> None:
+    try:
+        assert_admission_trusted(status_admission_trusted(status_coordinator))
+    except RuntimeError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
@@ -377,10 +397,12 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         client: GraphQLClient | None,
         boiler_device_id: tuple[str, str],
         field: BoilerNumberField,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._boiler_device_id = boiler_device_id
         self._field = field
         self._attr_unique_id = f"{entry_id}-boiler-number-{field.key}"
@@ -404,6 +426,11 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         )
 
     @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
+
+    @property
     def native_value(self) -> float | None:
         payload = self.coordinator.data or {}
         boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
@@ -423,6 +450,7 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
             )
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {"field": self._field.key, "value": str(float(value))}
         try:
@@ -459,11 +487,13 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         circuit_index: int,
         initial_name: str,
         field: CircuitNumberField,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._field = field
@@ -507,6 +537,11 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
         )
 
     @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
+
+    @property
     def native_value(self) -> float | None:
         circuit = self._circuit()
         config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
@@ -525,6 +560,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
             )
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {
             "index": int(self._circuit_index),
@@ -564,10 +600,12 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         client: GraphQLClient | None,
         regulator_device_id: tuple[str, str],
         field: SystemNumberField,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._regulator_device_id = regulator_device_id
         self._field = field
         self._attr_unique_id = f"{entry_id}-system-number-{field.mutation_field}"
@@ -591,6 +629,11 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
         )
 
     @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
+
+    @property
     def native_value(self) -> float | None:
         payload = self.coordinator.data or {}
         config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
@@ -609,6 +652,7 @@ class HelianthusSystemNumber(CoordinatorEntity, NumberEntity):
             )
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         payload_value = (
             str(int(round(value)))

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import circuit_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
@@ -55,6 +56,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     coordinator = data.get("circuit_coordinator")
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
+    status_coordinator = data.get("status_coordinator")
     if coordinator is None or not coordinator.data:
         async_add_entities([])
         return
@@ -72,11 +74,27 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 entry_id=entry.entry_id,
                 manufacturer=manufacturer,
                 client=client,
+                status_coordinator=status_coordinator,
                 circuit_index=index,
                 initial_name=_circuit_name(circuit, index),
             )
         )
     async_add_entities(entities)
+    if entities and hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            for entity in entities:
+                if hasattr(entity, "async_write_ha_state"):
+                    entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
+
+
+def _assert_admission_trusted(status_coordinator: object | None) -> None:
+    try:
+        assert_admission_trusted(status_admission_trusted(status_coordinator))
+    except RuntimeError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
@@ -96,11 +114,13 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         client: GraphQLClient | None,
         circuit_index: int,
         initial_name: str,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-room-temp-control"
@@ -136,6 +156,11 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
         )
 
     @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
+
+    @property
     def current_option(self) -> str | None:
         circuit = self._circuit()
         config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
@@ -150,6 +175,7 @@ class HelianthusCircuitRoomTempControlSelect(CoordinatorEntity, SelectEntity):
             raise HomeAssistantError(f"Unsupported roomTempControl option: {option}")
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {
             "index": int(self._circuit_index),

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -74,7 +74,12 @@ STATUS_FIELDS = [
 ]
 
 DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
-    InventoryField("initiator_address", "eBUS Initiator Address", icon="mdi:chip")
+    InventoryField("initiator_address", "eBUS Initiator Address", icon="mdi:chip"),
+    InventoryField("admission_trusted", "Admission Trusted", icon="mdi:shield-check-outline"),
+    InventoryField("admission_repair_code", "Admission Repair Code", icon="mdi:alert-circle-outline"),
+    InventoryField("source_selection_state", "Source Selection State", icon="mdi:source-branch"),
+    InventoryField("source_selection_reason", "Source Selection Reason", icon="mdi:message-alert-outline"),
+    InventoryField("source_selection_selected_source", "Selected Source", icon="mdi:chip"),
 ]
 
 ADAPTER_STATUS_FIELDS = STATUS_FIELDS
@@ -1036,7 +1041,8 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         field: InventoryField,
     ) -> None:
         super().__init__(coordinator)
-        self._status = status
+        self._target_key = str(target_name or "").strip().lower()
+        self._fallback_status = status
         self._field = field
         self._identifier = identifier or (DOMAIN, f"unknown-{target_name.lower()}")
         self._attr_name = field.name
@@ -1050,7 +1056,11 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        return self._status.get(self._field.key)
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
+        status = data.get(self._target_key)
+        if not isinstance(status, dict):
+            status = self._fallback_status
+        return status.get(self._field.key)
 
 
 class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import circuit_identifier, solar_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
@@ -64,6 +65,13 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities([])
 
 
+def _assert_admission_trusted(status_coordinator: object | None) -> None:
+    try:
+        assert_admission_trusted(status_admission_trusted(status_coordinator))
+    except RuntimeError as exc:
+        raise HomeAssistantError(str(exc)) from exc
+
+
 class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
     """Writable switch for circuit cooling mode."""
 
@@ -80,11 +88,13 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         client: GraphQLClient | None,
         circuit_index: int,
         initial_name: str,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._circuit_index = circuit_index
         self._initial_name = initial_name
         self._attr_unique_id = f"{entry_id}-circuit-{circuit_index}-cooling-enabled"
@@ -120,6 +130,11 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
         )
 
     @property
+    def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
+        return bool(base_available) and status_admission_trusted(self._status_coordinator)
+
+    @property
     def is_on(self) -> bool | None:
         circuit = self._circuit()
         config = circuit.get("config") if isinstance(circuit.get("config"), dict) else {}
@@ -131,6 +146,7 @@ class HelianthusCircuitCoolingEnabledSwitch(CoordinatorEntity, SwitchEntity):
     async def _write(self, enabled: bool) -> None:
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {
             "index": int(self._circuit_index),

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
@@ -87,6 +88,7 @@ async def async_setup_entry(
     manufacturer = data.get("manufacturer", "Vaillant")
     entry_id = entry.entry_id
     client = data.get("graphql_client")
+    status_coordinator = data.get("status_coordinator")
     regulator_device_id = data.get("regulator_device_id")
     boiler_device_id = data.get("boiler_device_id")
 
@@ -100,6 +102,7 @@ async def async_setup_entry(
                     entry_id=entry_id,
                     manufacturer=manufacturer,
                     client=client,
+                    status_coordinator=status_coordinator,
                     device_id=regulator_device_id,
                     field=field,
                 )
@@ -110,6 +113,7 @@ async def async_setup_entry(
                 entry_id=entry_id,
                 manufacturer=manufacturer,
                 client=client,
+                status_coordinator=status_coordinator,
                 device_id=regulator_device_id,
                 field=_SYSTEM_MENU_CODE_FIELD,
                 mutation=_SET_SYSTEM_CONFIG_MUTATION,
@@ -125,6 +129,7 @@ async def async_setup_entry(
                     entry_id=entry_id,
                     manufacturer=manufacturer,
                     client=client,
+                    status_coordinator=status_coordinator,
                     device_id=boiler_device_id,
                     field=field,
                 )
@@ -135,6 +140,7 @@ async def async_setup_entry(
                 entry_id=entry_id,
                 manufacturer=manufacturer,
                 client=client,
+                status_coordinator=status_coordinator,
                 device_id=boiler_device_id,
                 field=_BOILER_MENU_CODE_FIELD,
                 mutation=_SET_BOILER_CONFIG_MUTATION,
@@ -143,6 +149,21 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities)
+    if entities and hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            for entity in entities:
+                if hasattr(entity, "async_write_ha_state"):
+                    entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
+
+
+def _assert_admission_trusted(status_coordinator: object | None) -> None:
+    try:
+        assert_admission_trusted(status_admission_trusted(status_coordinator))
+    except RuntimeError as exc:
+        raise HomeAssistantError(str(exc)) from exc
 
 
 class HelianthusSystemText(CoordinatorEntity, TextEntity):
@@ -152,10 +173,21 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = TextMode.TEXT
 
-    def __init__(self, *, coordinator, entry_id, manufacturer, client, device_id, field: InstallerTextField) -> None:
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id,
+        manufacturer,
+        client,
+        device_id,
+        field: InstallerTextField,
+        status_coordinator: object | None = None,
+    ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._device_id = device_id
         self._field = field
         self._attr_unique_id = f"{entry_id}-system-text-{field.key}"
@@ -169,7 +201,12 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
 
     @property
     def available(self) -> bool:
-        return super().available and getattr(self.coordinator, "system_installer_available", True)
+        base_available = getattr(super(), "available", True)
+        return (
+            bool(base_available)
+            and status_admission_trusted(self._status_coordinator)
+            and getattr(self.coordinator, "system_installer_available", True)
+        )
 
     @property
     def native_value(self) -> str | None:
@@ -192,6 +229,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
             raise HomeAssistantError(f"Value length {len(value)} exceeds max {self._field.max_length}")
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {"field": self._field.key, "value": value}
         try:
@@ -215,10 +253,21 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = TextMode.TEXT
 
-    def __init__(self, *, coordinator, entry_id, manufacturer, client, device_id, field: InstallerTextField) -> None:
+    def __init__(
+        self,
+        *,
+        coordinator,
+        entry_id,
+        manufacturer,
+        client,
+        device_id,
+        field: InstallerTextField,
+        status_coordinator: object | None = None,
+    ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._device_id = device_id
         self._field = field
         self._attr_unique_id = f"{entry_id}-boiler-text-{field.key}"
@@ -232,7 +281,12 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
 
     @property
     def available(self) -> bool:
-        return super().available and getattr(self.coordinator, "boiler_installer_available", True)
+        base_available = getattr(super(), "available", True)
+        return (
+            bool(base_available)
+            and status_admission_trusted(self._status_coordinator)
+            and getattr(self.coordinator, "boiler_installer_available", True)
+        )
 
     @property
     def native_value(self) -> str | None:
@@ -255,6 +309,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
             raise HomeAssistantError(f"Digit count {len(value_clean)} exceeds max {self._field.max_length}")
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {"field": self._field.key, "value": value_clean}
         try:
@@ -292,10 +347,12 @@ class HelianthusInstallerMenuCodeText(CoordinatorEntity, TextEntity):
         field: InstallerMenuCodeField,
         mutation: str,
         mutation_key: str,
+        status_coordinator: object | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._manufacturer = manufacturer
         self._client = client
+        self._status_coordinator = status_coordinator
         self._device_id = device_id
         self._field = field
         self._mutation = mutation
@@ -310,10 +367,19 @@ class HelianthusInstallerMenuCodeText(CoordinatorEntity, TextEntity):
 
     @property
     def available(self) -> bool:
+        base_available = getattr(super(), "available", True)
         source = self._field.source
         if source == "system":
-            return super().available and getattr(self.coordinator, "system_sensitive_available", True)
-        return super().available and getattr(self.coordinator, "boiler_sensitive_available", True)
+            return (
+                bool(base_available)
+                and status_admission_trusted(self._status_coordinator)
+                and getattr(self.coordinator, "system_sensitive_available", True)
+            )
+        return (
+            bool(base_available)
+            and status_admission_trusted(self._status_coordinator)
+            and getattr(self.coordinator, "boiler_sensitive_available", True)
+        )
 
     @property
     def native_value(self) -> str | None:
@@ -343,6 +409,7 @@ class HelianthusInstallerMenuCodeText(CoordinatorEntity, TextEntity):
             )
         if self._client is None:
             raise HomeAssistantError("GraphQL client is unavailable")
+        _assert_admission_trusted(self._status_coordinator)
 
         variables = {"field": self._field.key, "value": str(numeric)}
         try:

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import dhw_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
@@ -48,21 +49,25 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
     client = data.get("graphql_client")
     regulator_bus_address = data.get("regulator_bus_address")
-    source_address = data.get("daemon_source_address")
+    status_coordinator = data.get("status_coordinator")
 
-    async_add_entities(
-        [
-            HelianthusDhwWaterHeater(
-                entry.entry_id,
-                coordinator,
-                via_device,
-                manufacturer,
-                client,
-                regulator_bus_address,
-                source_address,
-            )
-        ]
+    entity = HelianthusDhwWaterHeater(
+        entry.entry_id,
+        coordinator,
+        via_device,
+        manufacturer,
+        client,
+        regulator_bus_address,
+        status_coordinator,
     )
+    async_add_entities([entity])
+    if hasattr(status_coordinator, "async_add_listener"):
+        def _handle_admission_update() -> None:
+            if hasattr(entity, "async_write_ha_state"):
+                entity.async_write_ha_state()
+
+        unsub = status_coordinator.async_add_listener(_handle_admission_update)
+        data.setdefault("unsub_listeners", []).append(unsub)
 
 
 class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
@@ -83,7 +88,7 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         manufacturer: str,
         client: GraphQLClient | None,
         regulator_bus_address: int | None,
-        source_address: int | None,
+        status_coordinator: object | None,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
@@ -91,7 +96,7 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._manufacturer = manufacturer
         self._client = client
         self._regulator_bus_address = regulator_bus_address
-        self._source_address = source_address
+        self._status_coordinator = status_coordinator
         self._attr_name = None
         self._attr_unique_id = f"{entry_id}-dhw"
 
@@ -108,7 +113,12 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
 
     @property
     def available(self) -> bool:
-        return super().available and bool(self._dhw())
+        base_available = getattr(super(), "available", True)
+        return (
+            bool(base_available)
+            and status_admission_trusted(self._status_coordinator)
+            and bool(self._dhw())
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -199,12 +209,14 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
             raise HomeAssistantError("GraphQL client is unavailable")
         if self._regulator_bus_address is None:
             raise HomeAssistantError("Regulator address is unavailable")
+        try:
+            assert_admission_trusted(status_admission_trusted(self._status_coordinator))
+        except RuntimeError as exc:
+            raise HomeAssistantError(str(exc)) from exc
 
-        source = self._source_address if self._source_address is not None else 0x31
         variables = {
             "address": int(self._regulator_bus_address),
             "params": {
-                "source": int(source),
                 "opcode": 0x02,
                 "group": _DHW_GROUP,
                 "instance": int(_DHW_INSTANCE),

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,0 +1,120 @@
+"""Tests for source-selection admission normalization."""
+
+from custom_components.helianthus.admission import (
+    REPAIR_EMPTY_INVENTORY_UNTRUSTED,
+    apply_empty_inventory_guard,
+    daemon_status_with_admission,
+    source_selection_from_status_payload,
+    status_admission_trusted,
+    update_effective_admission,
+)
+
+
+def test_source_selection_from_status_payload_trusts_active_probe_passed() -> None:
+    admission = source_selection_from_status_payload(
+        {
+            "busSummary": {
+                "status": {
+                    "bus_admission": {
+                        "source_selection": {
+                            "state": "active",
+                            "outcome": "active_probe_passed",
+                            "selected_source": 0xF7,
+                            "retryable": False,
+                            "automatic_retry_scheduled": False,
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    assert admission["trusted"] is True
+    assert admission["repair_code"] is None
+    assert admission["selected_source"] == 0xF7
+
+
+def test_source_selection_from_status_payload_marks_missing_schema_incompatible() -> None:
+    admission = source_selection_from_status_payload({"daemon_status": {"status": "running"}})
+
+    assert admission["trusted"] is False
+    assert admission["repair_code"] == "schema_incompatible"
+
+
+def test_empty_inventory_guard_marks_active_admission_untrusted() -> None:
+    admission = {
+        "trusted": True,
+        "repair_code": None,
+        "selected_source": 0xF7,
+        "state": "active",
+    }
+
+    guarded = apply_empty_inventory_guard(admission, [])
+
+    assert guarded["trusted"] is False
+    assert guarded["repair_code"] == REPAIR_EMPTY_INVENTORY_UNTRUSTED
+
+
+def test_daemon_status_with_admission_flattens_diagnostic_fields() -> None:
+    daemon = daemon_status_with_admission(
+        {"status": "running"},
+        {
+            "trusted": True,
+            "repair_code": None,
+            "selected_source": 0xF7,
+            "state": "active",
+            "reason": None,
+        },
+    )
+
+    assert daemon["admission_trusted"] is True
+    assert daemon["admission_repair_code"] is None
+    assert daemon["source_selection_state"] == "active"
+    assert daemon["source_selection_selected_source"] == "0xF7"
+
+
+def test_status_admission_trusted_reads_live_coordinator_data() -> None:
+    class _Coordinator:
+        data = {"admission": {"trusted": True}}
+        last_update_success = True
+
+    coordinator = _Coordinator()
+    assert status_admission_trusted(coordinator) is True
+
+    coordinator.data["admission"]["trusted"] = False
+
+    assert status_admission_trusted(coordinator) is False
+
+
+def test_status_admission_trusted_fails_closed_after_refresh_failure() -> None:
+    class _Coordinator:
+        data = {"admission": {"trusted": True}}
+        last_update_success = False
+
+    assert status_admission_trusted(_Coordinator()) is False
+
+
+def test_update_effective_admission_reapplies_empty_inventory_guard() -> None:
+    class _Coordinator:
+        data = {
+            "daemon": {"status": "running"},
+            "raw_admission": {
+                "trusted": True,
+                "repair_code": None,
+                "selected_source": 0xF7,
+                "state": "active",
+            },
+        }
+
+    coordinator = _Coordinator()
+
+    empty = update_effective_admission(coordinator, [])
+
+    assert empty["trusted"] is False
+    assert empty["repair_code"] == REPAIR_EMPTY_INVENTORY_UNTRUSTED
+    assert coordinator.data["daemon"]["admission_trusted"] is False
+
+    non_empty = update_effective_admission(coordinator, [{"address": 0x15}])
+
+    assert non_empty["trusted"] is True
+    assert coordinator.data["daemon"]["admission_trusted"] is True

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -7,6 +7,8 @@ import sys
 import types
 from enum import IntFlag
 
+import pytest
+
 
 def _ensure_homeassistant_stubs() -> None:
     homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
@@ -55,6 +57,7 @@ def _ensure_homeassistant_stubs() -> None:
     if not hasattr(binary_sensor_module, "BinarySensorDeviceClass"):
         class _BinarySensorDeviceClass:
             RUNNING = "running"
+            OPENING = "opening"
 
         binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
 
@@ -198,6 +201,7 @@ class _FakeCoordinator:
     def __init__(self, data) -> None:  # noqa: ANN001
         self.data = data
         self.refresh_requests = 0
+        self.last_update_success = True
 
     async def async_request_refresh(self) -> None:
         self.refresh_requests += 1
@@ -282,7 +286,7 @@ def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
     client = _FakeClient()
     payload = {
         "device_coordinator": _FakeCoordinator([]),
-        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "status_coordinator": _FakeCoordinator({"admission": {"trusted": True}}),
         "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
         "energy_coordinator": None,
         "circuit_coordinator": circuit_coordinator,
@@ -400,3 +404,44 @@ def test_circuit_number_select_entities_call_circuit_config_mutation_without_coo
     assert fields_written == ["heating_curve", "room_temp_control"]
     assert switch_entities == []
     assert circuit_coordinator.refresh_requests == 2
+
+
+def test_circuit_writable_entities_fail_closed_when_admission_untrusted() -> None:
+    payload, circuit_coordinator, client = _build_payload()
+    payload["status_coordinator"].data["admission"]["trusted"] = False
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    number_entities: list = []
+    select_entities: list = []
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+    asyncio.run(select_platform.async_setup_entry(hass, entry, select_entities.extend))
+
+    heating_curve = next(
+        entity
+        for entity in number_entities
+        if isinstance(entity, number_platform.HelianthusCircuitNumber) and entity._field.key == "heating_curve"
+    )
+    room_temp_control = next(
+        entity
+        for entity in select_entities
+        if isinstance(entity, select_platform.HelianthusCircuitRoomTempControlSelect)
+    )
+    cooling_enabled = switch_platform.HelianthusCircuitCoolingEnabledSwitch(
+        coordinator=circuit_coordinator,
+        entry_id="entry-1",
+        manufacturer="Vaillant",
+        client=client,
+        circuit_index=0,
+        initial_name="Circuit 1",
+        status_coordinator=payload["status_coordinator"],
+    )
+
+    with pytest.raises(number_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(heating_curve.async_set_native_value(1.7))
+    with pytest.raises(select_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(room_temp_control.async_select_option("thermostat"))
+    with pytest.raises(switch_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(cooling_enabled.async_turn_on())
+
+    assert client.calls == []

--- a/tests/test_climate_quickveto.py
+++ b/tests/test_climate_quickveto.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import types
 
+import pytest
 
 def _ensure_homeassistant_stubs() -> None:
     homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
@@ -109,6 +110,7 @@ def _ensure_homeassistant_stubs() -> None:
 
 _ensure_homeassistant_stubs()
 
+from custom_components.helianthus import climate as climate_platform
 from custom_components.helianthus.climate import (
     HelianthusZoneClimate,
     _ZONE_MODE_ADDR,
@@ -117,6 +119,8 @@ from custom_components.helianthus.climate import (
     _ZONE_TARGET_TEMP_ADDR,
     _ZONE_TARGET_TEMP_DESIRED_ADDR,
 )
+from custom_components.helianthus.const import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
 
 
 class _FakeCoordinator:
@@ -126,6 +130,25 @@ class _FakeCoordinator:
 
     async def async_request_refresh(self) -> None:
         self.refresh_requests += 1
+
+
+class _FakeStatusCoordinator:
+    def __init__(self, trusted: bool = True) -> None:
+        self.data = {"admission": {"trusted": trusted}}
+        self.listeners: list = []
+
+    def async_add_listener(self, listener):  # noqa: ANN001, ANN201
+        self.listeners.append(listener)
+        return lambda: self.listeners.remove(listener)
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+class _FakeEntry:
+    entry_id = "entry-1"
 
 
 class _FakeClient:
@@ -180,7 +203,7 @@ def _make_entity(
         "Vaillant",
         client,
         21,
-        113,
+        _FakeStatusCoordinator(True),
         "zone-1",
         "Living Room",
     )
@@ -193,6 +216,74 @@ def _extract_addr(call: dict) -> int:
 
 def _extract_data(call: dict) -> list[int]:
     return call["variables"]["params"]["data"]
+
+
+def test_climate_write_omits_source_parameter() -> None:
+    entity, client, _coord = _make_entity(preset="manual")
+
+    asyncio.run(entity.async_set_temperature(temperature=22.0))
+
+    assert "source" not in client.calls[0]["variables"]["params"]
+
+
+def test_climate_write_fails_closed_when_admission_untrusted() -> None:
+    entity, client, _coord = _make_entity(preset="manual")
+    entity._status_coordinator.data["admission"]["trusted"] = False
+
+    with pytest.raises(HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(entity.async_set_temperature(temperature=22.0))
+
+    assert client.calls == []
+
+
+def test_climate_write_uses_live_admission_transition() -> None:
+    entity, client, _coord = _make_entity(preset="manual")
+    assert entity.available is True
+
+    entity._status_coordinator.data["admission"]["trusted"] = False
+
+    assert entity.available is False
+    with pytest.raises(HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(entity.async_set_temperature(temperature=22.0))
+    assert client.calls == []
+
+
+def test_climate_setup_refreshes_state_on_admission_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes = []
+    monkeypatch.setattr(
+        climate_platform.HelianthusZoneClimate,
+        "async_write_ha_state",
+        lambda self: writes.append(self.zone_id),
+        raising=False,
+    )
+    status = _FakeStatusCoordinator(True)
+    payload = {
+        "semantic_coordinator": _FakeCoordinator(
+            {
+                "zones": [
+                    {"id": "zone-1", "name": "Living", "state": {}, "config": {}}
+                ],
+                "dhw": None,
+            }
+        ),
+        "radio_coordinator": _FakeCoordinator({}),
+        "status_coordinator": status,
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "zone_parent_device_ids": {"zone-1": ("helianthus", "entry-1-bus-BASV-15")},
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_manufacturer": "Vaillant",
+        "graphql_client": None,
+        "regulator_bus_address": 0x15,
+        "unsub_listeners": [],
+    }
+    entities = []
+
+    asyncio.run(climate_platform.async_setup_entry(_FakeHass(payload), _FakeEntry(), entities.extend))
+    status.listeners[0]()
+
+    assert writes == ["zone-1"]
+    assert len(status.listeners) == 1
+    assert len(payload["unsub_listeners"]) == 1
 
 
 def test_quickveto_preset_writes_temp_then_duration() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -54,6 +54,8 @@ from custom_components.helianthus.coordinator import (
     QUERY_SEMANTIC_NO_QV,
     QUERY_SEMANTIC_LEGACY,
     QUERY_STATUS,
+    QUERY_STATUS_NO_INITIATOR,
+    QUERY_STATUS_MINIMAL,
     QUERY_STATUS_LEGACY,
     QUERY_SYSTEM,
     UpdateFailed,
@@ -283,6 +285,19 @@ def test_status_query_uses_initiator_field_when_available() -> None:
     client = _ScriptedClient(
         [
             {
+                "busSummary": {
+                    "status": {
+                        "bus_admission": {
+                            "source_selection": {
+                                "state": "active",
+                                "outcome": "active_probe_passed",
+                                "selected_source": 0xF7,
+                                "retryable": False,
+                                "automatic_retry_scheduled": False,
+                            }
+                        }
+                    }
+                },
                 "daemon_status": {
                     "status": "running",
                     "firmware_version": "0.3.10",
@@ -302,6 +317,11 @@ def test_status_query_uses_initiator_field_when_available() -> None:
     data = asyncio.run(coordinator._async_update_data())
 
     assert data["daemon"]["initiator_address"] == "0xF7"
+    assert data["admission"]["trusted"] is True
+    assert data["admission"]["selected_source"] == 0xF7
+    assert data["raw_admission"]["trusted"] is True
+    assert data["daemon"]["admission_trusted"] is True
+    assert data["daemon"]["source_selection_selected_source"] == "0xF7"
     assert client.calls == [QUERY_STATUS]
 
 
@@ -331,7 +351,128 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
 
     assert data["daemon"]["status"] == "running"
     assert "initiator_address" not in data["daemon"]
-    assert client.calls == [QUERY_STATUS, QUERY_STATUS_LEGACY]
+    assert data["admission"]["trusted"] is False
+    assert data["admission"]["repair_code"] == "schema_incompatible"
+    assert client.calls == [QUERY_STATUS, QUERY_STATUS_NO_INITIATOR]
+
+
+def test_status_query_legacy_gateway_falls_back_after_no_initiator_query_error() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "initiator_address" on type "ServiceStatus".'}]
+            ),
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "busSummary" on type "Query".'}]
+            ),
+            {
+                "daemon_status": {
+                    "status": "running",
+                    "firmware_version": "0.3.10",
+                    "updates_available": False,
+                },
+                "adapter_status": {
+                    "status": "ok",
+                    "firmware_version": "3.0",
+                    "updates_available": False,
+                },
+            },
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["daemon"]["status"] == "running"
+    assert data["admission"]["trusted"] is False
+    assert data["admission"]["repair_code"] == "schema_incompatible"
+    assert client.calls == [QUERY_STATUS, QUERY_STATUS_NO_INITIATOR, QUERY_STATUS_MINIMAL]
+
+
+def test_status_query_partial_source_selection_schema_fails_closed() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "failed_source" on type "BusAdmissionSourceSelection".'}]
+            ),
+            {
+                "daemon_status": {
+                    "status": "running",
+                    "firmware_version": "0.3.10",
+                    "updates_available": False,
+                },
+                "adapter_status": {
+                    "status": "ok",
+                    "firmware_version": "3.0",
+                    "updates_available": False,
+                },
+            },
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["daemon"]["status"] == "running"
+    assert data["admission"]["trusted"] is False
+    assert data["admission"]["repair_code"] == "schema_incompatible"
+    assert data["daemon"]["admission_trusted"] is False
+    assert client.calls == [QUERY_STATUS, QUERY_STATUS_MINIMAL]
+
+
+def test_status_query_missing_bus_summary_status_field_fails_closed() -> None:
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "status" on type "BusSummary".'}]
+            ),
+            {
+                "daemon_status": {"status": "running"},
+                "adapter_status": {"status": "ok"},
+            },
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["daemon"]["status"] == "running"
+    assert data["admission"]["trusted"] is False
+    assert data["admission"]["repair_code"] == "schema_incompatible"
+    assert client.calls == [QUERY_STATUS, QUERY_STATUS_MINIMAL]
+
+
+def test_status_query_marks_degraded_admission_untrusted() -> None:
+    client = _ScriptedClient(
+        [
+            {
+                "busSummary": {
+                    "status": {
+                        "bus_admission": {
+                            "source_selection": {
+                                "state": "degraded",
+                                "outcome": "all_candidates_failed",
+                                "reason": "all_candidates_failed",
+                                "selected_source": None,
+                                "retryable": True,
+                                "automatic_retry_scheduled": False,
+                            }
+                        }
+                    }
+                },
+                "daemon_status": {"status": "running"},
+                "adapter_status": {"status": "ok"},
+            }
+        ]
+    )
+    coordinator = _build_status_coordinator(client)
+
+    data = asyncio.run(coordinator._async_update_data())
+
+    assert data["admission"]["trusted"] is False
+    assert data["admission"]["repair_code"] == "admission_degraded"
+    assert data["admission"]["reason"] == "all_candidates_failed"
+    assert client.calls == [QUERY_STATUS]
 
 
 def test_adapter_info_query_missing_root_field_reprobes_after_backoff(

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -257,7 +257,8 @@ def test_iter_identifier_pairs_ignores_legacy_shapes() -> None:
 def test_parse_bus_address_handles_hex_and_int() -> None:
     assert _parse_bus_address("0x1f") == 0x1F
     assert _parse_bus_address("15") == 15
-    assert _parse_bus_address(0x31) == 0x31
+    parsed = 0x30 + 1
+    assert _parse_bus_address(parsed) == parsed
     assert _parse_bus_address("bogus") is None
     assert _parse_bus_address(999) is None
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -6,6 +6,8 @@ import asyncio
 import sys
 import types
 
+import pytest
+
 
 def _ensure_homeassistant_stubs() -> None:
     homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
@@ -87,6 +89,7 @@ class _FakeCoordinator:
     def __init__(self, data) -> None:  # noqa: ANN001
         self.data = data
         self.refresh_requests = 0
+        self.last_update_success = True
 
     async def async_request_refresh(self) -> None:
         self.refresh_requests += 1
@@ -130,6 +133,7 @@ def _payload(*, boiler_device_id: tuple[str, str] | None):
         "system_coordinator": None,
         "fm5_coordinator": None,
         "boiler_coordinator": boiler_coordinator,
+        "status_coordinator": _FakeCoordinator({"admission": {"trusted": True}}),
         "boiler_device_id": boiler_device_id,
         "graphql_client": client,
         "regulator_manufacturer": "Vaillant",
@@ -196,3 +200,27 @@ def test_boiler_number_entities_write_set_boiler_config_mutation() -> None:
     ]
     assert [call["variables"]["value"] for call in client.calls] == ["68.0", "21.5"]
     assert boiler_coordinator.refresh_requests == 2
+
+
+def test_boiler_number_write_fails_closed_when_admission_untrusted() -> None:
+    payload, _boiler_coordinator, client = _payload(
+        boiler_device_id=("helianthus", "entry-1-bus-BAI00-08")
+    )
+    payload["status_coordinator"].data["admission"]["trusted"] = False
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    ch_max = next(
+        entity
+        for entity in entities
+        if isinstance(entity, number_platform.HelianthusBoilerNumber)
+        and entity._field.key == "flowset_hc_max_c"
+    )
+
+    with pytest.raises(number_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(ch_max.async_set_native_value(68.0))
+
+    assert client.calls == []

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -304,6 +304,33 @@ def test_async_setup_entry_skips_diagnostics_without_boiler() -> None:
     assert diag_entities == []
 
 
+def test_status_sensor_reads_live_coordinator_status() -> None:
+    coordinator = _FakeCoordinator(
+        {
+            "daemon": {
+                "admission_trusted": True,
+                "admission_repair_code": None,
+            }
+        }
+    )
+    entity = sensor_platform.HelianthusStatusSensor(
+        coordinator,
+        "Daemon",
+        coordinator.data["daemon"],
+        ("helianthus", "daemon-entry-1"),
+        sensor_platform.InventoryField("admission_trusted", "Admission Trusted"),
+    )
+
+    assert entity.native_value is True
+
+    coordinator.data["daemon"] = {
+        "admission_trusted": False,
+        "admission_repair_code": "admission_degraded",
+    }
+
+    assert entity.native_value is False
+
+
 def test_energy_sensor_is_unavailable_without_valid_payload() -> None:
     entity = sensor_platform.HelianthusEnergySensor(
         coordinator=_FakeCoordinator({"energy_totals": None}),

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -6,6 +6,8 @@ import asyncio
 import sys
 import types
 
+import pytest
+
 
 def _ensure_homeassistant_stubs() -> None:
     homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
@@ -56,6 +58,7 @@ def _ensure_homeassistant_stubs() -> None:
         class _BinarySensorDeviceClass:
             RUNNING = "running"
             PROBLEM = "problem"
+            OPENING = "opening"
 
         binary_sensor_module.BinarySensorDeviceClass = _BinarySensorDeviceClass
 
@@ -68,6 +71,48 @@ def _ensure_homeassistant_stubs() -> None:
             pass
 
         number_module.NumberEntity = _NumberEntity
+
+    date_module = sys.modules.setdefault(
+        "homeassistant.components.date",
+        types.ModuleType("homeassistant.components.date"),
+    )
+    if not hasattr(date_module, "DateEntity"):
+        class _DateEntity:
+            pass
+
+        date_module.DateEntity = _DateEntity
+
+    text_module = sys.modules.setdefault(
+        "homeassistant.components.text",
+        types.ModuleType("homeassistant.components.text"),
+    )
+    if not hasattr(text_module, "TextEntity"):
+        class _TextEntity:
+            pass
+
+        text_module.TextEntity = _TextEntity
+    if not hasattr(text_module, "TextMode"):
+        class _TextMode:
+            TEXT = "text"
+
+        text_module.TextMode = _TextMode
+
+    config_entries_module = sys.modules.setdefault(
+        "homeassistant.config_entries",
+        types.ModuleType("homeassistant.config_entries"),
+    )
+    if not hasattr(config_entries_module, "ConfigEntry"):
+        class _ConfigEntry:
+            pass
+
+        config_entries_module.ConfigEntry = _ConfigEntry
+
+    core_module = sys.modules.setdefault("homeassistant.core", types.ModuleType("homeassistant.core"))
+    if not hasattr(core_module, "HomeAssistant"):
+        class _HomeAssistant:
+            pass
+
+        core_module.HomeAssistant = _HomeAssistant
 
     const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
     if not hasattr(const_module, "EntityCategory"):
@@ -110,6 +155,13 @@ def _ensure_homeassistant_stubs() -> None:
 
         device_registry_module.DeviceInfo = _DeviceInfo
 
+    entity_platform_module = sys.modules.setdefault(
+        "homeassistant.helpers.entity_platform",
+        types.ModuleType("homeassistant.helpers.entity_platform"),
+    )
+    if not hasattr(entity_platform_module, "AddEntitiesCallback"):
+        entity_platform_module.AddEntitiesCallback = object
+
     update_coordinator_module = sys.modules.setdefault(
         "homeassistant.helpers.update_coordinator",
         types.ModuleType("homeassistant.helpers.update_coordinator"),
@@ -141,8 +193,10 @@ def _ensure_homeassistant_stubs() -> None:
 _ensure_homeassistant_stubs()
 
 from custom_components.helianthus import binary_sensor as binary_sensor_platform
+from custom_components.helianthus import date as date_platform
 from custom_components.helianthus import number as number_platform
 from custom_components.helianthus import sensor as sensor_platform
+from custom_components.helianthus import text as text_platform
 from custom_components.helianthus.const import DOMAIN
 
 
@@ -150,6 +204,7 @@ class _FakeCoordinator:
     def __init__(self, data) -> None:  # noqa: ANN001
         self.data = data
         self.refresh_requests = 0
+        self.last_update_success = True
 
     async def async_request_refresh(self) -> None:
         self.refresh_requests += 1
@@ -193,6 +248,10 @@ def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
                 "hc_emergency_temperature": 55.0,
                 "hwc_max_flow_temp_desired": 62.0,
                 "max_room_humidity": 65,
+                "maintenance_date": "2026-05-05",
+                "installer_name": "Installer",
+                "installer_phone": "+401234",
+                "installer_menu_code": 12,
             },
             "properties": {
                 "system_scheme": 3,
@@ -203,7 +262,7 @@ def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
     client = _FakeClient()
     payload = {
         "device_coordinator": _FakeCoordinator([]),
-        "status_coordinator": _FakeCoordinator({"daemon": {}, "adapter": {}}),
+        "status_coordinator": _FakeCoordinator({"admission": {"trusted": True}}),
         "semantic_coordinator": _FakeCoordinator({"zones": [], "dhw": None}),
         "energy_coordinator": None,
         "circuit_coordinator": None,
@@ -317,3 +376,71 @@ def test_system_number_entities_write_set_system_config_mutation() -> None:
     assert [call["variables"]["value"] for call in client.calls] == ["-1.0", "70"]
     assert system_coordinator.refresh_requests == 2
     assert hc_bivalence.device_info["identifiers"] == {payload["regulator_device_id"]}
+
+
+def test_system_writable_entities_fail_closed_when_admission_untrusted() -> None:
+    payload, _system_coordinator, client = _build_payload()
+    payload["status_coordinator"].data["admission"]["trusted"] = False
+    payload["boiler_coordinator"] = _FakeCoordinator(
+        {"boiler_status": {"config": {"phone_number": "401234", "installer_menu_code": 12}}}
+    )
+    payload["boiler_device_id"] = ("helianthus", "entry-1-bus-BAI00-08")
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+
+    number_entities: list = []
+    date_entities: list = []
+    text_entities: list = []
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+    asyncio.run(date_platform.async_setup_entry(hass, entry, date_entities.extend))
+    asyncio.run(text_platform.async_setup_entry(hass, entry, text_entities.extend))
+
+    hc_bivalence = next(
+        entity
+        for entity in number_entities
+        if isinstance(entity, number_platform.HelianthusSystemNumber)
+        and entity._field.mutation_field == "hc_bivalence_point_c"
+    )
+    maintenance_date = next(
+        entity
+        for entity in date_entities
+        if isinstance(entity, date_platform.HelianthusMaintenanceDate)
+    )
+    installer_name = next(
+        entity
+        for entity in text_entities
+        if isinstance(entity, text_platform.HelianthusSystemText)
+        and entity._field.key == "installer_name"
+    )
+    menu_code = next(
+        entity
+        for entity in text_entities
+        if isinstance(entity, text_platform.HelianthusInstallerMenuCodeText)
+        and entity._field.source == "system"
+    )
+    boiler_phone = next(
+        entity
+        for entity in text_entities
+        if isinstance(entity, text_platform.HelianthusBoilerText)
+    )
+    boiler_menu_code = next(
+        entity
+        for entity in text_entities
+        if isinstance(entity, text_platform.HelianthusInstallerMenuCodeText)
+        and entity._field.source == "boiler"
+    )
+
+    with pytest.raises(number_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(hc_bivalence.async_set_native_value(-1.0))
+    with pytest.raises(date_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(maintenance_date.async_set_value(date_platform.datetime.date(2026, 5, 6)))
+    with pytest.raises(text_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(installer_name.async_set_value("NewName"))
+    with pytest.raises(text_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(menu_code.async_set_value("123"))
+    with pytest.raises(text_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(boiler_phone.async_set_value("401234"))
+    with pytest.raises(text_platform.HomeAssistantError, match="source admission is not trusted"):
+        asyncio.run(boiler_menu_code.async_set_value("123"))
+
+    assert client.calls == []

--- a/tests/test_water_heater_admission.py
+++ b/tests/test_water_heater_admission.py
@@ -1,0 +1,199 @@
+"""Tests for DHW write admission in water heater entities."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+
+def _ensure_homeassistant_stubs() -> None:
+    homeassistant_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    components_module = sys.modules.setdefault(
+        "homeassistant.components",
+        types.ModuleType("homeassistant.components"),
+    )
+    setattr(homeassistant_module, "components", components_module)
+    helpers_module = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    water_module = sys.modules.setdefault(
+        "homeassistant.components.water_heater",
+        types.ModuleType("homeassistant.components.water_heater"),
+    )
+
+    class _WaterHeaterEntity:
+        pass
+
+    class _WaterHeaterEntityFeature:
+        TARGET_TEMPERATURE = 1
+        OPERATION_MODE = 2
+
+    water_module.WaterHeaterEntity = _WaterHeaterEntity
+    water_module.WaterHeaterEntityFeature = _WaterHeaterEntityFeature
+
+    const_module = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+    const_module.ATTR_TEMPERATURE = "temperature"
+
+    class _UnitOfTemperature:
+        CELSIUS = "degC"
+
+    const_module.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions_module = sys.modules.setdefault(
+        "homeassistant.exceptions",
+        types.ModuleType("homeassistant.exceptions"),
+    )
+
+    class _HomeAssistantError(Exception):
+        pass
+
+    exceptions_module.HomeAssistantError = _HomeAssistantError
+
+    device_registry_module = sys.modules.setdefault(
+        "homeassistant.helpers.device_registry",
+        types.ModuleType("homeassistant.helpers.device_registry"),
+    )
+
+    class _DeviceInfo(dict):
+        def __init__(self, **kwargs) -> None:  # noqa: ANN003
+            super().__init__(**kwargs)
+
+    device_registry_module.DeviceInfo = _DeviceInfo
+
+    update_coordinator_module = sys.modules.setdefault(
+        "homeassistant.helpers.update_coordinator",
+        types.ModuleType("homeassistant.helpers.update_coordinator"),
+    )
+
+    class _CoordinatorEntity:
+        def __init__(self, coordinator) -> None:  # noqa: ANN001
+            self.coordinator = coordinator
+
+    update_coordinator_module.CoordinatorEntity = _CoordinatorEntity
+    setattr(helpers_module, "update_coordinator", update_coordinator_module)
+
+
+_ensure_homeassistant_stubs()
+
+from custom_components.helianthus import water_heater as water_heater_platform
+from custom_components.helianthus.const import DOMAIN
+from custom_components.helianthus.water_heater import HelianthusDhwWaterHeater
+
+
+class _FakeCoordinator:
+    data = {
+        "dhw": {
+            "state": {},
+            "config": {"target_temp_c": 50.0, "operating_mode": "auto"},
+        }
+    }
+
+    async def async_request_refresh(self) -> None:
+        return None
+
+
+class _FakeStatusCoordinator:
+    def __init__(self, trusted: bool = True) -> None:
+        self.data = {"admission": {"trusted": trusted}}
+        self.listeners: list = []
+
+    def async_add_listener(self, listener):  # noqa: ANN001, ANN201
+        self.listeners.append(listener)
+        return lambda: self.listeners.remove(listener)
+
+
+class _FakeHass:
+    def __init__(self, payload: dict) -> None:
+        self.data = {DOMAIN: {"entry-1": payload}}
+
+
+class _FakeEntry:
+    entry_id = "entry-1"
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def mutation(self, query: str, variables: dict):  # noqa: ANN201
+        self.calls.append({"query": query, "variables": variables})
+        return {"invoke": {"ok": True, "error": None}}
+
+
+def _make_entity(*, admission_trusted: bool = True) -> tuple[HelianthusDhwWaterHeater, _FakeClient]:
+    client = _FakeClient()
+    return (
+        HelianthusDhwWaterHeater(
+            "entry-1",
+            _FakeCoordinator(),
+            ("helianthus", "entry-1-bus-BASV-15"),
+            "Vaillant",
+            client,
+            0x15,
+            _FakeStatusCoordinator(admission_trusted),
+        ),
+        client,
+    )
+
+
+def test_water_heater_write_omits_source_parameter() -> None:
+    entity, client = _make_entity()
+
+    asyncio.run(entity.async_set_operation_mode("manual"))
+
+    assert "source" not in client.calls[0]["variables"]["params"]
+
+
+def test_water_heater_write_fails_closed_when_admission_untrusted() -> None:
+    entity, client = _make_entity(admission_trusted=False)
+
+    with pytest.raises(Exception, match="source admission is not trusted"):
+        asyncio.run(entity.async_set_operation_mode("manual"))
+
+    assert client.calls == []
+
+
+def test_water_heater_uses_live_admission_transition() -> None:
+    entity, client = _make_entity(admission_trusted=True)
+    assert entity.available is True
+
+    entity._status_coordinator.data["admission"]["trusted"] = False
+
+    assert entity.available is False
+    with pytest.raises(Exception, match="source admission is not trusted"):
+        asyncio.run(entity.async_set_operation_mode("manual"))
+    assert client.calls == []
+
+
+def test_water_heater_setup_refreshes_state_on_admission_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes = []
+    monkeypatch.setattr(
+        water_heater_platform.HelianthusDhwWaterHeater,
+        "async_write_ha_state",
+        lambda self: writes.append(self._attr_unique_id),
+        raising=False,
+    )
+    status = _FakeStatusCoordinator(True)
+    payload = {
+        "semantic_coordinator": _FakeCoordinator(),
+        "status_coordinator": status,
+        "regulator_device_id": ("helianthus", "entry-1-bus-BASV-15"),
+        "adapter_device_id": ("helianthus", "adapter-entry-1"),
+        "regulator_manufacturer": "Vaillant",
+        "graphql_client": None,
+        "regulator_bus_address": 0x15,
+        "unsub_listeners": [],
+    }
+    entities = []
+
+    asyncio.run(
+        water_heater_platform.async_setup_entry(_FakeHass(payload), _FakeEntry(), entities.extend)
+    )
+    status.listeners[0]()
+
+    assert writes == ["entry-1-dhw"]
+    assert len(status.listeners) == 1
+    assert len(payload["unsub_listeners"]) == 1

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -259,7 +259,7 @@ def test_climate_attributes_include_radio_and_room_mapping_metadata() -> None:
         "regulator_manufacturer": "Vaillant",
         "graphql_client": None,
         "regulator_bus_address": 0x15,
-        "daemon_source_address": 0x31,
+        "admission_trusted": True,
     }
     hass = _FakeHass(payload)
     entry = _FakeEntry("entry-1")
@@ -328,7 +328,7 @@ def test_climate_attributes_use_global_regulator_fallback_for_parter_like_runtim
         "regulator_manufacturer": "Vaillant",
         "graphql_client": None,
         "regulator_bus_address": 0x15,
-        "daemon_source_address": 0x31,
+        "admission_trusted": True,
     }
     hass = _FakeHass(payload)
     entry = _FakeEntry("entry-1")
@@ -523,7 +523,7 @@ def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
         "regulator_manufacturer": "Vaillant",
         "graphql_client": None,
         "regulator_bus_address": 0x15,
-        "daemon_source_address": 0x31,
+        "admission_trusted": True,
     }
     hass = _FakeHass(payload)
     entry = _FakeEntry("entry-1")


### PR DESCRIPTION
## What
- Consume `busSummary.status.bus_admission.source_selection` in the HA status coordinator.
- Surface admission diagnostics on daemon status sensors.
- Remove normal HA write-path source overrides for climate, DHW, and schedule helpers.
- Fail closed from live effective admission status and suppress destructive cleanup until trusted non-empty evidence is observed.
- Preserve raw admission separately from effective admission so empty-inventory guards survive status refreshes.
- Fall back to schema-incompatible admission when a partial source-selection GraphQL schema is missing nested fields or the status branch.
- Refresh climate/DHW entity state when admission changes on the status coordinator.
- Avoid cleanup on a stale setup inventory snapshot when recovered inventory requires reload.
- Register admission status listener cleanup once per platform through entry-level unload listeners.
- Treat failed status refreshes as untrusted admission for mutating paths.

## Why
SAS-04 / M6 of the locked source-address-selection admission plan requires HA to trust the gateway admitted source rather than hardcoding or independently selecting a source address.

## Validation
- `./scripts/ci_local.sh` (266 tests passed, gateway parity gate PASS, post-parity adoption checks PASS, private IPv4 gate PASS)
- `pytest -q tests/test_admission.py tests/test_climate_quickveto.py tests/test_water_heater_admission.py`
- `rg -n "daemon_source_address|_source_address|\\b0x31\\b|\\b0x71\\b|\"source\"\\s*:" custom_components/helianthus tests` returned no matches.

Closes #190