### PR TITLE
Deduplicate same-GUID gateway entries

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -454,6 +454,18 @@ def _parse_identifier_index(token: str, prefix: str) -> int | None:
     return value
 
 
+def _config_entry_sort_key(config_entry: object) -> str:
+    """Return a stable ordering key for duplicate config entry ownership."""
+
+    return str(getattr(config_entry, "entry_id", "") or "")
+
+
+def _config_entry_enabled(config_entry: object) -> bool:
+    """Return whether a config entry may own live gateway setup."""
+
+    return getattr(config_entry, "disabled_by", None) is None
+
+
 async def _find_verified_entry_by_configured_instance_guid(
     hass: object,
     session: object,
@@ -467,8 +479,12 @@ async def _find_verified_entry_by_configured_instance_guid(
         verify_gateway_identity,
     )
 
+    owner_entry: object | None = None
+
     for config_entry in hass.config_entries.async_entries(DOMAIN):
         if getattr(config_entry, "entry_id", None) == exclude_entry_id:
+            continue
+        if not _config_entry_enabled(config_entry):
             continue
         data = getattr(config_entry, "data", None) or {}
         if (
@@ -503,8 +519,11 @@ async def _find_verified_entry_by_configured_instance_guid(
                 getattr(exc, "reason", type(exc).__name__),
             )
             continue
-        return config_entry
-    return None
+        if owner_entry is None or _config_entry_sort_key(config_entry) < _config_entry_sort_key(
+            owner_entry
+        ):
+            owner_entry = config_entry
+    return owner_entry
 
 
 def _merge_duplicate_config_entry_options(
@@ -551,6 +570,29 @@ def _schedule_duplicate_config_entry_removal(hass: object, entry_id: str) -> boo
         return False
     async_create_task(async_remove(entry_id))
     return True
+
+
+def _remove_config_entry_registry_state(
+    *,
+    device_registry: object,
+    entity_registry: object,
+    entry_id: str,
+    device_entries_for_config_entry: object,
+    entity_entries_for_config_entry: object,
+) -> tuple[int, int]:
+    """Remove device/entity registry rows that belong only to a duplicate entry."""
+
+    removed_entities = 0
+    for entity_entry in tuple(entity_entries_for_config_entry(entity_registry, entry_id)):
+        entity_registry.async_remove(entity_entry.entity_id)
+        removed_entities += 1
+
+    removed_devices = 0
+    for device_entry in tuple(device_entries_for_config_entry(device_registry, entry_id)):
+        device_registry.async_remove_device(device_entry.id)
+        removed_devices += 1
+
+    return removed_entities, removed_devices
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -610,6 +652,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
+
+    def refuse_duplicate_setup(owner_entry: object, instance_guid: str) -> bool:
+        options_merged = _merge_duplicate_config_entry_options(
+            hass,
+            alias_entry=entry,
+            owner_entry=owner_entry,
+        )
+        removed_entities, removed_devices = _remove_config_entry_registry_state(
+            device_registry=device_registry,
+            entity_registry=entity_registry,
+            entry_id=entry.entry_id,
+            device_entries_for_config_entry=dr.async_entries_for_config_entry,
+            entity_entries_for_config_entry=er.async_entries_for_config_entry,
+        )
+        _LOGGER.warning(
+            "Refusing to set up Helianthus entry %s because %s reports "
+            "instance GUID %s already owned by entry %s; removed %d stale "
+            "entities and %d stale devices; migrated_options=%s",
+            entry.entry_id,
+            host,
+            instance_guid,
+            owner_entry.entry_id,
+            removed_entities,
+            removed_devices,
+            options_merged,
+        )
+        if _schedule_duplicate_config_entry_removal(hass, entry.entry_id):
+            _LOGGER.warning(
+                "Scheduled duplicate Helianthus config entry %s for removal",
+                entry.entry_id,
+            )
+        return False
 
     # Phase C2: migrate camelCase unique_ids to snake_case before platform setup.
     uid_migrated = _migrate_unique_ids_to_snake_case(hass, entry)
@@ -714,41 +788,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 exclude_entry_id=entry.entry_id,
             )
             if duplicate_entry is not None:
-                options_merged = _merge_duplicate_config_entry_options(
-                    hass,
-                    alias_entry=entry,
-                    owner_entry=duplicate_entry,
-                )
-                removed_entities = 0
-                for entity_entry in tuple(
-                    er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-                ):
-                    entity_registry.async_remove(entity_entry.entity_id)
-                    removed_entities += 1
-                removed_devices = 0
-                for device_entry in tuple(
-                    dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-                ):
-                    device_registry.async_remove_device(device_entry.id)
-                    removed_devices += 1
-                _LOGGER.warning(
-                    "Refusing to set up Helianthus entry %s because %s now reports "
-                    "instance GUID %s already owned by entry %s; removed %d stale "
-                    "entities and %d stale devices; migrated_options=%s",
-                    entry.entry_id,
-                    host,
-                    live_instance_guid,
-                    duplicate_entry.entry_id,
-                    removed_entities,
-                    removed_devices,
-                    options_merged,
-                )
-                if _schedule_duplicate_config_entry_removal(hass, entry.entry_id):
-                    _LOGGER.warning(
-                        "Scheduled duplicate Helianthus config entry %s for removal",
-                        entry.entry_id,
-                    )
-                return False
+                return refuse_duplicate_setup(duplicate_entry, live_instance_guid)
 
             entry_instance_guid = live_instance_guid
             hass.config_entries.async_update_entry(
@@ -770,6 +810,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry.entry_id,
                 entry_instance_guid,
             )
+        else:
+            duplicate_entry = await _find_verified_entry_by_configured_instance_guid(
+                hass,
+                session,
+                live_instance_guid,
+                exclude_entry_id=entry.entry_id,
+            )
+            if (
+                duplicate_entry is not None
+                and _config_entry_sort_key(duplicate_entry)
+                < _config_entry_sort_key(entry)
+            ):
+                return refuse_duplicate_setup(duplicate_entry, live_instance_guid)
 
     if entry_instance_guid is not None:
         normalized_unique_id = normalize_instance_guid(entry.unique_id)

--- a/tests/test_config_flow_identity_repair.py
+++ b/tests/test_config_flow_identity_repair.py
@@ -287,6 +287,94 @@ def test_setup_duplicate_owner_accepts_verified_live_claimant() -> None:
     assert session.urls == ["http://192.0.2.10:8080/graphql"]
 
 
+def test_setup_duplicate_owner_prefers_earliest_entry_id_among_verified_claimants() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _find_verified_entry_by_configured_instance_guid
+
+    later_claimant = SimpleNamespace(
+        entry_id="z-entry",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "192.0.2.20",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    earlier_claimant = SimpleNamespace(
+        entry_id="a-entry",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "192.0.2.10",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    hass = SimpleNamespace(config_entries=_FakeConfigEntries([later_claimant, earlier_claimant]))
+    session = _FakeSession([LIVE_GUID, LIVE_GUID])
+
+    result = asyncio.run(
+        _find_verified_entry_by_configured_instance_guid(
+            hass,
+            session,
+            LIVE_GUID,
+        )
+    )
+
+    assert result is earlier_claimant
+    assert session.urls == [
+        "http://192.0.2.20:8080/graphql",
+        "http://192.0.2.10:8080/graphql",
+    ]
+
+
+def test_setup_duplicate_owner_ignores_disabled_entries() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _find_verified_entry_by_configured_instance_guid
+
+    disabled_claimant = SimpleNamespace(
+        entry_id="a-disabled-entry",
+        unique_id=LIVE_GUID,
+        disabled_by="user",
+        data={
+            "host": "192.0.2.10",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    enabled_claimant = SimpleNamespace(
+        entry_id="z-enabled-entry",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "192.0.2.20",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    hass = SimpleNamespace(
+        config_entries=_FakeConfigEntries([disabled_claimant, enabled_claimant])
+    )
+    session = _FakeSession([LIVE_GUID])
+
+    result = asyncio.run(
+        _find_verified_entry_by_configured_instance_guid(
+            hass,
+            session,
+            LIVE_GUID,
+        )
+    )
+
+    assert result is enabled_claimant
+    assert session.urls == ["http://192.0.2.20:8080/graphql"]
+
+
 def test_duplicate_alias_options_are_preserved_on_owner_before_removal() -> None:
     _ensure_config_flow_stubs()
     from custom_components.helianthus import _merge_duplicate_config_entry_options
@@ -322,6 +410,54 @@ def test_duplicate_alias_options_are_preserved_on_owner_before_removal() -> None
             "zone-2": "calendar.owner",
         },
     }
+
+
+def test_duplicate_alias_registry_cleanup_removes_alias_tree_only() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _remove_config_entry_registry_state
+
+    class _FakeEntityRegistry:
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+
+        def async_remove(self, entity_id: str) -> None:
+            self.removed.append(entity_id)
+
+    class _FakeDeviceRegistry:
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+
+        def async_remove_device(self, device_id: str) -> None:
+            self.removed.append(device_id)
+
+    entity_registry = _FakeEntityRegistry()
+    device_registry = _FakeDeviceRegistry()
+    entity_entries = {
+        "alias-entry": [SimpleNamespace(entity_id="sensor.alias_gateway")],
+        "owner-entry": [SimpleNamespace(entity_id="sensor.owner_gateway")],
+    }
+    device_entries = {
+        "alias-entry": [SimpleNamespace(id="alias-device")],
+        "owner-entry": [SimpleNamespace(id="owner-device")],
+    }
+
+    removed_entities, removed_devices = _remove_config_entry_registry_state(
+        device_registry=device_registry,
+        entity_registry=entity_registry,
+        entry_id="alias-entry",
+        device_entries_for_config_entry=lambda _registry, entry_id: device_entries[
+            entry_id
+        ],
+        entity_entries_for_config_entry=lambda _registry, entry_id: entity_entries[
+            entry_id
+        ],
+    )
+
+    assert (removed_entities, removed_devices) == (1, 1)
+    assert entity_registry.removed == ["sensor.alias_gateway"]
+    assert device_registry.removed == ["alias-device"]
+    assert entity_entries["owner-entry"][0].entity_id == "sensor.owner_gateway"
+    assert device_entries["owner-entry"][0].id == "owner-device"
 
 
 def test_duplicate_alias_removal_is_scheduled_after_refusal() -> None:


### PR DESCRIPTION
## What
- Detect same-GUID duplicate Helianthus config entries during setup, including the live_instance_guid == entry_instance_guid case.
- Pick the deterministic earliest verified enabled owner for duplicate GUID claimants.
- Ignore disabled entries during owner election so a disabled stale entry cannot evict the active gateway tree.
- Reuse the existing option merge and scheduled duplicate entry removal behavior; factor alias-only registry cleanup into a tested helper.

## Why
A gateway discovered via mDNS and direct IP can represent the same physical gateway and report the same GUID. Without migration/repair, Home Assistant can show two gateway entries for one GUID even though both should export the same child tree.

Fixes #216.

## Validation
- pytest -q tests/test_identity.py tests/test_config_flow_identity_repair.py
- pytest -q
- git diff --check

Smoke test required: YES