### PR TITLE
Remove duplicate gateway aliases

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 from .admission import (
@@ -507,6 +507,52 @@ async def _find_verified_entry_by_configured_instance_guid(
     return None
 
 
+def _merge_duplicate_config_entry_options(
+    hass: object,
+    *,
+    alias_entry: object,
+    owner_entry: object,
+) -> bool:
+    """Preserve alias-only options before removing a duplicate config entry."""
+
+    alias_options = dict(getattr(alias_entry, "options", None) or {})
+    if not alias_options:
+        return False
+    owner_options = dict(getattr(owner_entry, "options", None) or {})
+    merged_options = _deep_merge_options(alias_options, owner_options)
+    if merged_options == owner_options:
+        return False
+    hass.config_entries.async_update_entry(owner_entry, options=merged_options)
+    return True
+
+
+def _deep_merge_options(
+    alias_options: Mapping[str, object],
+    owner_options: Mapping[str, object],
+) -> dict[str, object]:
+    """Merge alias-only nested options while preserving owner conflicts."""
+
+    merged = dict(alias_options)
+    for key, owner_value in owner_options.items():
+        alias_value = merged.get(key)
+        if isinstance(alias_value, Mapping) and isinstance(owner_value, Mapping):
+            merged[key] = _deep_merge_options(alias_value, owner_value)
+        else:
+            merged[key] = owner_value
+    return merged
+
+
+def _schedule_duplicate_config_entry_removal(hass: object, entry_id: str) -> bool:
+    """Schedule removal of an alias entry after setup returns."""
+
+    async_remove = getattr(hass.config_entries, "async_remove", None)
+    async_create_task = getattr(hass, "async_create_task", None)
+    if not callable(async_remove) or not callable(async_create_task):
+        return False
+    async_create_task(async_remove(entry_id))
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Helianthus from a config entry."""
     from homeassistant.core import callback
@@ -662,6 +708,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 exclude_entry_id=entry.entry_id,
             )
             if duplicate_entry is not None:
+                options_merged = _merge_duplicate_config_entry_options(
+                    hass,
+                    alias_entry=entry,
+                    owner_entry=duplicate_entry,
+                )
                 removed_entities = 0
                 for entity_entry in tuple(
                     er.async_entries_for_config_entry(entity_registry, entry.entry_id)
@@ -677,14 +728,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.warning(
                     "Refusing to set up Helianthus entry %s because %s now reports "
                     "instance GUID %s already owned by entry %s; removed %d stale "
-                    "entities and %d stale devices",
+                    "entities and %d stale devices; migrated_options=%s",
                     entry.entry_id,
                     host,
                     live_instance_guid,
                     duplicate_entry.entry_id,
                     removed_entities,
                     removed_devices,
+                    options_merged,
                 )
+                if _schedule_duplicate_config_entry_removal(hass, entry.entry_id):
+                    _LOGGER.warning(
+                        "Scheduled duplicate Helianthus config entry %s for removal",
+                        entry.entry_id,
+                    )
                 return False
 
             entry_instance_guid = live_instance_guid

--- a/tests/test_config_flow_identity_repair.py
+++ b/tests/test_config_flow_identity_repair.py
@@ -117,6 +117,7 @@ class _FakeConfigEntries:
         self._entries = entries
         self.created: list[dict] = []
         self.reloads: list[str] = []
+        self.removals: list[str] = []
 
     def async_entries(self, domain: str) -> list[SimpleNamespace]:
         assert domain == DOMAIN
@@ -128,6 +129,10 @@ class _FakeConfigEntries:
 
     async def async_reload(self, entry_id: str) -> None:
         self.reloads.append(entry_id)
+
+    def async_remove(self, entry_id: str) -> str:
+        self.removals.append(entry_id)
+        return f"remove:{entry_id}"
 
 
 class _FakeResponse:
@@ -280,3 +285,56 @@ def test_setup_duplicate_owner_accepts_verified_live_claimant() -> None:
 
     assert result is live_claimant
     assert session.urls == ["http://192.0.2.10:8080/graphql"]
+
+
+def test_duplicate_alias_options_are_preserved_on_owner_before_removal() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _merge_duplicate_config_entry_options
+
+    alias_entry = SimpleNamespace(
+        entry_id="alias-entry",
+        options={
+            "scan_interval": 15,
+            "zone_schedule_helpers": {
+                "zone-1": "calendar.old",
+                "zone-2": "calendar.alias",
+            },
+        },
+    )
+    owner_entry = SimpleNamespace(
+        entry_id="owner-entry",
+        options={
+            "scan_interval": 30,
+            "zone_schedule_helpers": {"zone-2": "calendar.owner"},
+        },
+    )
+    hass = SimpleNamespace(config_entries=_FakeConfigEntries([alias_entry, owner_entry]))
+
+    assert _merge_duplicate_config_entry_options(
+        hass,
+        alias_entry=alias_entry,
+        owner_entry=owner_entry,
+    )
+    assert owner_entry.options == {
+        "scan_interval": 30,
+        "zone_schedule_helpers": {
+            "zone-1": "calendar.old",
+            "zone-2": "calendar.owner",
+        },
+    }
+
+
+def test_duplicate_alias_removal_is_scheduled_after_refusal() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _schedule_duplicate_config_entry_removal
+
+    config_entries = _FakeConfigEntries([])
+    scheduled: list[str] = []
+    hass = SimpleNamespace(
+        config_entries=config_entries,
+        async_create_task=scheduled.append,
+    )
+
+    assert _schedule_duplicate_config_entry_removal(hass, "alias-entry")
+    assert config_entries.removals == ["alias-entry"]
+    assert scheduled == ["remove:alias-entry"]


### PR DESCRIPTION
## What
Remove duplicate Helianthus config-entry aliases when setup proves they point to a live gateway GUID already owned by another verified entry.

## Why
After #197/#199, the stale direct-IP entry no longer owns children, but it still appears as a second gateway shell next to the mDNS entry. Same live GUID should converge to one canonical gateway entry and one child tree regardless of connection means.

## Changes
- Preserve alias-only options on the canonical owner before alias removal.
- Schedule duplicate alias config-entry removal after refusing setup.
- Add regression coverage for option preservation and removal scheduling.

## Validation
- python3 -m pytest tests/test_config_flow_identity_repair.py -q: PASS
- ./scripts/ci_local.sh: PASS (283 tests, parity/adoption gates, private IPv4 gate)

Closes #201