### PR TITLE
Reconcile duplicate gateway config entries

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -454,6 +454,59 @@ def _parse_identifier_index(token: str, prefix: str) -> int | None:
     return value
 
 
+async def _find_verified_entry_by_configured_instance_guid(
+    hass: object,
+    session: object,
+    instance_guid: str,
+    *,
+    exclude_entry_id: str | None = None,
+) -> object | None:
+    from .identity import (
+        GatewayIdentityVerificationError,
+        configured_instance_guid,
+        verify_gateway_identity,
+    )
+
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        if getattr(config_entry, "entry_id", None) == exclude_entry_id:
+            continue
+        data = getattr(config_entry, "data", None) or {}
+        if (
+            configured_instance_guid(data, getattr(config_entry, "unique_id", None))
+            != instance_guid
+        ):
+            continue
+        try:
+            host = str(data["host"])
+            port = int(data["port"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        path = data.get(CONF_PATH) or DEFAULT_GRAPHQL_PATH
+        transport = data.get(CONF_TRANSPORT) or DEFAULT_GRAPHQL_TRANSPORT
+        version = (data.get(CONF_VERSION) or "").strip() or None
+        try:
+            await verify_gateway_identity(
+                session=session,
+                host=host,
+                port=port,
+                path=path,
+                transport=transport,
+                expected_instance_guid=instance_guid,
+                version=version,
+            )
+        except (GatewayIdentityVerificationError, TypeError, ValueError) as exc:
+            _LOGGER.debug(
+                "Configured Helianthus owner entry %s did not verify live "
+                "instance GUID %s: %s",
+                getattr(config_entry, "entry_id", "<unknown>"),
+                instance_guid,
+                getattr(exc, "reason", type(exc).__name__),
+            )
+            continue
+        return config_entry
+    return None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Helianthus from a config entry."""
     from homeassistant.core import callback
@@ -550,6 +603,123 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             stale_devices_removed,
         )
 
+    host = entry.data.get(CONF_HOST)
+    port = entry.data.get(CONF_PORT)
+    if not host or not port:
+        _LOGGER.warning("Config entry missing host/port; device discovery skipped")
+        return True
+
+    session = async_get_clientsession(hass)
+    path = entry.data.get(CONF_PATH) or DEFAULT_GRAPHQL_PATH
+    transport = entry.data.get(CONF_TRANSPORT) or DEFAULT_GRAPHQL_TRANSPORT
+    version = (entry.data.get(CONF_VERSION) or "").strip() or None
+    entry_instance_guid = configured_instance_guid(entry.data, entry.unique_id)
+    try:
+        verified_endpoint = await verify_gateway_identity(
+            session=session,
+            host=str(host),
+            port=int(port),
+            path=path,
+            transport=transport,
+            expected_instance_guid=None,
+            version=version,
+        )
+    except (GatewayIdentityVerificationError, TypeError, ValueError) as exc:
+        reason = getattr(exc, "reason", type(exc).__name__)
+        _LOGGER.debug(
+            "Stable identity refresh skipped for Helianthus entry %s: %s",
+            entry.entry_id,
+            reason,
+        )
+    else:
+        live_instance_guid = verified_endpoint.instance_guid
+        if entry_instance_guid is None:
+            entry_instance_guid = live_instance_guid
+            hass.config_entries.async_update_entry(
+                entry,
+                data=updated_entry_data(
+                    entry.data,
+                    verified_endpoint,
+                    version=version or verified_endpoint.version,
+                ),
+                unique_id=entry_instance_guid,
+            )
+            host = verified_endpoint.host
+            port = verified_endpoint.port
+            path = verified_endpoint.path
+            transport = verified_endpoint.transport
+            version = version or verified_endpoint.version
+            _LOGGER.info(
+                "Migrated Helianthus entry %s to stable instance GUID %s",
+                entry.entry_id,
+                entry_instance_guid,
+            )
+        elif live_instance_guid != entry_instance_guid:
+            duplicate_entry = await _find_verified_entry_by_configured_instance_guid(
+                hass,
+                session,
+                live_instance_guid,
+                exclude_entry_id=entry.entry_id,
+            )
+            if duplicate_entry is not None:
+                removed_entities = 0
+                for entity_entry in tuple(
+                    er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+                ):
+                    entity_registry.async_remove(entity_entry.entity_id)
+                    removed_entities += 1
+                removed_devices = 0
+                for device_entry in tuple(
+                    dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+                ):
+                    device_registry.async_remove_device(device_entry.id)
+                    removed_devices += 1
+                _LOGGER.warning(
+                    "Refusing to set up Helianthus entry %s because %s now reports "
+                    "instance GUID %s already owned by entry %s; removed %d stale "
+                    "entities and %d stale devices",
+                    entry.entry_id,
+                    host,
+                    live_instance_guid,
+                    duplicate_entry.entry_id,
+                    removed_entities,
+                    removed_devices,
+                )
+                return False
+
+            entry_instance_guid = live_instance_guid
+            hass.config_entries.async_update_entry(
+                entry,
+                data=updated_entry_data(
+                    entry.data,
+                    verified_endpoint,
+                    version=version or verified_endpoint.version,
+                ),
+                unique_id=entry_instance_guid,
+            )
+            host = verified_endpoint.host
+            port = verified_endpoint.port
+            path = verified_endpoint.path
+            transport = verified_endpoint.transport
+            version = version or verified_endpoint.version
+            _LOGGER.warning(
+                "Rebound Helianthus entry %s from stale instance GUID to live GUID %s",
+                entry.entry_id,
+                entry_instance_guid,
+            )
+
+    if entry_instance_guid is not None:
+        normalized_unique_id = normalize_instance_guid(entry.unique_id)
+        stored_data_guid = normalize_instance_guid(entry.data.get(CONF_INSTANCE_GUID))
+        if normalized_unique_id != entry_instance_guid or stored_data_guid != entry_instance_guid:
+            updated_data = dict(entry.data)
+            updated_data[CONF_INSTANCE_GUID] = entry_instance_guid
+            hass.config_entries.async_update_entry(
+                entry,
+                data=updated_data,
+                unique_id=entry_instance_guid,
+            )
+
     daemon_device_id = daemon_identifier(entry.entry_id)
     adapter_device_id = adapter_identifier(entry.entry_id)
     existing_entry_devices = tuple(dr.async_entries_for_config_entry(device_registry, entry.entry_id))
@@ -572,67 +742,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     adapter_registry_device_id = adapter_device_entry.id
     del daemon_device_entry
-
-    host = entry.data.get(CONF_HOST)
-    port = entry.data.get(CONF_PORT)
-    if not host or not port:
-        _LOGGER.warning("Config entry missing host/port; device discovery skipped")
-        return True
-
-    session = async_get_clientsession(hass)
-    path = entry.data.get(CONF_PATH) or DEFAULT_GRAPHQL_PATH
-    transport = entry.data.get(CONF_TRANSPORT) or DEFAULT_GRAPHQL_TRANSPORT
-    version = (entry.data.get(CONF_VERSION) or "").strip() or None
-    entry_instance_guid = configured_instance_guid(entry.data, entry.unique_id)
-    if entry_instance_guid is None:
-        try:
-            verified_endpoint = await verify_gateway_identity(
-                session=session,
-                host=str(host),
-                port=int(port),
-                path=path,
-                transport=transport,
-                expected_instance_guid=None,
-                version=version,
-            )
-        except GatewayIdentityVerificationError as exc:
-            _LOGGER.debug(
-                "Stable identity adoption skipped for Helianthus entry %s: %s",
-                entry.entry_id,
-                exc.reason,
-            )
-        else:
-            entry_instance_guid = verified_endpoint.instance_guid
-            hass.config_entries.async_update_entry(
-                entry,
-                data=updated_entry_data(
-                    entry.data,
-                    verified_endpoint,
-                    version=version or verified_endpoint.version,
-                ),
-                unique_id=entry_instance_guid,
-            )
-            host = verified_endpoint.host
-            port = verified_endpoint.port
-            path = verified_endpoint.path
-            transport = verified_endpoint.transport
-            version = version or verified_endpoint.version
-            _LOGGER.info(
-                "Migrated Helianthus entry %s to stable instance GUID %s",
-                entry.entry_id,
-                entry_instance_guid,
-            )
-    else:
-        normalized_unique_id = normalize_instance_guid(entry.unique_id)
-        stored_data_guid = normalize_instance_guid(entry.data.get(CONF_INSTANCE_GUID))
-        if normalized_unique_id != entry_instance_guid or stored_data_guid != entry_instance_guid:
-            updated_data = dict(entry.data)
-            updated_data[CONF_INSTANCE_GUID] = entry_instance_guid
-            hass.config_entries.async_update_entry(
-                entry,
-                data=updated_data,
-                unique_id=entry_instance_guid,
-            )
 
     graphql_url = build_graphql_url(host, port, path=path, transport=transport)
     client = GraphQLClient(session=session, url=graphql_url)

--- a/custom_components/helianthus/config_flow.py
+++ b/custom_components/helianthus/config_flow.py
@@ -178,6 +178,19 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return None
         return verified
 
+    async def _async_find_entry_by_live_guid(
+        self, instance_guid: str
+    ) -> tuple[config_entries.ConfigEntry, VerifiedHelianthusEndpoint] | None:
+        """Find an existing entry whose configured endpoint proves this live GUID."""
+
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if configured_instance_guid(entry.data, entry.unique_id) == instance_guid:
+                continue
+            verified = await self._async_verify_existing_entry(entry, instance_guid)
+            if verified is not None:
+                return entry, verified
+        return None
+
     async def _async_finish_verified_entry(
         self,
         verified_endpoint: VerifiedHelianthusEndpoint | None,
@@ -217,6 +230,23 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if current_verified is not None:
                 return self.async_abort(reason="duplicate_instance_guid")
 
+            self.hass.config_entries.async_update_entry(
+                existing_entry,
+                data=existing_data,
+                unique_id=instance_guid,
+                title=existing_entry.title or title,
+            )
+            await self.hass.config_entries.async_reload(existing_entry.entry_id)
+            return self.async_abort(reason="reconfigured")
+
+        live_existing = await self._async_find_entry_by_live_guid(instance_guid)
+        if live_existing is not None:
+            existing_entry, current_verified = live_existing
+            existing_data = updated_entry_data(
+                existing_entry.data,
+                current_verified,
+                version=version or current_verified.version,
+            )
             self.hass.config_entries.async_update_entry(
                 existing_entry,
                 data=existing_data,

--- a/tests/test_config_flow_identity_repair.py
+++ b/tests/test_config_flow_identity_repair.py
@@ -1,0 +1,282 @@
+"""Tests for config-flow stable identity repair."""
+
+from __future__ import annotations
+
+import asyncio
+from types import ModuleType, SimpleNamespace
+import sys
+
+from custom_components.helianthus.const import (
+    CONF_INSTANCE_GUID,
+    CONF_PATH,
+    CONF_TRANSPORT,
+    DOMAIN,
+)
+from custom_components.helianthus.identity import VerifiedHelianthusEndpoint
+
+
+OLD_GUID = "3678381d-034e-4f6a-ab72-fce6eaa91245"
+LIVE_GUID = "323de887-ee42-4f71-98cd-7cf61a5a8f07"
+
+
+def _ensure_config_flow_stubs() -> None:
+    voluptuous_module = sys.modules.setdefault("voluptuous", ModuleType("voluptuous"))
+    if not hasattr(voluptuous_module, "Schema"):
+        voluptuous_module.Schema = lambda value: value
+        voluptuous_module.Required = lambda key, default=None: key
+        voluptuous_module.Optional = lambda key, default=None: key
+
+    homeassistant_module = sys.modules.setdefault("homeassistant", ModuleType("homeassistant"))
+
+    config_entries_module = sys.modules.setdefault(
+        "homeassistant.config_entries",
+        ModuleType("homeassistant.config_entries"),
+    )
+    setattr(homeassistant_module, "config_entries", config_entries_module)
+
+    if not hasattr(config_entries_module, "ConfigFlow"):
+        class _ConfigFlow:
+            def __init_subclass__(cls, **kwargs):  # noqa: ANN003
+                super().__init_subclass__()
+
+            async def async_set_unique_id(self, unique_id: str) -> None:
+                self._unique_id = unique_id
+
+            def async_abort(self, *, reason: str) -> dict[str, str]:
+                return {"type": "abort", "reason": reason}
+
+            def async_create_entry(self, *, title: str, data: dict) -> dict:
+                return {"type": "create_entry", "title": title, "data": data}
+
+            def async_show_form(self, **kwargs):  # noqa: ANN003
+                return {"type": "form", **kwargs}
+
+        config_entries_module.ConfigFlow = _ConfigFlow
+
+    if not hasattr(config_entries_module, "OptionsFlow"):
+        class _OptionsFlow:
+            def async_create_entry(self, *, title: str, data: dict) -> dict:
+                return {"type": "create_entry", "title": title, "data": data}
+
+            def async_show_form(self, **kwargs):  # noqa: ANN003
+                return {"type": "form", **kwargs}
+
+        config_entries_module.OptionsFlow = _OptionsFlow
+
+    if not hasattr(config_entries_module, "ConfigEntry"):
+        class _ConfigEntry:
+            pass
+
+        config_entries_module.ConfigEntry = _ConfigEntry
+    if not hasattr(config_entries_module, "FlowResult"):
+        config_entries_module.FlowResult = dict
+
+    const_module = sys.modules.setdefault("homeassistant.const", ModuleType("homeassistant.const"))
+    const_module.CONF_HOST = "host"
+    const_module.CONF_PORT = "port"
+    const_module.CONF_SCAN_INTERVAL = "scan_interval"
+
+    data_entry_flow_module = sys.modules.setdefault(
+        "homeassistant.data_entry_flow",
+        ModuleType("homeassistant.data_entry_flow"),
+    )
+    data_entry_flow_module.FlowResult = dict
+
+    helpers_module = sys.modules.setdefault(
+        "homeassistant.helpers",
+        ModuleType("homeassistant.helpers"),
+    )
+    setattr(homeassistant_module, "helpers", helpers_module)
+
+    aiohttp_client_module = sys.modules.setdefault(
+        "homeassistant.helpers.aiohttp_client",
+        ModuleType("homeassistant.helpers.aiohttp_client"),
+    )
+    aiohttp_client_module.async_get_clientsession = lambda hass: object()
+    setattr(helpers_module, "aiohttp_client", aiohttp_client_module)
+
+    service_info_parent = sys.modules.setdefault(
+        "homeassistant.helpers.service_info",
+        ModuleType("homeassistant.helpers.service_info"),
+    )
+    service_info_module = sys.modules.setdefault(
+        "homeassistant.helpers.service_info.zeroconf",
+        ModuleType("homeassistant.helpers.service_info.zeroconf"),
+    )
+    setattr(helpers_module, "service_info", service_info_parent)
+    setattr(service_info_parent, "zeroconf", service_info_module)
+    if not hasattr(service_info_module, "ZeroconfServiceInfo"):
+        class _ZeroconfServiceInfo:
+            pass
+
+        service_info_module.ZeroconfServiceInfo = _ZeroconfServiceInfo
+
+
+class _FakeConfigEntries:
+    def __init__(self, entries: list[SimpleNamespace]) -> None:
+        self._entries = entries
+        self.created: list[dict] = []
+        self.reloads: list[str] = []
+
+    def async_entries(self, domain: str) -> list[SimpleNamespace]:
+        assert domain == DOMAIN
+        return self._entries
+
+    def async_update_entry(self, entry: SimpleNamespace, **kwargs) -> None:  # noqa: ANN003
+        for key, value in kwargs.items():
+            setattr(entry, key, value)
+
+    async def async_reload(self, entry_id: str) -> None:
+        self.reloads.append(entry_id)
+
+
+class _FakeResponse:
+    def __init__(self, instance_guid: str) -> None:
+        self.instance_guid = instance_guid
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> dict:
+        return {
+            "data": {
+                "gateway_identity": {
+                    "instance_guid": self.instance_guid,
+                }
+            }
+        }
+
+
+class _FakeSession:
+    def __init__(self, instance_guids: list[str]) -> None:
+        self.instance_guids = instance_guids
+        self.urls: list[str] = []
+
+    def post(self, url: str, json: dict) -> _FakeResponse:
+        self.urls.append(url)
+        return _FakeResponse(self.instance_guids.pop(0))
+
+
+def test_zeroconf_rebinds_existing_entry_when_stored_guid_is_stale() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus.config_flow import HelianthusConfigFlow
+
+    stale_entry = SimpleNamespace(
+        entry_id="01KK2FYJ7KCXCZ4A766ZPJSPE9",
+        title="172.30.32.1",
+        unique_id=OLD_GUID,
+        data={
+            "host": "172.30.32.1",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: OLD_GUID,
+        },
+    )
+    config_entries = _FakeConfigEntries([stale_entry])
+    flow = HelianthusConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=config_entries)
+
+    async def _validate_connection(**kwargs):  # noqa: ANN003
+        assert kwargs["host"] == "172.30.32.1"
+        assert kwargs["expected_instance_guid"] == LIVE_GUID
+        return (
+            VerifiedHelianthusEndpoint(
+                instance_guid=LIVE_GUID,
+                host="172.30.32.1",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            ),
+            None,
+        )
+
+    flow._async_validate_connection = _validate_connection
+
+    result = asyncio.run(
+        flow._async_finish_verified_entry(
+            VerifiedHelianthusEndpoint(
+                instance_guid=LIVE_GUID,
+                host="172.30.232.1",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            ),
+            version=None,
+            title="helianthus._helianthus-graphql._tcp.local.",
+        )
+    )
+
+    assert result == {"type": "abort", "reason": "reconfigured"}
+    assert stale_entry.unique_id == LIVE_GUID
+    assert stale_entry.data[CONF_INSTANCE_GUID] == LIVE_GUID
+    assert stale_entry.data["host"] == "172.30.32.1"
+    assert config_entries.reloads == ["01KK2FYJ7KCXCZ4A766ZPJSPE9"]
+
+
+def test_setup_duplicate_owner_requires_live_identity_proof() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _find_verified_entry_by_configured_instance_guid
+
+    stale_claimant = SimpleNamespace(
+        entry_id="stale-entry",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "192.0.2.10",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    hass = SimpleNamespace(config_entries=_FakeConfigEntries([stale_claimant]))
+    session = _FakeSession([OLD_GUID])
+
+    result = asyncio.run(
+        _find_verified_entry_by_configured_instance_guid(
+            hass,
+            session,
+            LIVE_GUID,
+            exclude_entry_id="live-entry",
+        )
+    )
+
+    assert result is None
+    assert session.urls == ["http://192.0.2.10:8080/graphql"]
+
+
+def test_setup_duplicate_owner_accepts_verified_live_claimant() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _find_verified_entry_by_configured_instance_guid
+
+    live_claimant = SimpleNamespace(
+        entry_id="live-entry",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "192.0.2.10",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    hass = SimpleNamespace(config_entries=_FakeConfigEntries([live_claimant]))
+    session = _FakeSession([LIVE_GUID])
+
+    result = asyncio.run(
+        _find_verified_entry_by_configured_instance_guid(
+            hass,
+            session,
+            LIVE_GUID,
+            exclude_entry_id="stale-entry",
+        )
+    )
+
+    assert result is live_claimant
+    assert session.urls == ["http://192.0.2.10:8080/graphql"]


### PR DESCRIPTION
## What
Reconcile duplicate Helianthus config entries when a stale stored instance GUID and a zeroconf alias both point at the same live gateway identity.

## Why
Issue #197 observed two active entries after gateway identity drift, creating duplicate device/entity trees. The integration now verifies live gateway identity before accepting aliases and refuses/cleans stale entries when another entry already owns the live GUID.

## Changes
- Config flow checks existing entries by live gateway_identity, not only stored GUID/host.
- Setup refreshes live identity before creating registry devices/entities.
- Stale duplicate entries are refused and their stale registry devices/entities are removed.
- Adds regression coverage for stale user entry plus live zeroconf alias.

## Validation
- ./scripts/ci_local.sh: PASS (278 tests, parity/adoption gates, private IPv4 gate)

Closes #197