### PR TITLE
Clean stale B524 radio registry keys (#212)

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -593,6 +593,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         daemon_identifier,
         exportable_radio_bus_keys,
         has_bus_identity_evidence,
+        is_b524_inventory_radio_bus_key,
         managing_device_identifier,
         nonexportable_radio_bus_keys,
         radio_device_identifier,
@@ -1494,14 +1495,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         reason: str,
     ) -> None:
         if not radio_keys:
-            return
+            radio_keys = set()
+        radio_keys_to_remove = set(radio_keys)
         removed_entities = 0
         for entity_entry in _entry_entities():
             if entity_entry.platform != DOMAIN:
                 continue
             unique_id = str(entity_entry.unique_id or "")
             radio_bus_key = _radio_bus_key_from_unique_id(unique_id)
-            if radio_bus_key not in radio_keys:
+            if radio_bus_key is None:
+                continue
+            if radio_bus_key not in radio_keys_to_remove and not (
+                is_b524_inventory_radio_bus_key(radio_bus_key)
+                and radio_bus_key not in known_radio_bus_keys
+            ):
                 continue
             entity_registry.async_remove(entity_entry.entity_id)
             removed_entities += 1
@@ -1513,7 +1520,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for identifier_domain, token in _iter_identifier_pairs(device_entry.identifiers):
                 if identifier_domain != DOMAIN or not token.startswith(radio_prefix):
                     continue
-                if token[len(radio_prefix):] in radio_keys:
+                radio_bus_key = token[len(radio_prefix):]
+                if radio_bus_key in radio_keys_to_remove or (
+                    is_b524_inventory_radio_bus_key(radio_bus_key)
+                    and radio_bus_key not in known_radio_bus_keys
+                ):
                     remove_device = True
                     break
             if not remove_device:

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -96,6 +96,12 @@ def radio_bus_key_from_device(device: dict) -> str | None:
     return build_radio_bus_key(group, instance)
 
 
+def is_b524_inventory_radio_bus_key(key: str | None) -> bool:
+    """Return whether a radio bus key belongs to the B524 inventory group."""
+
+    return bool(key and key.startswith("g0c-i"))
+
+
 def exportable_radio_bus_keys(devices: Iterable[object]) -> set[str]:
     """Return radio slot keys that should participate in HA inventory decisions."""
 
@@ -118,12 +124,11 @@ def nonexportable_radio_bus_keys(devices: Iterable[object]) -> set[str]:
     for device in devices:
         if not isinstance(device, dict):
             continue
-        group = _parse_bus_address(device.get("group"))
-        if group != 0x0C:
+        key = radio_bus_key_from_device(device)
+        if not is_b524_inventory_radio_bus_key(key):
             continue
         if should_export_radio_device(device):
             continue
-        key = radio_bus_key_from_device(device)
         if key:
             out.add(key)
     return out

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -14,6 +14,7 @@ from custom_components.helianthus.device_ids import (
     energy_identifier,
     exportable_radio_bus_keys,
     has_bus_identity_evidence,
+    is_b524_inventory_radio_bus_key,
     managing_device_identifier,
     nonexportable_radio_bus_keys,
     radio_device_identifier,
@@ -141,6 +142,13 @@ def test_nonexportable_radio_bus_keys_selects_observed_identityless_slots() -> N
             },
         ]
     ) == {"g0c-i00"}
+
+
+def test_is_b524_inventory_radio_bus_key_matches_only_inventory_group() -> None:
+    assert is_b524_inventory_radio_bus_key("g0c-i00")
+    assert is_b524_inventory_radio_bus_key("g0c-i02")
+    assert not is_b524_inventory_radio_bus_key("g09-i02")
+    assert not is_b524_inventory_radio_bus_key("")
 
 
 def test_alias_faces_share_fallback_key_when_alias_addresses_match() -> None:


### PR DESCRIPTION
## What
- Removes stale B524 inventory radio registry keys when they are absent from the current exported radio inventory.
- Keeps cleanup limited to radio keys shaped like g0c-iNN, so transient non-inventory radio disconnects are not removed.
- Leaves valid exported radio keys untouched.

## Validation
- ./scripts/ci_local.sh
- pytest -q tests/test_device_ids.py tests/test_radio_device.py tests/test_sensor.py

Live trigger: after #210 deploy, current-entry g0c-i00/g0c-i02 rows remained because those bad slots are absent from the coordinator payload and therefore were not observed as non-exportable.

Closes #212