### PR TITLE
Repair Helianthus reachable host rebinding

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING
 
 from .admission import (
@@ -14,6 +14,7 @@ from .admission import (
 )
 from .const import (
     CONF_DHW_SCHEDULE_HELPER,
+    CONF_HOST_ALIASES,
     CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
@@ -466,6 +467,68 @@ def _config_entry_enabled(config_entry: object) -> bool:
     return getattr(config_entry, "disabled_by", None) is None
 
 
+_HASSIO_HELIANTHUS_FALLBACK_HOSTS = (
+    "local-helianthus.local.hass.io",
+    "172.30.32.1",
+)
+
+
+def _entry_identity_probe_addresses(
+    data: Mapping[str, object],
+    primary_host: str,
+) -> tuple[str, ...]:
+    """Return secondary hosts to try when verifying a stored gateway endpoint."""
+
+    ordered: list[str] = []
+    seen = {primary_host}
+
+    def add(value: object) -> None:
+        host = str(value or "").strip()
+        if not host or host in seen:
+            return
+        seen.add(host)
+        ordered.append(host)
+
+    aliases = data.get(CONF_HOST_ALIASES)
+    if isinstance(aliases, str):
+        add(aliases)
+    elif isinstance(aliases, Iterable):
+        for alias in aliases:
+            add(alias)
+
+    if primary_host.startswith("172.30."):
+        for host in _HASSIO_HELIANTHUS_FALLBACK_HOSTS:
+            add(host)
+
+    return tuple(ordered)
+
+
+def _update_entry_endpoint_if_changed(
+    hass: object,
+    entry: object,
+    verified_endpoint: object,
+    *,
+    version: str | None,
+) -> bool:
+    """Persist a verified reachable endpoint when a config entry drifted."""
+
+    from .identity import same_endpoint, updated_entry_data
+
+    data = getattr(entry, "data", None) or {}
+    if same_endpoint(data, verified_endpoint):
+        return False
+    hass.config_entries.async_update_entry(
+        entry,
+        data=updated_entry_data(
+            data,
+            verified_endpoint,
+            version=version or getattr(verified_endpoint, "version", None),
+        ),
+        unique_id=verified_endpoint.instance_guid,
+    )
+    return True
+
+
 async def _find_verified_entry_by_configured_instance_guid(
     hass: object,
     session: object,
@@ -747,6 +810,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             port=int(port),
             path=path,
             transport=transport,
+            addresses=_entry_identity_probe_addresses(entry.data, str(host)),
             expected_instance_guid=None,
             version=version,
         )
@@ -823,6 +887,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 < _config_entry_sort_key(entry)
             ):
                 return refuse_duplicate_setup(duplicate_entry, live_instance_guid)
+            if _update_entry_endpoint_if_changed(
+                hass,
+                entry,
+                verified_endpoint,
+                version=version or verified_endpoint.version,
+            ):
+                host = verified_endpoint.host
+                port = verified_endpoint.port
+                path = verified_endpoint.path
+                transport = verified_endpoint.transport
+                version = version or verified_endpoint.version
+                _LOGGER.info(
+                    "Rebound Helianthus entry %s to reachable endpoint %s:%s",
+                    entry.entry_id,
+                    host,
+                    port,
+                )
 
     if entry_instance_guid is not None:
         normalized_unique_id = normalize_instance_guid(entry.unique_id)

--- a/custom_components/helianthus/config_flow.py
+++ b/custom_components/helianthus/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 import voluptuous as vol
@@ -16,6 +17,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
+    CONF_HOST_ALIASES,
     CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
@@ -28,6 +30,7 @@ from .discovery import normalize_transport, parse_mdns_service
 from .identity import (
     GatewayIdentityVerificationError,
     VerifiedHelianthusEndpoint,
+    candidate_hosts,
     configured_instance_guid,
     same_endpoint,
     updated_entry_data,
@@ -197,19 +200,46 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         *,
         version: str | None,
         title: str,
+        host_aliases: list[str] | tuple[str, ...] | None = None,
     ) -> FlowResult:
         if verified_endpoint is None:
             return self.async_abort(reason="invalid_response")
+
+        def with_host_aliases(data: dict[str, Any], primary_host: str) -> dict[str, Any]:
+            alias_source: Iterable[str] | None
+            if host_aliases is not None:
+                alias_source = host_aliases
+            else:
+                stored_aliases = data.get(CONF_HOST_ALIASES)
+                if isinstance(stored_aliases, str):
+                    alias_source = (stored_aliases,)
+                elif isinstance(stored_aliases, Iterable):
+                    alias_source = stored_aliases
+                else:
+                    alias_source = None
+            aliases = [
+                host
+                for host in candidate_hosts(primary_host, alias_source)
+                if host != primary_host
+            ]
+            if aliases:
+                data[CONF_HOST_ALIASES] = aliases
+            else:
+                data.pop(CONF_HOST_ALIASES, None)
+            return data
 
         instance_guid = verified_endpoint.instance_guid
         await self.async_set_unique_id(instance_guid)
         existing_entry = self._async_find_entry_by_guid(instance_guid)
 
         if existing_entry is not None:
-            existing_data = updated_entry_data(
-                existing_entry.data,
-                verified_endpoint,
-                version=version or verified_endpoint.version,
+            existing_data = with_host_aliases(
+                updated_entry_data(
+                    existing_entry.data,
+                    verified_endpoint,
+                    version=version or verified_endpoint.version,
+                ),
+                verified_endpoint.host,
             )
             if same_endpoint(existing_entry.data, verified_endpoint):
                 if (
@@ -242,10 +272,13 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         live_existing = await self._async_find_entry_by_live_guid(instance_guid)
         if live_existing is not None:
             existing_entry, current_verified = live_existing
-            existing_data = updated_entry_data(
-                existing_entry.data,
-                current_verified,
-                version=version or current_verified.version,
+            existing_data = with_host_aliases(
+                updated_entry_data(
+                    existing_entry.data,
+                    current_verified,
+                    version=version or current_verified.version,
+                ),
+                current_verified.host,
             )
             self.hass.config_entries.async_update_entry(
                 existing_entry,
@@ -256,10 +289,13 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
             return self.async_abort(reason="reconfigured")
 
-        data = updated_entry_data(
-            {},
-            verified_endpoint,
-            version=version or verified_endpoint.version,
+        data = with_host_aliases(
+            updated_entry_data(
+                {},
+                verified_endpoint,
+                version=version or verified_endpoint.version,
+            ),
+            verified_endpoint.host,
         )
         return self.async_create_entry(title=title, data=data)
 
@@ -291,4 +327,5 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             verified_endpoint,
             version=record.version,
             title=record.name or verified_endpoint.host,
+            host_aliases=list(candidate_hosts(record.host, record.addresses)),
         )

--- a/custom_components/helianthus/const.py
+++ b/custom_components/helianthus/const.py
@@ -7,6 +7,7 @@ CONF_PATH = "path"
 CONF_TRANSPORT = "transport"
 CONF_VERSION = "version"
 CONF_INSTANCE_GUID = "instance_guid"
+CONF_HOST_ALIASES = "host_aliases"
 
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_USE_SUBSCRIPTIONS = "use_subscriptions"

--- a/tests/test_config_flow_identity_repair.py
+++ b/tests/test_config_flow_identity_repair.py
@@ -7,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 import sys
 
 from custom_components.helianthus.const import (
+    CONF_HOST_ALIASES,
     CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
@@ -223,6 +224,160 @@ def test_zeroconf_rebinds_existing_entry_when_stored_guid_is_stale() -> None:
     assert stale_entry.data[CONF_INSTANCE_GUID] == LIVE_GUID
     assert stale_entry.data["host"] == "172.30.32.1"
     assert config_entries.reloads == ["01KK2FYJ7KCXCZ4A766ZPJSPE9"]
+
+
+def test_zeroconf_entry_records_unselected_host_aliases() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus.config_flow import HelianthusConfigFlow
+
+    config_entries = _FakeConfigEntries([])
+    flow = HelianthusConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=config_entries)
+
+    result = asyncio.run(
+        flow._async_finish_verified_entry(
+            VerifiedHelianthusEndpoint(
+                instance_guid=LIVE_GUID,
+                host="172.30.32.1",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            ),
+            version=None,
+            title="helianthus._helianthus-graphql._tcp.local.",
+            host_aliases=["172.30.232.1", "172.30.32.1"],
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"]["host"] == "172.30.32.1"
+    assert result["data"][CONF_HOST_ALIASES] == ["172.30.232.1"]
+
+
+def test_existing_entry_update_preserves_host_aliases_when_user_flow_has_no_aliases() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus.config_flow import HelianthusConfigFlow
+
+    existing_entry = SimpleNamespace(
+        entry_id="01KSC4TH4K09D1VXX0MHFT6BBF",
+        title="Helianthus",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "172.30.32.1",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+            CONF_HOST_ALIASES: ["172.30.232.1", "local-helianthus.local.hass.io"],
+        },
+    )
+    config_entries = _FakeConfigEntries([existing_entry])
+    flow = HelianthusConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=config_entries)
+
+    result = asyncio.run(
+        flow._async_finish_verified_entry(
+            VerifiedHelianthusEndpoint(
+                instance_guid=LIVE_GUID,
+                host="172.30.32.1",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            ),
+            version=None,
+            title="172.30.32.1",
+        )
+    )
+
+    assert result == {"type": "abort", "reason": "already_configured"}
+    assert existing_entry.data[CONF_HOST_ALIASES] == [
+        "172.30.232.1",
+        "local-helianthus.local.hass.io",
+    ]
+    assert config_entries.reloads == []
+
+
+def test_existing_entry_update_preserves_string_host_alias_without_character_split() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus.config_flow import HelianthusConfigFlow
+
+    existing_entry = SimpleNamespace(
+        entry_id="01KSC4TH4K09D1VXX0MHFT6BBF",
+        title="Helianthus",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "172.30.32.1",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+            CONF_HOST_ALIASES: "172.30.232.1",
+        },
+    )
+    config_entries = _FakeConfigEntries([existing_entry])
+    flow = HelianthusConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=config_entries)
+
+    result = asyncio.run(
+        flow._async_finish_verified_entry(
+            VerifiedHelianthusEndpoint(
+                instance_guid=LIVE_GUID,
+                host="172.30.32.1",
+                port=8080,
+                path="/graphql",
+                transport="http",
+            ),
+            version=None,
+            title="172.30.32.1",
+        )
+    )
+
+    assert result == {"type": "abort", "reason": "already_configured"}
+    assert existing_entry.data[CONF_HOST_ALIASES] == ["172.30.232.1"]
+    assert config_entries.reloads == []
+
+
+def test_setup_identity_probe_addresses_adds_stored_and_hassio_fallbacks() -> None:
+    from custom_components.helianthus import _entry_identity_probe_addresses
+
+    assert _entry_identity_probe_addresses(
+        {CONF_HOST_ALIASES: ["172.30.232.1", "local-helianthus.local.hass.io"]},
+        "172.30.232.1",
+    ) == ("local-helianthus.local.hass.io", "172.30.32.1")
+
+
+def test_setup_identity_refresh_rebinds_same_guid_to_reachable_alias() -> None:
+    _ensure_config_flow_stubs()
+    from custom_components.helianthus import _update_entry_endpoint_if_changed
+
+    entry = SimpleNamespace(
+        entry_id="01KSC4TH4K09D1VXX0MHFT6BBF",
+        unique_id=LIVE_GUID,
+        data={
+            "host": "172.30.232.1",
+            "port": 8080,
+            CONF_PATH: "/graphql",
+            CONF_TRANSPORT: "http",
+            CONF_INSTANCE_GUID: LIVE_GUID,
+        },
+    )
+    config_entries = _FakeConfigEntries([entry])
+    hass = SimpleNamespace(config_entries=config_entries)
+
+    assert _update_entry_endpoint_if_changed(
+        hass,
+        entry,
+        VerifiedHelianthusEndpoint(
+            instance_guid=LIVE_GUID,
+            host="172.30.32.1",
+            port=8080,
+            path="/graphql",
+            transport="http",
+        ),
+        version=None,
+    )
+    assert entry.data["host"] == "172.30.32.1"
+    assert entry.unique_id == LIVE_GUID
 
 
 def test_setup_duplicate_owner_requires_live_identity_proof() -> None:


### PR DESCRIPTION
## What
Repair same-GUID endpoint rebinding when an existing Helianthus config entry points at an unreachable add-on address but mDNS or stored aliases expose a reachable endpoint.

## Why
Live HA had a single Helianthus entry with the correct GUID but host 172.30.232.1 was unreachable from HA Core, leaving integration entities unavailable even though the gateway was reachable through the add-on network.

## Changes
- Store unselected mDNS host aliases on config entries.
- Probe stored aliases plus Hass.io fallback hosts during identity verification for 172.30.* endpoints.
- Persist the reachable endpoint when the live GUID matches.
- Add regression tests for alias storage, fallback probe ordering, and same-GUID endpoint rebinding.

## Validation
- ./scripts/ci_local.sh

Closes #197