### PR TITLE
Remove residual radio and status residue (#207)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -591,12 +591,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bus_identifier,
         circuit_identifier,
         daemon_identifier,
+        exportable_radio_bus_keys,
         has_bus_identity_evidence,
         managing_device_identifier,
         radio_device_identifier,
+        radio_bus_key_from_device,
         resolve_bus_address,
         resolve_boiler_physical_device_id,
         resolve_boiler_via_device_id,
+        should_export_radio_device,
         stable_bus_identity_model,
         zone_identifier,
     )
@@ -1040,6 +1043,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     radio_devices_payload = radio_payload.get("radio_devices")
     if not isinstance(radio_devices_payload, list):
         radio_devices_payload = []
+    radio_devices_payload = [
+        device
+        for device in radio_devices_payload
+        if isinstance(device, dict) and should_export_radio_device(device)
+    ]
 
     # ADR-027: Merge B524 function-module enrichment into physical bus devices.
     # Group 0x0C entries whose deviceClassAddress matches a known bus address
@@ -1047,8 +1055,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _B524_FUNCTION_MODULE_GROUP = 0x0C
     b524_merge_targets: dict[str, tuple[str, str]] = {}
     for device in radio_devices_payload:
-        if not isinstance(device, dict):
-            continue
         group = parse_optional_int(device.get("group"))
         if group != _B524_FUNCTION_MODULE_GROUP:
             continue
@@ -1058,12 +1064,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bus_device_id = bus_address_device_ids.get(class_addr)
         if bus_device_id is None:
             continue
-        inst = parse_optional_int(device.get("instance"))
-        if inst is None:
+        bus_key = radio_bus_key_from_device(device)
+        if bus_key is None:
             continue
-        bus_key = str(device.get("radio_bus_key") or "").strip()
-        if not bus_key:
-            bus_key = build_radio_bus_key(group, inst)
         b524_merge_targets[bus_key] = bus_device_id
         _LOGGER.debug(
             "B524 merge: radio slot %s (group=0x%02X, class_addr=%d) -> bus device %s",
@@ -1073,15 +1076,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     known_radio_bus_keys: set[str] = set()
     radio_parent = regulator_device or adapter_device_id
     for device in radio_devices_payload:
-        if not isinstance(device, dict):
-            continue
         group = parse_optional_int(device.get("group"))
         instance = parse_optional_int(device.get("instance"))
         if group is None or instance is None:
             continue
-        bus_key = str(device.get("radio_bus_key") or "").strip()
-        if not bus_key:
-            bus_key = build_radio_bus_key(group, instance)
+        bus_key = radio_bus_key_from_device(device)
+        if bus_key is None:
+            continue
         known_radio_bus_keys.add(bus_key)
         # ADR-027: skip HA device creation for merged B524 function module slots.
         if bus_key in b524_merge_targets:
@@ -1456,6 +1457,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             remove_entry = False
             if entity_entry.domain in {"fan", "valve", "switch"}:
                 remove_entry = True
+            elif unique_id in status_sparse_unique_ids and not _is_sparse_entity_live(unique_id):
+                remove_entry = True
             elif _stale_bus_address_unique_id(unique_id, entry.entry_id, known_bus_devices):
                 remove_entry = True
             elif entity_entry.domain == "number" and re.match(
@@ -1560,6 +1563,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "INTEGRATION",
                 integration_disabler,
             )
+        existing_unique_ids = {
+            str(entity_entry.unique_id or "")
+            for entity_entry in _entry_entities()
+            if entity_entry.platform == DOMAIN
+        }
+        missing_live_status_ids = [
+            unique_id
+            for unique_id in status_sparse_unique_ids
+            if unique_id not in existing_unique_ids and _is_sparse_entity_live(unique_id)
+        ]
+        if missing_live_status_ids:
+            _LOGGER.info(
+                "Helianthus scheduling reload for %d live sparse status entities for entry %s (%s)",
+                len(missing_live_status_ids),
+                entry.entry_id,
+                reason,
+            )
+            schedule_reload("sparse status entities became live")
+            return
         enabled = 0
         for entity_entry in _entry_entities():
             if entity_entry.platform != DOMAIN:
@@ -1809,19 +1831,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def handle_radio_update() -> None:
         payload = radio_coordinator.data or {}
-        current_keys: set[str] = set()
-        for radio in payload.get("radio_devices", []) or []:
-            if not isinstance(radio, dict):
-                continue
-            key = str(radio.get("radio_bus_key") or "").strip()
-            if key:
-                current_keys.add(key)
-                continue
-            group = parse_optional_int(radio.get("group"))
-            instance = parse_optional_int(radio.get("instance"))
-            if group is None or instance is None:
-                continue
-            current_keys.add(build_radio_bus_key(group, instance))
+        radio_devices = payload.get("radio_devices", []) or []
+        current_keys = exportable_radio_bus_keys(radio_devices)
         current_zone_parent_ids, unresolved = current_zone_parent_device_ids()
         if should_reload_zone_parent_state(
             zone_parent_device_ids,

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -15,6 +15,7 @@ from .device_ids import (
     circuit_identifier,
     dhw_identifier,
     radio_device_identifier,
+    should_export_radio_device,
     solar_identifier,
 )
 
@@ -271,6 +272,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if radio_coordinator and radio_coordinator.data:
         for radio in radio_coordinator.data.get("radio_devices", []) or []:
             if not isinstance(radio, dict):
+                continue
+            if not should_export_radio_device(radio):
                 continue
             slot = _radio_slot(radio)
             bus_key = _radio_bus_key(radio)

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -32,6 +32,14 @@ def _clean(value: object | None) -> str | None:
     return cleaned or None
 
 
+def _has_known_identity_text(value: object | None) -> bool:
+    cleaned = _clean(value)
+    if not cleaned:
+        return False
+    lowered = cleaned.lower()
+    return lowered not in _UNKNOWN_IDENTITY_TOKENS and not lowered.startswith("unknown ")
+
+
 def has_bus_identity_evidence(device: dict) -> bool:
     """Return whether a GraphQL device payload is more than an address sighting."""
 
@@ -46,10 +54,61 @@ def has_bus_identity_evidence(device: dict) -> bool:
         "software_version",
         "part_number",
     ):
-        cleaned = _clean(device.get(key))
-        if cleaned and cleaned.lower() not in _UNKNOWN_IDENTITY_TOKENS:
+        if _has_known_identity_text(device.get(key)):
             return True
     return False
+
+
+def has_radio_identity_evidence(device: dict) -> bool:
+    """Return whether a radio slot carries a real device identity."""
+
+    class_address = _parse_bus_address(device.get("device_class_address"))
+    if class_address in {0x15, 0x26, 0x35}:
+        return True
+    for key in ("device_model", "firmware_version"):
+        if _has_known_identity_text(device.get(key)):
+            return True
+    hardware_identifier = _parse_bus_address(device.get("hardware_identifier"))
+    return hardware_identifier is not None and hardware_identifier > 0
+
+
+def should_export_radio_device(device: dict) -> bool:
+    """Return whether a radio slot should become HA device/entity inventory."""
+
+    group = _parse_bus_address(device.get("group"))
+    if group is None:
+        return False
+    if group == 0x0C:
+        return has_radio_identity_evidence(device)
+    return device.get("device_connected") is True or has_radio_identity_evidence(device)
+
+
+def radio_bus_key_from_device(device: dict) -> str | None:
+    """Return the stable radio slot key carried by a radio device payload."""
+
+    key = _clean(device.get("radio_bus_key"))
+    if key:
+        return key
+    group = _parse_bus_address(device.get("group"))
+    instance = _parse_bus_address(device.get("instance"))
+    if group is None or instance is None:
+        return None
+    return build_radio_bus_key(group, instance)
+
+
+def exportable_radio_bus_keys(devices: Iterable[object]) -> set[str]:
+    """Return radio slot keys that should participate in HA inventory decisions."""
+
+    out: set[str] = set()
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+        if not should_export_radio_device(device):
+            continue
+        key = radio_bus_key_from_device(device)
+        if key:
+            out.add(key)
+    return out
 
 
 def stable_bus_identity_model(device_id: object | None, product_model: object | None = None) -> str:

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -22,6 +22,7 @@ from .device_ids import (
     has_bus_identity_evidence,
     radio_device_identifier,
     resolve_bus_address,
+    should_export_radio_device,
     solar_identifier,
     stable_bus_identity_model,
 )
@@ -537,16 +538,18 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     daemon_status = status_entries.get("daemon", {})
     adapter_status = status_entries.get("adapter", {})
 
-    sensors.extend(
-        HelianthusStatusSensor(
-            status_coordinator,
-            "Daemon",
-            daemon_status,
-            data.get("daemon_device_id"),
-            field,
+    for field in DAEMON_STATUS_FIELDS:
+        if field.optional and daemon_status.get(field.key) is None:
+            continue
+        sensors.append(
+            HelianthusStatusSensor(
+                status_coordinator,
+                "Daemon",
+                daemon_status,
+                data.get("daemon_device_id"),
+                field,
+            )
         )
-        for field in DAEMON_STATUS_FIELDS
-    )
     sensors.extend(
         HelianthusStatusSensor(
             status_coordinator,
@@ -638,6 +641,8 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         radio_devices = radio_coordinator.data.get("radio_devices", []) or []
         for radio in radio_devices:
             if not isinstance(radio, dict):
+                continue
+            if not should_export_radio_device(radio):
                 continue
             slot = _radio_slot(radio)
             bus_key = _radio_bus_key(radio)

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -12,12 +12,14 @@ from custom_components.helianthus.device_ids import (
     daemon_identifier,
     dhw_identifier,
     energy_identifier,
+    exportable_radio_bus_keys,
     has_bus_identity_evidence,
     managing_device_identifier,
     radio_device_identifier,
     resolve_boiler_physical_device_id,
     resolve_boiler_via_device_id,
     resolve_bus_address,
+    should_export_radio_device,
     solar_identifier,
     zone_identifier,
 )
@@ -65,6 +67,48 @@ def test_has_bus_identity_evidence_rejects_address_only_payload() -> None:
 def test_has_bus_identity_evidence_accepts_device_identity_payload() -> None:
     assert has_bus_identity_evidence({"address": 0x15, "device_id": "BASV2"})
     assert has_bus_identity_evidence({"address": 0x08, "serial_number": "ABC123"})
+
+
+def test_should_export_radio_device_rejects_identityless_inventory_slot() -> None:
+    assert not should_export_radio_device(
+        {
+            "group": 0x0C,
+            "instance": 0,
+            "device_connected": True,
+            "device_class_address": 0,
+            "device_model": "Unknown (0x00)",
+            "hardware_identifier": 0,
+        }
+    )
+
+
+def test_should_export_radio_device_accepts_known_radio_identities() -> None:
+    assert should_export_radio_device({"group": 0x09, "device_connected": True})
+    assert should_export_radio_device({"group": 0x0C, "device_class_address": 0x26})
+    assert should_export_radio_device({"group": 0x0C, "hardware_identifier": 1})
+
+
+def test_exportable_radio_bus_keys_ignores_identityless_inventory_slots() -> None:
+    assert exportable_radio_bus_keys(
+        [
+            {
+                "group": 0x0C,
+                "instance": 0,
+                "radio_bus_key": "g0c-i00",
+                "device_connected": True,
+                "device_class_address": 0,
+                "device_model": "Unknown (0x00)",
+                "hardware_identifier": 0,
+            },
+            {
+                "group": 0x09,
+                "instance": 1,
+                "radio_bus_key": "g09-i01",
+                "device_connected": True,
+                "device_class_address": 0x15,
+            },
+        ]
+    ) == {"g09-i01"}
 
 
 def test_alias_faces_share_fallback_key_when_alias_addresses_match() -> None:

--- a/tests/test_radio_device.py
+++ b/tests/test_radio_device.py
@@ -229,6 +229,32 @@ def test_radio_sensor_entities_cover_room_and_inventory_devices() -> None:
     assert "entry-1-radio-0c-02-sensor-hardware_identifier" in unique_ids
 
 
+def test_identityless_inventory_radio_slot_exports_no_entities() -> None:
+    radio_devices = [
+        {
+            "group": 0x0C,
+            "instance": 0,
+            "radio_bus_key": "g0c-i00",
+            "device_class_address": 0,
+            "device_connected": True,
+            "hardware_identifier": 0,
+            "stale_cycles": 0,
+        },
+    ]
+    hass = _FakeHass(_base_payload(radio_devices))
+    entry = _FakeEntry("entry-1")
+    sensor_entities: list = []
+    binary_entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, sensor_entities.extend))
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, entry, binary_entities.extend))
+
+    sensor_uids = {getattr(entity, "_attr_unique_id", "") for entity in sensor_entities}
+    binary_uids = {getattr(entity, "_attr_unique_id", "") for entity in binary_entities}
+    assert "entry-1-radio-0c-00-sensor-device_class_address" not in sensor_uids
+    assert "entry-1-radio-0c-00-connected" not in binary_uids
+
+
 def test_radio_connected_entity_becomes_unavailable_after_third_stale_cycle() -> None:
     radio_devices = [
         {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -393,6 +393,52 @@ def test_status_sensor_reads_live_coordinator_status() -> None:
     assert entity.native_value is False
 
 
+def test_async_setup_entry_skips_null_optional_status_sensor() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    payload["status_coordinator"] = _FakeCoordinator(
+        {
+            "daemon": {
+                "admission_trusted": True,
+                "admission_repair_code": None,
+            },
+            "adapter": {},
+        }
+    )
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    unique_ids = {getattr(entity, "_attr_unique_id", "") for entity in entities}
+    assert "daemon-entry-1-admission_repair_code" not in unique_ids
+
+
+def test_async_setup_entry_creates_live_optional_status_sensor() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    payload["status_coordinator"] = _FakeCoordinator(
+        {
+            "daemon": {
+                "admission_trusted": False,
+                "admission_repair_code": "admission_degraded",
+            },
+            "adapter": {},
+        }
+    )
+    hass = _FakeHass(payload)
+    entry = _FakeEntry("entry-1")
+    entities: list = []
+
+    asyncio.run(sensor_platform.async_setup_entry(hass, entry, entities.extend))
+
+    entity = next(
+        entity
+        for entity in entities
+        if getattr(entity, "_attr_unique_id", "") == "daemon-entry-1-admission_repair_code"
+    )
+    assert entity.native_value == "admission_degraded"
+
+
 def test_sparse_demand_and_adapter_sensors_are_disabled_by_default_when_value_null() -> None:
     semantic = _FakeCoordinator(
         {


### PR DESCRIPTION
## What
- Filter identityless B524 radio inventory slots before HA device/entity export.
- Remove stale sparse daemon status entities when their optional value is no longer live.
- Skip null optional daemon status sensors during setup so disabled entities are not update-triggered.

## Validation
- ./scripts/ci_local.sh
- pytest -q tests/test_device_ids.py tests/test_sensor.py tests/test_radio_device.py tests/test_coordinator.py

Closes #207