### PR TITLE
Suppress sparse entity update residue (#205)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -591,6 +591,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bus_identifier,
         circuit_identifier,
         daemon_identifier,
+        has_bus_identity_evidence,
         managing_device_identifier,
         radio_device_identifier,
         resolve_bus_address,
@@ -600,7 +601,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         zone_identifier,
     )
     from .subscriptions import start_subscriptions
-    from .zone_parent import build_zone_parent_device_ids
+    from .zone_parent import build_zone_parent_device_ids, should_reload_zone_parent_state
 
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
@@ -848,6 +849,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
     def resolved_bus_device_key(device: dict) -> str | None:
+        if not has_bus_identity_evidence(device):
+            return None
         address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:
             return None
@@ -1175,6 +1178,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     radio_sensor_unique_id_re = re.compile(
         rf"^{re.escape(entry.entry_id)}-radio-(?P<group>[0-9a-f]{{2}})-(?P<instance>\d{{2}})-sensor-(?P<key>.+)$"
     )
+    radio_connected_unique_id_re = re.compile(
+        rf"^{re.escape(entry.entry_id)}-radio-(?P<group>[0-9a-f]{{2}})-(?P<instance>\d{{2}})-connected$"
+    )
     solar_unique_id_re = re.compile(
         rf"^{re.escape(entry.entry_id)}-solar-(?P<kind>sensor|binary)-(?P<key>.+)$"
     )
@@ -1418,6 +1424,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return "temperature_c" in live_keys
         return False
 
+    def _radio_bus_key_from_unique_id(unique_id: str | None) -> str | None:
+        if not unique_id:
+            return None
+        for pattern in (radio_sensor_unique_id_re, radio_connected_unique_id_re):
+            match = pattern.match(unique_id)
+            if match is None:
+                continue
+            return build_radio_bus_key(
+                int(match.group("group"), 16),
+                int(match.group("instance")),
+            )
+        return None
+
     # ADR-027: build set of merged B524 slot prefixes for entity cleanup.
     # bus_key format: "g0c-i01" -> unique_id slot format: "0c-01"
     def _bus_key_to_uid_slot(bk: str) -> str:
@@ -1449,6 +1468,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 unique_id.startswith(prefix) for prefix in _b524_merged_uid_prefixes
             ):
                 remove_entry = True
+            elif (radio_bus_key := _radio_bus_key_from_unique_id(unique_id)) is not None:
+                remove_entry = radio_bus_key not in known_radio_bus_keys
             else:
                 cylinder_match = cylinder_unique_id_re.match(unique_id)
                 if cylinder_match and int(cylinder_match.group("index")) not in known_cylinder_indexes:
@@ -1513,7 +1534,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 radio_prefix = f"{entry.entry_id}-radio-"
                 if token.startswith(radio_prefix):
                     radio_bus_key = token[len(radio_prefix):]
-                    if radio_bus_key in b524_merge_targets:
+                    if radio_bus_key not in known_radio_bus_keys or radio_bus_key in b524_merge_targets:
                         remove_device = True
                         break
             if not remove_device:
@@ -1759,10 +1780,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         has_new_zones = bool(current_zone_ids - known_zones)
         has_new_dhw = dhw is not None and not known_has_dhw
         current_zone_parent_ids, unresolved = current_zone_parent_device_ids()
-        if unresolved:
-            schedule_reload("zone parent resolution became incomplete")
-            return
-        if current_zone_parent_ids != zone_parent_device_ids:
+        if should_reload_zone_parent_state(
+            zone_parent_device_ids,
+            unresolved_zone_ids,
+            current_zone_parent_ids,
+            unresolved,
+        ):
             schedule_reload("zone parent mapping changed")
             return
         if has_new_zones or has_new_dhw:
@@ -1800,10 +1823,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 continue
             current_keys.add(build_radio_bus_key(group, instance))
         current_zone_parent_ids, unresolved = current_zone_parent_device_ids()
-        if unresolved:
-            schedule_reload("zone parent resolution became incomplete")
-            return
-        if current_zone_parent_ids != zone_parent_device_ids:
+        if should_reload_zone_parent_state(
+            zone_parent_device_ids,
+            unresolved_zone_ids,
+            current_zone_parent_ids,
+            unresolved,
+        ):
             schedule_reload("zone parent mapping changed")
             return
         auto_enable_sparse_entities("radio update")

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import build_radio_bus_key, radio_device_identifier
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 from .semantic_tokens import normalize_allowed_mode_tokens, normalize_preset_token
 from .zone_parent import (
@@ -175,8 +176,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if entities and hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
             for entity in entities:
-                if hasattr(entity, "async_write_ha_state"):
-                    entity.async_write_ha_state()
+                async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -1582,7 +1582,8 @@ def _has_radio_identity_evidence(device: dict[str, Any]) -> bool:
         return True
     if str(device.get("firmware_version") or "").strip():
         return True
-    if _parse_optional_int(device.get("hardware_identifier")) is not None:
+    hardware_identifier = _parse_optional_int(device.get("hardware_identifier"))
+    if hardware_identifier is not None and hardware_identifier > 0:
         return True
     return False
 

--- a/custom_components/helianthus/date.py
+++ b/custom_components/helianthus/date.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_SYSTEM_CONFIG_MUTATION = """
@@ -61,8 +62,7 @@ async def async_setup_entry(
     if entities and hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
             for entity in entities:
-                if hasattr(entity, "async_write_ha_state"):
-                    entity.async_write_ha_state()
+                async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -16,6 +16,7 @@ _KNOWN_BUS_IDENTITY_MODELS: dict[str, str] = {
     "BAI00": "VUW",
     "NETX3": "VR940f",
 }
+_UNKNOWN_IDENTITY_TOKENS = {"unknown", "none", "null"}
 
 
 def _token(value: object | None) -> str:
@@ -29,6 +30,26 @@ def _clean(value: object | None) -> str | None:
         return None
     cleaned = str(value).strip()
     return cleaned or None
+
+
+def has_bus_identity_evidence(device: dict) -> bool:
+    """Return whether a GraphQL device payload is more than an address sighting."""
+
+    for key in (
+        "device_id",
+        "product_model",
+        "product_family",
+        "display_name",
+        "serial_number",
+        "mac_address",
+        "hardware_version",
+        "software_version",
+        "part_number",
+    ):
+        cleaned = _clean(device.get(key))
+        if cleaned and cleaned.lower() not in _UNKNOWN_IDENTITY_TOKENS:
+            return True
+    return False
 
 
 def stable_bus_identity_model(device_id: object | None, product_model: object | None = None) -> str:

--- a/custom_components/helianthus/entity_updates.py
+++ b/custom_components/helianthus/entity_updates.py
@@ -1,0 +1,26 @@
+"""Entity state-write guards for runtime safety checks."""
+
+from __future__ import annotations
+
+
+def _entity_is_disabled(entity: object) -> bool:
+    """Return True when an entity is disabled in the registry or runtime."""
+    if getattr(entity, "enabled", True) is False:
+        return True
+    registry_entry = getattr(entity, "registry_entry", None)
+    return (
+        registry_entry is not None
+        and getattr(registry_entry, "disabled_by", None) is not None
+    )
+
+
+def async_write_entity_state_if_enabled(entity: object) -> None:
+    """Write entity state only when the entity is enabled."""
+    writer = getattr(entity, "async_write_ha_state", None)
+    if not callable(writer):
+        return
+    if getattr(entity, "hass", None) is None:
+        return
+    if _entity_is_disabled(entity):
+        return
+    writer()

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import circuit_identifier, cylinder_identifier
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
@@ -367,8 +368,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if entities and hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
             for entity in entities:
-                if hasattr(entity, "async_write_ha_state"):
-                    entity.async_write_ha_state()
+                async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import circuit_identifier
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
@@ -83,8 +84,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if entities and hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
             for entity in entities:
-                if hasattr(entity, "async_write_ha_state"):
-                    entity.async_write_ha_state()
+                async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -19,6 +19,7 @@ from .device_ids import (
     circuit_identifier,
     dhw_identifier,
     energy_identifier,
+    has_bus_identity_evidence,
     radio_device_identifier,
     resolve_bus_address,
     solar_identifier,
@@ -511,6 +512,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     sensors: list[SensorEntity] = []
     seen_bus_keys: set[str] = set()
     for device in device_coordinator.data or []:
+        if not has_bus_identity_evidence(device):
+            continue
         device_id = _clean_text(device.get("device_id")) or "unknown"
         address = resolve_bus_address(device.get("address"), device.get("addresses"))
         if address is None:

--- a/custom_components/helianthus/text.py
+++ b/custom_components/helianthus/text.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_SYSTEM_CONFIG_MUTATION = """
@@ -152,10 +153,7 @@ async def async_setup_entry(
     if entities and hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
             for entity in entities:
-                if hasattr(entity, "async_write_ha_state"):
-                    if getattr(entity, "hass", None) is None:
-                        continue
-                    entity.async_write_ha_state()
+                async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
 from .device_ids import dhw_identifier
+from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _INVOKE_SET_EXT_REGISTER = """
@@ -63,8 +64,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities([entity])
     if hasattr(status_coordinator, "async_add_listener"):
         def _handle_admission_update() -> None:
-            if hasattr(entity, "async_write_ha_state"):
-                entity.async_write_ha_state()
+            async_write_entity_state_if_enabled(entity)
 
         unsub = status_coordinator.async_add_listener(_handle_admission_update)
         data.setdefault("unsub_listeners", []).append(unsub)

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -277,3 +277,28 @@ def build_zone_parent_device_ids(
         parent_device_ids[zone_id] = parent_device_id
 
     return parent_device_ids, tuple(sorted(unresolved_zone_ids))
+
+
+def should_reload_zone_parent_state(
+    baseline_parent_device_ids: dict[str, tuple[str, str]],
+    baseline_unresolved_zone_ids: tuple[str, ...],
+    current_parent_device_ids: dict[str, tuple[str, str]],
+    current_unresolved_zone_ids: tuple[str, ...],
+) -> bool:
+    """Return True when zone parent changes require a config entry reload."""
+    baseline_unresolved = set(baseline_unresolved_zone_ids)
+    current_unresolved = set(current_unresolved_zone_ids)
+    if current_unresolved:
+        # Transition from complete -> incomplete can orphan existing entities.
+        if not baseline_unresolved:
+            return True
+        if current_unresolved != baseline_unresolved:
+            return True
+        if current_parent_device_ids != baseline_parent_device_ids:
+            return True
+        # If a previously-resolved zone became unresolved, re-parenting is required.
+        if set(baseline_parent_device_ids).intersection(current_unresolved):
+            return True
+        # Baseline was already incomplete; wait for a complete mapping before reload.
+        return False
+    return current_parent_device_ids != baseline_parent_device_ids

--- a/tests/test_climate_quickveto.py
+++ b/tests/test_climate_quickveto.py
@@ -279,6 +279,8 @@ def test_climate_setup_refreshes_state_on_admission_updates(monkeypatch: pytest.
     entities = []
 
     asyncio.run(climate_platform.async_setup_entry(_FakeHass(payload), _FakeEntry(), entities.extend))
+    for entity in entities:
+        entity.hass = object()
     status.listeners[0]()
 
     assert writes == ["zone-1"]

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -12,6 +12,7 @@ from custom_components.helianthus.device_ids import (
     daemon_identifier,
     dhw_identifier,
     energy_identifier,
+    has_bus_identity_evidence,
     managing_device_identifier,
     radio_device_identifier,
     resolve_boiler_physical_device_id,
@@ -40,6 +41,30 @@ def test_resolve_bus_address_uses_alias_list_when_available() -> None:
     assert resolve_bus_address(0x15, [0x08, "0x15"]) == 0x08
     assert resolve_bus_address("0x26", None) == 0x26
     assert resolve_bus_address(None, None) is None
+
+
+def test_has_bus_identity_evidence_rejects_address_only_payload() -> None:
+    assert not has_bus_identity_evidence(
+        {
+            "address": 0x31,
+            "addresses": [0x31],
+            "device_id": "",
+            "display_name": None,
+            "hardware_version": "",
+            "mac_address": "",
+            "manufacturer": "",
+            "part_number": None,
+            "product_family": None,
+            "product_model": None,
+            "serial_number": "",
+            "software_version": "",
+        }
+    )
+
+
+def test_has_bus_identity_evidence_accepts_device_identity_payload() -> None:
+    assert has_bus_identity_evidence({"address": 0x15, "device_id": "BASV2"})
+    assert has_bus_identity_evidence({"address": 0x08, "serial_number": "ABC123"})
 
 
 def test_alias_faces_share_fallback_key_when_alias_addresses_match() -> None:

--- a/tests/test_entity_updates.py
+++ b/tests/test_entity_updates.py
@@ -1,0 +1,45 @@
+"""Tests for guarded entity state updates."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.helianthus.entity_updates import async_write_entity_state_if_enabled
+
+
+class _FakeEntity:
+    def __init__(self) -> None:
+        self.write_count = 0
+        self.enabled = True
+        self.hass = object()
+        self.registry_entry = None
+
+    def async_write_ha_state(self) -> None:
+        self.write_count += 1
+
+
+def test_async_write_entity_state_if_enabled_writes_for_enabled_entity() -> None:
+    entity = _FakeEntity()
+    async_write_entity_state_if_enabled(entity)
+    assert entity.write_count == 1
+
+
+def test_async_write_entity_state_if_enabled_skips_disabled_runtime_entity() -> None:
+    entity = _FakeEntity()
+    entity.enabled = False
+    async_write_entity_state_if_enabled(entity)
+    assert entity.write_count == 0
+
+
+def test_async_write_entity_state_if_enabled_skips_unattached_entity() -> None:
+    entity = _FakeEntity()
+    entity.hass = None
+    async_write_entity_state_if_enabled(entity)
+    assert entity.write_count == 0
+
+
+def test_async_write_entity_state_if_enabled_skips_registry_disabled_entity() -> None:
+    entity = _FakeEntity()
+    entity.registry_entry = SimpleNamespace(disabled_by="integration")
+    async_write_entity_state_if_enabled(entity)
+    assert entity.write_count == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -165,6 +165,47 @@ def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
     }
 
 
+def test_async_setup_entry_skips_address_only_bus_devices() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    payload["device_coordinator"] = _FakeCoordinator(
+        [
+            {
+                "address": 0x31,
+                "addresses": [0x31],
+                "device_id": "",
+                "display_name": None,
+                "hardware_version": "",
+                "mac_address": "",
+                "manufacturer": "",
+                "part_number": None,
+                "product_family": None,
+                "product_model": None,
+                "serial_number": "",
+                "software_version": "",
+            },
+            {
+                "address": 0x15,
+                "addresses": [0x15],
+                "device_id": "BASV2",
+                "product_model": "VRC 720f/2",
+            },
+        ]
+    )
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    bus_unique_ids = {
+        entity._attr_unique_id
+        for entity in entities
+        if isinstance(entity, sensor_platform.HelianthusBusAddressSensor)
+    }
+    assert "entry-1-bus-unknown-31-ebus-address" not in bus_unique_ids
+    assert "entry-1-bus-VRC-720f/2-15-ebus-address" in bus_unique_ids
+
+
 def test_async_setup_entry_adds_reduced_boiler_temperature_sensors_on_bai00_only() -> None:
     boiler_device_id = ("helianthus", "entry-1-bus-BAI00-08")
     payload = _build_payload(boiler_device_id=boiler_device_id)

--- a/tests/test_text_listener.py
+++ b/tests/test_text_listener.py
@@ -112,6 +112,14 @@ class _FakeStatusCoordinator:
         return lambda: None
 
 
+def _set_entity_hass(entity: object, hass: object | None) -> None:
+    hass_descriptor = getattr(type(entity), "hass", None)
+    if isinstance(hass_descriptor, property):
+        setattr(entity, "_hass", hass)
+        return
+    setattr(entity, "hass", hass)
+
+
 def test_text_listener_skips_entities_until_home_assistant_attaches_them() -> None:
     _ensure_text_stubs()
     from custom_components.helianthus import text as text_platform
@@ -136,11 +144,12 @@ def test_text_listener_skips_entities_until_home_assistant_attaches_them() -> No
             entity.write_count = getattr(entity, "write_count", 0) + 1
 
         entity.async_write_ha_state = _write_state
+        _set_entity_hass(entity, None)
 
     status_coordinator.listener()
     assert [getattr(entity, "write_count", 0) for entity in entities] == [0, 0, 0]
 
     for entity in entities:
-        entity.hass = hass
+        _set_entity_hass(entity, hass)
     status_coordinator.listener()
     assert [getattr(entity, "write_count", 0) for entity in entities] == [1, 1, 1]

--- a/tests/test_water_heater_admission.py
+++ b/tests/test_water_heater_admission.py
@@ -192,6 +192,8 @@ def test_water_heater_setup_refreshes_state_on_admission_updates(monkeypatch: py
     asyncio.run(
         water_heater_platform.async_setup_entry(_FakeHass(payload), _FakeEntry(), entities.extend)
     )
+    for entity in entities:
+        entity.hass = object()
     status.listeners[0]()
 
     assert writes == ["entry-1-dhw"]

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -149,7 +149,10 @@ from custom_components.helianthus import climate as climate_platform
 from custom_components.helianthus import sensor as sensor_platform
 from custom_components.helianthus.const import DOMAIN
 from custom_components.helianthus.device_ids import radio_device_identifier
-from custom_components.helianthus.zone_parent import build_zone_parent_device_ids
+from custom_components.helianthus.zone_parent import (
+    build_zone_parent_device_ids,
+    should_reload_zone_parent_state,
+)
 
 
 class _FakeCoordinator:
@@ -532,3 +535,30 @@ def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
     asyncio.run(climate_platform.async_setup_entry(hass, entry, entities.extend))
 
     assert entities == []
+
+
+def test_zone_parent_reload_skips_when_baseline_already_incomplete() -> None:
+    assert should_reload_zone_parent_state(
+        baseline_parent_device_ids={},
+        baseline_unresolved_zone_ids=("zone-1",),
+        current_parent_device_ids={},
+        current_unresolved_zone_ids=("zone-1",),
+    ) is False
+
+
+def test_zone_parent_reload_triggers_when_complete_baseline_becomes_incomplete() -> None:
+    assert should_reload_zone_parent_state(
+        baseline_parent_device_ids={"zone-1": ("helianthus", "entry-1-bus-BASV-15")},
+        baseline_unresolved_zone_ids=(),
+        current_parent_device_ids={},
+        current_unresolved_zone_ids=("zone-1",),
+    ) is True
+
+
+def test_zone_parent_reload_triggers_when_incomplete_baseline_partially_resolves() -> None:
+    assert should_reload_zone_parent_state(
+        baseline_parent_device_ids={},
+        baseline_unresolved_zone_ids=("zone-1", "zone-2"),
+        current_parent_device_ids={"zone-1": ("helianthus", "entry-1-radio-g09-i01")},
+        current_unresolved_zone_ids=("zone-2",),
+    ) is True


### PR DESCRIPTION
## Summary
- add a shared guarded entity state writer for admission/listener callbacks
- skip updates for unattached, disabled, or registry-disabled sparse entities
- suppress repeated zone-parent reload churn when baseline parent resolution is already incomplete
- stop exporting identity-less bus address sightings as HA devices/entities
- clean stale radio inventory slots and avoid treating `hardware_identifier=0` as identity evidence

## Validation
- pytest -q tests/test_entity_updates.py tests/test_zone_valve.py tests/test_climate_quickveto.py tests/test_water_heater_admission.py tests/test_text_listener.py tests/test_number.py tests/test_circuit.py tests/test_system.py
- pytest -q tests/test_device_ids.py tests/test_sensor.py tests/test_radio_device.py tests/test_coordinator.py tests/test_entity_updates.py tests/test_zone_valve.py
- ./scripts/ci_local.sh
- git diff --check

Fixes #205