### PR TITLE
SAS-08: Verify HA has no legacy admission dependency

### DIFF
--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,5 +1,7 @@
 """Tests for source-selection admission normalization."""
 
+import pytest
+
 from custom_components.helianthus.admission import (
     REPAIR_EMPTY_INVENTORY_UNTRUSTED,
     apply_empty_inventory_guard,
@@ -39,6 +41,55 @@ def test_source_selection_from_status_payload_marks_missing_schema_incompatible(
 
     assert admission["trusted"] is False
     assert admission["repair_code"] == "schema_incompatible"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "busSummary": {
+                "status": {
+                    "busAdmission": {
+                        "sourceSelection": {
+                            "state": "active",
+                            "outcome": "active_probe_passed",
+                            "selectedSource": int("31", 16),
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "busSummary": {
+                "status": {
+                    "bus_admission": {
+                        "sourceSelection": {
+                            "state": "active",
+                            "outcome": "active_probe_passed",
+                            "selectedSource": int("71", 16),
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "busSummary": {
+                "status": {
+                    "admission": {
+                        "trusted": True,
+                        "selectedSource": int("31", 16),
+                    }
+                }
+            }
+        },
+    ],
+)
+def test_legacy_admission_shapes_fail_closed(payload: dict) -> None:
+    admission = source_selection_from_status_payload(payload)
+
+    assert admission["trusted"] is False
+    assert admission["repair_code"] == "schema_incompatible"
+    assert admission["selected_source"] is None
 
 
 def test_empty_inventory_guard_marks_active_admission_untrusted() -> None:

--- a/tests/test_legacy_admission_dependency_gate.py
+++ b/tests/test_legacy_admission_dependency_gate.py
@@ -87,7 +87,7 @@ def _params_value(node: ast.Dict) -> ast.AST:
     raise AssertionError("write variable dict has no params key")
 
 
-def test_status_queries_consume_only_snake_case_source_selection_admission() -> None:
+def test_source_selection_schema_no_legacy_admission_fields() -> None:
     for query_name in ("QUERY_STATUS", "QUERY_STATUS_NO_INITIATOR"):
         query = _constant_string_assignment(COORDINATOR, query_name)
         assert "bus_admission" in query
@@ -111,7 +111,7 @@ def test_integration_code_has_no_legacy_admission_field_dependency() -> None:
     assert offenders == []
 
 
-def test_write_mutation_payloads_have_no_source_or_fixed_source_fallback() -> None:
+def test_writes_use_admitted_source_without_fallback() -> None:
     checked: list[str] = []
     offenders: list[str] = []
 

--- a/tests/test_legacy_admission_dependency_gate.py
+++ b/tests/test_legacy_admission_dependency_gate.py
@@ -1,0 +1,128 @@
+"""Static gates for source-selection admission dependency boundaries."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_ROOT = REPO_ROOT / "custom_components" / "helianthus"
+COORDINATOR = INTEGRATION_ROOT / "coordinator.py"
+
+LEGACY_ADMISSION_TOKENS = (
+    "busAdmission",
+    "sourceSelection",
+    "selectedSource",
+    "failedSource",
+    "lastSuccessfulSource",
+    "automaticRetryScheduled",
+    "admissionTrusted",
+    "admissionRepairCode",
+    "params.source",
+)
+
+FIXED_WRITE_SOURCE_VALUES = {int("31", 16), int("71", 16)}
+FIXED_WRITE_SOURCE_STRINGS = {"31", "71", "0x31", "0x71"}
+
+
+def _python_sources() -> list[Path]:
+    return sorted(INTEGRATION_ROOT.rglob("*.py"))
+
+
+def _string_key(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _constant_string_assignment(path: Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            continue
+        value = ast.literal_eval(node.value)
+        if not isinstance(value, str):
+            raise AssertionError(f"{name} is not a string constant")
+        return value
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def _contains_source_key(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Dict):
+            continue
+        if any(_string_key(key) == "source" for key in child.keys):
+            return True
+    return False
+
+
+def _contains_fixed_source_literal(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Constant):
+            continue
+        if isinstance(child.value, int) and child.value in FIXED_WRITE_SOURCE_VALUES:
+            return True
+        if isinstance(child.value, str) and child.value.strip().lower() in FIXED_WRITE_SOURCE_STRINGS:
+            return True
+    return False
+
+
+def _write_variable_dicts(path: Path) -> list[ast.Dict]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    writes: list[ast.Dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        if any(_string_key(key) == "params" for key in node.keys):
+            writes.append(node)
+    return writes
+
+
+def _params_value(node: ast.Dict) -> ast.AST:
+    for key, value in zip(node.keys, node.values, strict=True):
+        if _string_key(key) == "params":
+            return value
+    raise AssertionError("write variable dict has no params key")
+
+
+def test_status_queries_consume_only_snake_case_source_selection_admission() -> None:
+    for query_name in ("QUERY_STATUS", "QUERY_STATUS_NO_INITIATOR"):
+        query = _constant_string_assignment(COORDINATOR, query_name)
+        assert "bus_admission" in query
+        assert "source_selection" in query
+        assert all(token not in query for token in LEGACY_ADMISSION_TOKENS)
+
+    minimal_query = _constant_string_assignment(COORDINATOR, "QUERY_STATUS_MINIMAL")
+    assert "bus_admission" not in minimal_query
+    assert "source_selection" not in minimal_query
+    assert all(token not in minimal_query for token in LEGACY_ADMISSION_TOKENS)
+
+
+def test_integration_code_has_no_legacy_admission_field_dependency() -> None:
+    offenders: list[str] = []
+    for path in _python_sources():
+        text = path.read_text(encoding="utf-8")
+        for token in LEGACY_ADMISSION_TOKENS:
+            if token in text:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {token}")
+
+    assert offenders == []
+
+
+def test_write_mutation_payloads_have_no_source_or_fixed_source_fallback() -> None:
+    checked: list[str] = []
+    offenders: list[str] = []
+
+    for path in _python_sources():
+        for node in _write_variable_dicts(path):
+            checked.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+            params = _params_value(node)
+            if _contains_source_key(params):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: params.source")
+            if _contains_fixed_source_literal(node):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: fixed source literal")
+
+    assert checked
+    assert offenders == []


### PR DESCRIPTION
## What
- Adds fail-closed coverage for legacy/camelCase admission payload shapes.
- Adds a static admission dependency gate proving HA status queries consume `bus_admission.source_selection` only.
- Gates HA write mutation payloads against `params.source` and fixed source-address fallback literals `0x31` / `0x71`.

## Why
This is the SAS-08 M4 proof that HA remains on the snake_case source-selection admission contract after SAS-04 and does not depend on legacy admission surfaces.

Closes #192.

## Validation
- `pytest tests/test_admission.py tests/test_legacy_admission_dependency_gate.py -q`
- `pytest tests/test_admission.py tests/test_legacy_admission_dependency_gate.py tests/test_coordinator.py -q`
- `./scripts/ci_local.sh`