### PR TITLE
fix: hide null-backed sparse HA entities

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -1192,6 +1192,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     boiler_sensor_sparse_unique_id_re = re.compile(
         rf"^{re.escape(entry.entry_id)}-boiler-sensor-(?P<key>hours_till_service)$"
     )
+    boiler_number_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-boiler-number-(?P<key>.+)$"
+    )
     boiler_text_unique_id_re = re.compile(
         rf"^{re.escape(entry.entry_id)}-boiler-text-(?P<key>phone_number)$"
     )
@@ -1326,6 +1329,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             or cylinder_unique_id_re.match(unique_id) is not None
             or boiler_temp_unique_id_re.match(unique_id) is not None
             or boiler_sensor_sparse_unique_id_re.match(unique_id) is not None
+            or boiler_number_unique_id_re.match(unique_id) is not None
             or boiler_text_unique_id_re.match(unique_id) is not None
             or circuit_sensor_unique_id_re.match(unique_id) is not None
             or circuit_number_unique_id_re.match(unique_id) is not None
@@ -1350,6 +1354,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         boiler_sensor_match = boiler_sensor_sparse_unique_id_re.match(unique_id)
         if boiler_sensor_match:
             return boiler_sensor_match.group("key") in _current_boiler_bucket_live_keys("config")
+
+        boiler_number_match = boiler_number_unique_id_re.match(unique_id)
+        if boiler_number_match:
+            return boiler_number_match.group("key") in _current_boiler_bucket_live_keys("config")
 
         boiler_text_match = boiler_text_unique_id_re.match(unique_id)
         if boiler_text_match:

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -1181,6 +1181,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     cylinder_unique_id_re = re.compile(
         rf"^{re.escape(entry.entry_id)}-cylinder-(?P<index>\d+)-(?:(?:config-(?P<config_key>.+))|(?P<kind>temperature))$"
     )
+    status_sparse_unique_ids = frozenset(
+        {
+            f"daemon-{entry.entry_id}-admission_repair_code",
+        }
+    )
+    boiler_temp_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-boiler-(?P<key>(?:flow|return|dhw|dhw_storage)_temperature_c)$"
+    )
+    boiler_sensor_sparse_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-boiler-sensor-(?P<key>hours_till_service)$"
+    )
+    boiler_text_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-boiler-text-(?P<key>phone_number)$"
+    )
+    circuit_sensor_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-circuit-(?P<index>\d+)-sensor-(?P<key>.+)$"
+    )
+    circuit_number_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-circuit-(?P<index>\d+)-number-(?P<key>.+)$"
+    )
+    adapter_hw_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-adapter-hw-(?P<key>.+)$"
+    )
+    zone_demand_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-zone-(?P<zone_id>.+)-heating-demand$"
+    )
+    zone_valve_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-zone-(?P<zone_id>.+)-sensor-valve_position_pct$"
+    )
+    dhw_demand_unique_id = f"{entry.entry_id}-dhw-dhw-heating-demand"
+    system_text_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-system-text-(?P<key>installer_name|installer_phone)$"
+    )
 
     def _entry_entities() -> tuple:
         return tuple(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
@@ -1227,9 +1260,127 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             out[index] = {key for key, value in cylinder.items() if value is not None}
         return out
 
+    def _live_keys(payload: object) -> set[str]:
+        if not isinstance(payload, dict):
+            return set()
+        return {key for key, value in payload.items() if value is not None}
+
+    def _current_status_live_keys(target: str) -> set[str]:
+        payload = status_coordinator.data if status_coordinator else None
+        bucket = payload.get(target) if isinstance(payload, dict) else None
+        return _live_keys(bucket)
+
+    def _current_boiler_bucket_live_keys(bucket_name: str) -> set[str]:
+        payload = boiler_coordinator.data if boiler_coordinator else None
+        boiler_status = payload.get("boiler_status") if isinstance(payload, dict) else None
+        bucket = boiler_status.get(bucket_name) if isinstance(boiler_status, dict) else None
+        return _live_keys(bucket)
+
+    def _current_circuit_live_keys(bucket_name: str, index: int) -> set[str]:
+        payload = circuit_coordinator.data if circuit_coordinator else None
+        if not isinstance(payload, dict):
+            return set()
+        for circuit in payload.get("circuits", []) or []:
+            if not isinstance(circuit, dict):
+                continue
+            if parse_optional_int(circuit.get("index")) != index:
+                continue
+            return _live_keys(circuit.get(bucket_name))
+        return set()
+
+    def _current_adapter_hw_live_keys() -> set[str]:
+        payload = adapter_info_coordinator.data if adapter_info_coordinator else None
+        return _live_keys(payload)
+
+    def _current_zone_state_live_keys(zone_id: str) -> set[str]:
+        payload = semantic_coordinator.data if semantic_coordinator else None
+        if not isinstance(payload, dict):
+            return set()
+        for zone in payload.get("zones", []) or []:
+            if not isinstance(zone, dict):
+                continue
+            if str(zone.get("id")) != zone_id:
+                continue
+            return _live_keys(zone.get("state"))
+        return set()
+
+    def _current_dhw_state_live_keys() -> set[str]:
+        payload = semantic_coordinator.data if semantic_coordinator else None
+        dhw = payload.get("dhw") if isinstance(payload, dict) else None
+        state = dhw.get("state") if isinstance(dhw, dict) else None
+        return _live_keys(state)
+
+    def _current_system_config_live_keys() -> set[str]:
+        payload = system_coordinator.data if system_coordinator else None
+        config = payload.get("config") if isinstance(payload, dict) else None
+        return _live_keys(config)
+
+    def _is_sparse_entity_candidate(unique_id: str | None) -> bool:
+        if not unique_id:
+            return False
+        return (
+            unique_id in status_sparse_unique_ids
+            or unique_id == dhw_demand_unique_id
+            or radio_sensor_unique_id_re.match(unique_id) is not None
+            or solar_unique_id_re.match(unique_id) is not None
+            or cylinder_unique_id_re.match(unique_id) is not None
+            or boiler_temp_unique_id_re.match(unique_id) is not None
+            or boiler_sensor_sparse_unique_id_re.match(unique_id) is not None
+            or boiler_text_unique_id_re.match(unique_id) is not None
+            or circuit_sensor_unique_id_re.match(unique_id) is not None
+            or circuit_number_unique_id_re.match(unique_id) is not None
+            or adapter_hw_unique_id_re.match(unique_id) is not None
+            or zone_demand_unique_id_re.match(unique_id) is not None
+            or zone_valve_unique_id_re.match(unique_id) is not None
+            or system_text_unique_id_re.match(unique_id) is not None
+        )
+
     def _is_sparse_entity_live(unique_id: str | None) -> bool:
         if not unique_id:
             return False
+        if unique_id in status_sparse_unique_ids:
+            return "admission_repair_code" in _current_status_live_keys("daemon")
+        if unique_id == dhw_demand_unique_id:
+            return "heating_demand_pct" in _current_dhw_state_live_keys()
+
+        boiler_temp_match = boiler_temp_unique_id_re.match(unique_id)
+        if boiler_temp_match:
+            return boiler_temp_match.group("key") in _current_boiler_bucket_live_keys("state")
+
+        boiler_sensor_match = boiler_sensor_sparse_unique_id_re.match(unique_id)
+        if boiler_sensor_match:
+            return boiler_sensor_match.group("key") in _current_boiler_bucket_live_keys("config")
+
+        boiler_text_match = boiler_text_unique_id_re.match(unique_id)
+        if boiler_text_match:
+            return boiler_text_match.group("key") in _current_boiler_bucket_live_keys("config")
+
+        circuit_sensor_match = circuit_sensor_unique_id_re.match(unique_id)
+        if circuit_sensor_match:
+            index = int(circuit_sensor_match.group("index"))
+            return circuit_sensor_match.group("key") in _current_circuit_live_keys("state", index)
+
+        circuit_number_match = circuit_number_unique_id_re.match(unique_id)
+        if circuit_number_match:
+            index = int(circuit_number_match.group("index"))
+            return circuit_number_match.group("key") in _current_circuit_live_keys("config", index)
+
+        adapter_hw_match = adapter_hw_unique_id_re.match(unique_id)
+        if adapter_hw_match:
+            return adapter_hw_match.group("key") in _current_adapter_hw_live_keys()
+
+        zone_demand_match = zone_demand_unique_id_re.match(unique_id)
+        if zone_demand_match:
+            return "heating_demand_pct" in _current_zone_state_live_keys(zone_demand_match.group("zone_id"))
+
+        zone_valve_match = zone_valve_unique_id_re.match(unique_id)
+        if zone_valve_match:
+            return "valve_position_pct" in _current_zone_state_live_keys(zone_valve_match.group("zone_id"))
+
+        system_text_match = system_text_unique_id_re.match(unique_id)
+        if system_text_match:
+            return system_text_match.group("key") in _current_system_config_live_keys()
+
         radio_match = radio_sensor_unique_id_re.match(unique_id)
         if radio_match:
             radio_slots_with_live_values = _current_radio_slots_with_live_values()
@@ -1399,6 +1550,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             schedule_reload("sparse entities became live")
 
+    def auto_disable_sparse_entities(reason: str) -> None:
+        registry_disabler = getattr(er, "RegistryEntryDisabler", None)
+        integration_disabler = "integration"
+        if registry_disabler is not None:
+            integration_disabler = getattr(
+                registry_disabler,
+                "INTEGRATION",
+                integration_disabler,
+            )
+        disabled = 0
+        for entity_entry in _entry_entities():
+            if entity_entry.platform != DOMAIN:
+                continue
+            if entity_entry.disabled_by is not None:
+                continue
+            unique_id = str(entity_entry.unique_id or "")
+            if not _is_sparse_entity_candidate(unique_id):
+                continue
+            if _is_sparse_entity_live(unique_id):
+                continue
+            entity_registry.async_update_entity(
+                entity_entry.entity_id,
+                disabled_by=integration_disabler,
+            )
+            disabled += 1
+        if disabled:
+            _LOGGER.info(
+                "Helianthus auto-disabled %d sparse entities for entry %s (%s)",
+                disabled,
+                entry.entry_id,
+                reason,
+            )
+            schedule_reload("sparse entities became null")
+
     def run_trusted_cleanup(reason: str) -> None:
         nonlocal cleanup_ran
         if cleanup_ran:
@@ -1411,6 +1596,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             return
         cleanup_obsolete_entity_registry_entries()
+        auto_disable_sparse_entities(reason)
         auto_enable_sparse_entities(reason)
         cleanup_obsolete_devices(reason)
         cleanup_ran = True
@@ -1551,6 +1737,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if current_ids and not current_ids.issubset(known_bus_devices):
             schedule_reload("new bus devices discovered")
             return
+        auto_enable_sparse_entities("status update")
         if cleanup_allowed and current_ids:
             run_trusted_cleanup("trusted admission status refresh")
 
@@ -1572,6 +1759,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
         if has_new_zones or has_new_dhw:
             schedule_reload("semantic inventory became available")
+            return
+        auto_enable_sparse_entities("semantic update")
 
     def handle_circuit_update() -> None:
         payload = circuit_coordinator.data or {}
@@ -1584,6 +1773,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 current_indexes.add(index)
         if current_indexes - known_circuit_indexes:
             schedule_reload("circuit inventory became available")
+            return
+        auto_enable_sparse_entities("circuit update")
 
     def handle_radio_update() -> None:
         payload = radio_coordinator.data or {}
@@ -1630,6 +1821,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
         auto_enable_sparse_entities("fm5 update")
 
+    def handle_boiler_update() -> None:
+        auto_enable_sparse_entities("boiler update")
+
+    def handle_adapter_info_update() -> None:
+        auto_enable_sparse_entities("adapter info update")
+
     unsub_listeners: list[Callable[[], None]] = []
     unsub_listeners.append(status_coordinator.async_add_listener(handle_status_update))
     unsub_listeners.append(device_coordinator.async_add_listener(handle_device_update))
@@ -1637,6 +1834,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unsub_listeners.append(circuit_coordinator.async_add_listener(handle_circuit_update))
     unsub_listeners.append(radio_coordinator.async_add_listener(handle_radio_update))
     unsub_listeners.append(fm5_coordinator.async_add_listener(handle_fm5_update))
+    unsub_listeners.append(boiler_coordinator.async_add_listener(handle_boiler_update))
+    unsub_listeners.append(adapter_info_coordinator.async_add_listener(handle_adapter_info_update))
 
     for zone_id, helper_entity in zone_schedule_helpers.items():
         @callback

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -417,6 +417,8 @@ class HelianthusBoilerNumber(CoordinatorEntity, NumberEntity):
         if field.sensitive:
             self._attr_entity_registry_visible_default = False
             self._attr_entity_registry_enabled_default = False
+        else:
+            self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -506,6 +508,7 @@ class HelianthusCircuitNumber(CoordinatorEntity, NumberEntity):
             self._attr_native_unit_of_measurement = field.unit
         if field.icon is not None:
             self._attr_icon = field.icon
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -32,6 +32,7 @@ class InventoryField:
     key: str
     name: str
     icon: str | None = None
+    optional: bool = False
 
 
 @dataclass(frozen=True)
@@ -76,7 +77,12 @@ STATUS_FIELDS = [
 DAEMON_STATUS_FIELDS = STATUS_FIELDS + [
     InventoryField("initiator_address", "eBUS Initiator Address", icon="mdi:chip"),
     InventoryField("admission_trusted", "Admission Trusted", icon="mdi:shield-check-outline"),
-    InventoryField("admission_repair_code", "Admission Repair Code", icon="mdi:alert-circle-outline"),
+    InventoryField(
+        "admission_repair_code",
+        "Admission Repair Code",
+        icon="mdi:alert-circle-outline",
+        optional=True,
+    ),
     InventoryField("source_selection_state", "Source Selection State", icon="mdi:source-branch"),
     InventoryField("source_selection_reason", "Source Selection Reason", icon="mdi:message-alert-outline"),
     InventoryField("source_selection_selected_source", "Selected Source", icon="mdi:chip"),
@@ -1049,6 +1055,8 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{self._identifier[1]}-{field.key}"
         if field.icon is not None:
             self._attr_icon = field.icon
+        if field.optional:
+            self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1083,6 +1091,7 @@ class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):
         self._field = field
         self._attr_name = field.label
         self._attr_unique_id = f"{entry_id}-boiler-{field.key}"
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     def _boiler_state(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -1242,6 +1251,7 @@ class HelianthusCircuitSensor(CoordinatorEntity, SensorEntity):
             self._attr_entity_category = field.entity_category
         if field.icon is not None:
             self._attr_icon = field.icon
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     def _circuit(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -1750,6 +1760,7 @@ class HelianthusZoneValvePositionSensor(CoordinatorEntity, SensorEntity):
         self._target_device_id = target_device_id
         self._attr_name = "Valve Position"
         self._attr_unique_id = f"{entry_id}-zone-{zone_id}-sensor-valve_position_pct"
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     def _zone(self) -> dict[str, Any]:
         payload = self.coordinator.data or {}
@@ -1813,6 +1824,7 @@ class HelianthusDemandSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = (
             f"{entry_id}-{target[0]}-{target[1] or 'dhw'}-heating-demand"
         )
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1996,6 +2008,7 @@ class HelianthusAdapterInfoSensor(CoordinatorEntity, SensorEntity):
             self._attr_state_class = state_class
         if icon is not None:
             self._attr_icon = icon
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -2033,6 +2046,7 @@ class HelianthusBoilerHoursTillServiceSensor(CoordinatorEntity, SensorEntity):
         self._boiler_device_id = boiler_device_id
         self._attr_unique_id = f"{entry_id}-boiler-sensor-hours_till_service"
         self._attr_name = "Hours Till Service"
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/helianthus/subscriptions.py
+++ b/custom_components/helianthus/subscriptions.py
@@ -263,10 +263,17 @@ async def _handle_message(
         ):
             current = semantic_coordinator.data
             zones = current.get("zones", [])
+            current_dhw = current.get("dhw")
+            merged_dhw = (
+                _merge_dicts(current_dhw, dhw)
+                if isinstance(current_dhw, dict) and isinstance(dhw, dict)
+                else dhw if dhw is None or isinstance(dhw, dict)
+                else current_dhw
+            )
             semantic_coordinator.async_set_updated_data(
                 {
                     "zones": zones if isinstance(zones, list) else [],
-                    "dhw": dhw if dhw is None or isinstance(dhw, dict) else current.get("dhw"),
+                    "dhw": merged_dhw,
                 }
             )
 

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -196,6 +196,7 @@ class HelianthusSystemText(CoordinatorEntity, TextEntity):
         self._attr_name = field.label
         self._attr_native_max = field.max_length
         self._attr_icon = field.icon
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -276,6 +277,7 @@ class HelianthusBoilerText(CoordinatorEntity, TextEntity):
         self._attr_name = field.label
         self._attr_native_max = field.max_length
         self._attr_icon = field.icon
+        self._attr_entity_registry_enabled_default = self.native_value is not None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -373,6 +373,35 @@ def test_circuit_sensor_platform_adds_expected_sensors_without_zone_link_attrs()
     assert "connected_zone_names" not in attrs
 
 
+def test_circuit_sparse_sensors_and_numbers_are_disabled_by_default_when_value_null() -> None:
+    payload, _, _ = _build_payload()
+    payload["circuit_coordinator"].data["circuits"][0]["state"]["calc_flow_temp_c"] = None
+    payload["circuit_coordinator"].data["circuits"][0]["config"]["frost_prot_c"] = None
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    sensor_entities: list = []
+    number_entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, sensor_entities.extend))
+    asyncio.run(number_platform.async_setup_entry(hass, entry, number_entities.extend))
+
+    calc_flow = next(
+        entity
+        for entity in sensor_entities
+        if isinstance(entity, sensor_platform.HelianthusCircuitSensor)
+        and entity._attr_unique_id == "entry-1-circuit-0-sensor-calc_flow_temp_c"
+    )
+    frost = next(
+        entity
+        for entity in number_entities
+        if isinstance(entity, number_platform.HelianthusCircuitNumber)
+        and entity._attr_unique_id == "entry-1-circuit-0-number-frost_prot_c"
+    )
+
+    assert calc_flow._attr_entity_registry_enabled_default is False
+    assert frost._attr_entity_registry_enabled_default is False
+
+
 def test_circuit_number_select_entities_call_circuit_config_mutation_without_cooling_enabled() -> None:
     payload, circuit_coordinator, client = _build_payload()
     hass = _FakeHass(payload)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -177,6 +177,25 @@ def test_async_setup_entry_skips_boiler_config_numbers_without_physical_bai00() 
     assert not any(isinstance(entity, number_platform.HelianthusBoilerNumber) for entity in entities)
 
 
+def test_boiler_config_numbers_are_disabled_by_default_when_value_null() -> None:
+    payload, _coordinator, _client = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
+    payload["boiler_coordinator"].data["boiler_status"]["config"]["partload_hwc_kw"] = None
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(number_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_numbers = {
+        entity._field.key: entity
+        for entity in entities
+        if isinstance(entity, number_platform.HelianthusBoilerNumber)
+    }
+
+    assert boiler_numbers["flowset_hc_max_c"]._attr_entity_registry_enabled_default is True
+    assert boiler_numbers["partload_hwc_kw"]._attr_entity_registry_enabled_default is False
+
+
 def test_boiler_number_entities_write_set_boiler_config_mutation() -> None:
     payload, boiler_coordinator, client = _payload(boiler_device_id=("helianthus", "entry-1-bus-BAI00-08"))
     hass = _FakeHass(payload)

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -476,6 +476,53 @@ def test_subscription_merges_sparse_zone_update_without_losing_config_or_list_en
     assert semantic.data["zones"][2]["id"] == "zone-2"
 
 
+def test_subscription_merges_sparse_dhw_update_without_losing_config() -> None:
+    class _FakeSemanticCoordinator:
+        def __init__(self) -> None:
+            self.data = {
+                "zones": [],
+                "dhw": {
+                    "state": {
+                        "current_temp_c": 47.0,
+                        "special_function": "off",
+                    },
+                    "config": {
+                        "operating_mode": "auto",
+                        "target_temp_c": 50.0,
+                    },
+                },
+            }
+
+        def async_set_updated_data(self, payload) -> None:  # noqa: ANN001
+            self.data = payload
+
+    semantic = _FakeSemanticCoordinator()
+
+    asyncio.run(
+        subscriptions._handle_message(
+            {
+                "type": "next",
+                "payload": {
+                    "data": {
+                        "dhw_update": {
+                            "state": {"current_temp_c": 49.0},
+                        }
+                    }
+                },
+            },
+            semantic_coordinator=semantic,
+            energy_coordinator=None,
+            boiler_coordinator=None,
+            radio_coordinator=None,
+        )
+    )
+
+    assert semantic.data["dhw"]["state"]["current_temp_c"] == 49.0
+    assert semantic.data["dhw"]["state"]["special_function"] == "off"
+    assert semantic.data["dhw"]["config"]["operating_mode"] == "auto"
+    assert semantic.data["dhw"]["config"]["target_temp_c"] == 50.0
+
+
 def test_radio_zone_candidates_update_on_reassignment() -> None:
     coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
     coordinator._last_by_slot = {}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -50,6 +50,7 @@ def _ensure_homeassistant_stubs() -> None:
     if not hasattr(const_module, "EntityCategory"):
         class _EntityCategory:
             DIAGNOSTIC = "diagnostic"
+            CONFIG = "config"
 
         const_module.EntityCategory = _EntityCategory
     if not hasattr(const_module, "PERCENTAGE"):
@@ -228,6 +229,26 @@ def test_async_setup_entry_skips_reduced_boiler_sensors_without_physical_bai00()
     assert boiler_entities == []
 
 
+def test_reduced_boiler_temperature_sensors_are_disabled_by_default_when_value_null() -> None:
+    boiler_device_id = ("helianthus", "entry-1-bus-BAI00-08")
+    payload = _build_payload(boiler_device_id=boiler_device_id)
+    payload["boiler_coordinator"].data["boiler_status"]["state"]["return_temperature_c"] = None
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    boiler_entities = {
+        entity._attr_unique_id: entity
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusBoilerTemperatureSensor)
+    }
+
+    assert boiler_entities["entry-1-boiler-flow_temperature_c"]._attr_entity_registry_enabled_default is True
+    assert boiler_entities["entry-1-boiler-return_temperature_c"]._attr_entity_registry_enabled_default is False
+
+
 def test_async_setup_entry_adds_boiler_diagnostic_sensors() -> None:
     boiler_device_id = ("helianthus", "entry-1-bus-BAI00-08")
     payload = _build_payload(boiler_device_id=boiler_device_id)
@@ -329,6 +350,49 @@ def test_status_sensor_reads_live_coordinator_status() -> None:
     }
 
     assert entity.native_value is False
+
+
+def test_sparse_demand_and_adapter_sensors_are_disabled_by_default_when_value_null() -> None:
+    semantic = _FakeCoordinator(
+        {
+            "zones": [
+                {
+                    "id": "zone-1",
+                    "state": {"heating_demand_pct": None},
+                }
+            ],
+            "dhw": {"state": {"heating_demand_pct": 12.0}},
+        }
+    )
+    zone_demand = sensor_platform.HelianthusDemandSensor(
+        semantic,
+        "entry-1",
+        ("helianthus", "entry-1-bus-BASV2-15"),
+        "Vaillant",
+        "Zone 1",
+        ("zone", "zone-1"),
+        target_device_id=("helianthus", "entry-1-bus-BASV2-15"),
+    )
+    dhw_demand = sensor_platform.HelianthusDemandSensor(
+        semantic,
+        "entry-1",
+        ("helianthus", "entry-1-bus-BASV2-15"),
+        "Vaillant",
+        "DHW",
+        ("dhw", None),
+        target_device_id=None,
+    )
+    adapter = sensor_platform.HelianthusAdapterInfoSensor(
+        _FakeCoordinator({"wifi_rssi_dbm": None}),
+        "entry-1",
+        ("helianthus", "adapter-entry-1"),
+        key="wifi_rssi_dbm",
+        label="Adapter WiFi Signal",
+    )
+
+    assert zone_demand._attr_entity_registry_enabled_default is False
+    assert dhw_demand._attr_entity_registry_enabled_default is True
+    assert adapter._attr_entity_registry_enabled_default is False
 
 
 def test_energy_sensor_is_unavailable_without_valid_payload() -> None:


### PR DESCRIPTION
## Summary
- mark null-backed sparse sensor/number/text entities disabled by default
- integration-disable old visible sparse entities during trusted cleanup, with auto-enable when their backing field becomes live
- include boiler config numbers in sparse lifecycle matching
- merge partial DHW subscription updates without losing existing config/state

## Validation
- ./scripts/ci_local.sh

Closes #203