### PR TITLE
Fix stable bus migration target ordering

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -349,6 +349,11 @@ def _select_bus_migration_target(
     serial_number: str | None,
 ) -> object | None:
     _, stable_token = stable_identifier
+    for device_entry in existing_devices:
+        tokens = _bus_identifier_tokens_for_entry(getattr(device_entry, "identifiers", set()), entry_id)
+        if stable_token in tokens:
+            return device_entry
+
     best_score: tuple[int, int, int, int, int, int] | None = None
     best_entry: object | None = None
     serialized_model_matches: list[object] = []
@@ -356,8 +361,6 @@ def _select_bus_migration_target(
         tokens = _bus_identifier_tokens_for_entry(getattr(device_entry, "identifiers", set()), entry_id)
         if not tokens:
             continue
-        if stable_token in tokens:
-            return device_entry
         entry_manufacturer = _clean_label(getattr(device_entry, "manufacturer", None))
         if entry_manufacturer and entry_manufacturer != manufacturer:
             continue

--- a/tests/test_init_labels.py
+++ b/tests/test_init_labels.py
@@ -181,6 +181,36 @@ def test_select_bus_migration_target_prefers_serialized_area_device_for_sparse_p
     assert selected is old_good
 
 
+def test_select_bus_migration_target_prefers_stable_owner_before_serial_match() -> None:
+    stable_identifier = (DOMAIN, "entry-1-bus-VR940f-04")
+    serial_duplicate = SimpleNamespace(
+        id="serial-dup",
+        identifiers={(DOMAIN, "entry-1-bus-VR940f-f1")},
+        manufacturer="Vaillant",
+        model="VR940f (eBUS: NETX3)",
+        serial_number="21-23-05-0020292012-0933-016291-N9",
+        area_id=None,
+    )
+    stable_owner = SimpleNamespace(
+        id="stable-owner",
+        identifiers={(DOMAIN, "entry-1-bus-VR940f-04")},
+        manufacturer="Vaillant",
+        model="VR940f (eBUS: NETX3)",
+        serial_number=None,
+        area_id=None,
+    )
+    selected = _select_bus_migration_target(
+        (serial_duplicate, stable_owner),
+        entry_id="entry-1",
+        stable_identifier=stable_identifier,
+        address=0x04,
+        manufacturer="Vaillant",
+        model_name="VR940f (eBUS: NETX3)",
+        serial_number="21-23-05-0020292012-0933-016291-N9",
+    )
+    assert selected is stable_owner
+
+
 def test_select_bus_migration_target_matches_sparse_duplicate_by_address() -> None:
     stable_identifier = (DOMAIN, "entry-1-bus-VUW-09")
     wrong_address = SimpleNamespace(


### PR DESCRIPTION
## What
Fixes HA device-registry migration when a stable bus identifier is already owned by one HA device but an earlier duplicate matches by serial/model.

## Why
Live HA setup failed with `DeviceIdentifierCollisionError` for `...-bus-VR940f-04`. The migration helper could return the serial-matching `VR940f-f1` device before seeing the exact stable identifier owner, causing Home Assistant to reject `merge_identifiers`.

## Changes
- Adds an order-independent first pass for exact stable bus identifier ownership.
- Adds a regression test for duplicate VR940f entries where the serial match appears before the stable owner.

## Validation
- `python3 -m pytest tests/test_init_labels.py`
- `./scripts/ci_local.sh`

Live note: deployed full custom component package to HA host after local CI. Post-07:45 HA logs show no `DeviceIdentifierCollisionError`, no `Error setting up entry ... for helianthus`, and no import/setup errors.

Closes #195