### PR TITLE
integration: resolve mapped zones from known radio slots

### DIFF
--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -116,12 +116,16 @@ def radio_device_ids_from_payload(
     return out
 
 
-def build_global_radio_candidates(radio_devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def build_global_radio_candidates(
+    radio_devices: list[dict[str, Any]],
+    *,
+    connected_only: bool = True,
+) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
     for device in radio_devices:
         if not isinstance(device, dict):
             continue
-        if device.get("device_connected") is not True:
+        if connected_only and device.get("device_connected") is not True:
             continue
         normalized = normalize_radio_slot_candidate(
             {
@@ -156,7 +160,14 @@ def select_zone_radio_candidate(
     radio_devices: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     candidates = list(radio_zone_candidates.get(zone_instance, []) or [])
-    global_candidates = build_global_radio_candidates(radio_devices or [])
+    global_candidates = build_global_radio_candidates(
+        radio_devices or [],
+        connected_only=True,
+    )
+    global_candidates_any = build_global_radio_candidates(
+        radio_devices or [],
+        connected_only=False,
+    )
 
     def pick(
         items: list[dict[str, Any]],
@@ -198,16 +209,18 @@ def select_zone_radio_candidate(
     if room_temperature_zone_mapping == 1:
         return (
             pick(candidates, 0x09, 0)
-            or pick(candidates, 0x09)
             or pick(global_candidates, 0x09, 0)
+            or pick(global_candidates_any, 0x09, 0)
+            or pick(candidates, 0x09)
             or pick(global_candidates, 0x09)
         )
     if room_temperature_zone_mapping in (2, 3, 4):
         remote_addr = room_temperature_zone_mapping - 1
         return (
             pick(candidates, 0x0A, remote_addr)
-            or pick_thermostat_fallback(candidates, remote_addr)
             or pick(global_candidates, 0x0A, remote_addr)
+            or pick(global_candidates_any, 0x0A, remote_addr)
+            or pick_thermostat_fallback(candidates, remote_addr)
             or pick_thermostat_fallback(global_candidates, remote_addr)
         )
     if room_temperature_zone_mapping in (0, None):

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -425,7 +425,7 @@ def test_build_zone_parent_device_ids_flags_mapped_zone_without_physical_parent(
     assert unresolved == ("zone-2",)
 
 
-def test_build_zone_parent_device_ids_recovers_once_live_radio_payload_is_available() -> None:
+def test_build_zone_parent_device_ids_resolves_mapped_zones_from_disconnected_slot_identity() -> None:
     zones = [
         {
             "id": "zone-1",
@@ -495,13 +495,153 @@ def test_build_zone_parent_device_ids_recovers_once_live_radio_payload_is_availa
         regulator,
     )
 
-    assert sparse_parent_ids == {}
-    assert sparse_unresolved == ("zone-1", "zone-2")
+    assert sparse_parent_ids == {
+        "zone-1": radio_device_identifier("entry-1", "g09-i01"),
+        "zone-2": radio_device_identifier("entry-1", "g0a-i01"),
+    }
+    assert sparse_unresolved == ()
     assert live_parent_ids == {
         "zone-1": radio_device_identifier("entry-1", "g09-i01"),
         "zone-2": radio_device_identifier("entry-1", "g0a-i01"),
     }
     assert live_unresolved == ()
+
+
+def test_build_zone_parent_device_ids_prefers_connected_slot_over_disconnected_identity() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [
+            {
+                "id": "zone-2",
+                "name": "Etaj",
+                "config": {"room_temperature_zone_mapping": 2},
+            }
+        ],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x0A,
+                    "instance": 1,
+                    "radio_bus_key": "g0a-i01",
+                    "device_connected": False,
+                    "remote_control_address": 1,
+                },
+                {
+                    "group": 0x0A,
+                    "instance": 2,
+                    "radio_bus_key": "g0a-i02",
+                    "device_connected": True,
+                    "remote_control_address": 1,
+                },
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+    )
+
+    assert zone_parent_device_ids == {
+        "zone-2": radio_device_identifier("entry-1", "g0a-i02"),
+    }
+    assert unresolved == ()
+
+
+def test_build_zone_parent_device_ids_prefers_exact_disconnected_identity_over_connected_fallback() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [
+            {
+                "id": "zone-1",
+                "name": "Parter",
+                "config": {"room_temperature_zone_mapping": 1},
+            },
+            {
+                "id": "zone-2",
+                "name": "Etaj",
+                "config": {"room_temperature_zone_mapping": 2},
+            },
+        ],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x09,
+                    "instance": 5,
+                    "radio_bus_key": "g09-i05",
+                    "device_connected": True,
+                    "remote_control_address": 5,
+                },
+                {
+                    "group": 0x09,
+                    "instance": 1,
+                    "radio_bus_key": "g09-i01",
+                    "device_connected": False,
+                    "remote_control_address": 0,
+                },
+                {
+                    "group": 0x0A,
+                    "instance": 5,
+                    "radio_bus_key": "g0a-i05",
+                    "device_connected": True,
+                    "remote_control_address": 5,
+                },
+                {
+                    "group": 0x0A,
+                    "instance": 1,
+                    "radio_bus_key": "g0a-i01",
+                    "device_connected": False,
+                    "remote_control_address": 1,
+                },
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+    )
+
+    assert zone_parent_device_ids == {
+        "zone-1": radio_device_identifier("entry-1", "g09-i01"),
+        "zone-2": radio_device_identifier("entry-1", "g0a-i01"),
+    }
+    assert unresolved == ()
+
+
+def test_build_zone_parent_device_ids_keeps_nonmatching_disconnected_slots_unresolved() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [
+            {
+                "id": "zone-1",
+                "name": "Parter",
+                "config": {"room_temperature_zone_mapping": 1},
+            },
+            {
+                "id": "zone-2",
+                "name": "Etaj",
+                "config": {"room_temperature_zone_mapping": 2},
+            },
+        ],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x09,
+                    "instance": 4,
+                    "radio_bus_key": "g09-i04",
+                    "device_connected": False,
+                    "remote_control_address": 4,
+                },
+                {
+                    "group": 0x0A,
+                    "instance": 3,
+                    "radio_bus_key": "g0a-i03",
+                    "device_connected": False,
+                    "remote_control_address": 3,
+                },
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+    )
+
+    assert zone_parent_device_ids == {}
+    assert unresolved == ("zone-1", "zone-2")
 
 
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:


### PR DESCRIPTION
## What
Fixes #214 by allowing mapped zones to resolve their parent device from known radio slot identity when the slot is present but currently reports device_connected=false.

## Why
The live HA host still logged: Helianthus zone parent resolution incomplete ... zone-1 after duplicate config-entry cleanup. The gateway payload includes stable mapping data, including room_temperature_zone_mapping=1, and a known radio slot, but the integration only considered connected radio candidates, leaving the zone unresolved until a connected snapshot arrived.

## Validation
- pytest tests/test_zone_valve.py
- pytest tests/test_climate_quickveto.py tests/test_binary_sensor.py
- ./scripts/ci_local.sh

## Doc gate
No docs PR: this is an HA integration repair for existing parent-device resolution semantics. It does not alter protocol behavior, GraphQL/MCP schema, or the eBUS semantic contract.