### PR TITLE
Label B524 DHW pseudo-circuit by role

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -694,7 +694,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         build_radio_bus_key,
         build_bus_device_key,
         bus_identifier,
+        circuit_display_name,
         circuit_identifier,
+        circuit_type_display_name,
         daemon_identifier,
         exportable_radio_bus_keys,
         has_bus_identity_evidence,
@@ -1074,15 +1076,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 return f"{major}.{minor}.{patch}"
         return token
 
-    def circuit_type_display_name(value: object | None) -> str:
-        token = str(value or "").strip().lower()
-        return {
-            "heating": "Heating",
-            "fixed_value": "Fixed Value",
-            "dhw": "DHW",
-            "return_increase": "Return Increase",
-        }.get(token, token.replace("_", " ").title() or "Circuit")
-
     known_bus_devices: set[str] = set()
     bus_address_device_ids: dict[int, tuple[str, str]] = {}
     regulator_device: tuple[str, str] | None = None
@@ -1268,7 +1261,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "identifiers": {circuit_device_id},
             "manufacturer": regulator_manufacturer,
             "model": circuit_type_name,
-            "name": f"Circuit {index + 1} ({circuit_type_name})",
+            "name": circuit_display_name(circuit, index),
         }
         if managing_device is not None:
             device_kwargs["via_device"] = managing_device

--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .device_ids import (
     build_radio_bus_key,
+    circuit_display_name,
     circuit_identifier,
     dhw_identifier,
     radio_device_identifier,
@@ -43,6 +44,10 @@ def _parse_optional_int(value: object | None) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _circuit_name(circuit: dict[str, Any], index: int) -> str:
+    return circuit_display_name(circuit, index)
 
 
 def _radio_slot(device: dict[str, Any]) -> tuple[int, int] | None:
@@ -205,15 +210,13 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             circuit_index = _parse_optional_int(circuit.get("index"))
             if circuit_index is None or circuit_index < 0:
                 continue
-            circuit_type = str(circuit.get("circuit_type") or "").strip().lower()
-            label = circuit_type.replace("_", " ").title() if circuit_type else f"Circuit {circuit_index + 1}"
             entities.append(
                 HelianthusCircuitPumpBinarySensor(
                     coordinator=circuit_coordinator,
                     entry_id=entry.entry_id,
                     manufacturer=manufacturer,
                     circuit_index=circuit_index,
-                    initial_name=f"Circuit {circuit_index + 1} ({label})",
+                    initial_name=_circuit_name(circuit, circuit_index),
                 )
             )
 

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -17,6 +17,12 @@ _KNOWN_BUS_IDENTITY_MODELS: dict[str, str] = {
     "NETX3": "VR940f",
 }
 _UNKNOWN_IDENTITY_TOKENS = {"unknown", "none", "null"}
+_CIRCUIT_TYPE_LABELS = {
+    "heating": "Heating",
+    "fixed_value": "Fixed Value",
+    "dhw": "DHW",
+    "return_increase": "Return Increase",
+}
 
 
 def _token(value: object | None) -> str:
@@ -38,6 +44,25 @@ def _has_known_identity_text(value: object | None) -> bool:
         return False
     lowered = cleaned.lower()
     return lowered not in _UNKNOWN_IDENTITY_TOKENS and not lowered.startswith("unknown ")
+
+
+def circuit_type_display_name(value: object | None) -> str:
+    """Return the human display label for a gateway circuit type token."""
+
+    token = str(value or "").strip().lower()
+    return _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
+
+
+def circuit_display_name(circuit: dict, index: int) -> str:
+    """Return the HA display name for a circuit while preserving stable indexes."""
+
+    token = str(circuit.get("circuit_type") or "").strip().lower()
+    label = circuit_type_display_name(token)
+    if token == "dhw":
+        if index == 9:
+            return "DHW Circuit"
+        return f"DHW Circuit {index + 1}"
+    return f"Circuit {index + 1} ({label})"
 
 
 def has_bus_identity_evidence(device: dict) -> bool:

--- a/custom_components/helianthus/fan.py
+++ b/custom_components/helianthus/fan.py
@@ -14,16 +14,10 @@ from .const import DOMAIN
 from .device_ids import (
     boiler_burner_identifier,
     boiler_hydraulics_identifier,
+    circuit_display_name,
     circuit_identifier,
     solar_identifier,
 )
-
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
 
 _FM5_MODE_INTERPRETED = "INTERPRETED"
 
@@ -41,9 +35,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 def _fm5_mode(payload: dict[str, Any] | None) -> str:

--- a/custom_components/helianthus/number.py
+++ b/custom_components/helianthus/number.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
-from .device_ids import circuit_identifier, cylinder_identifier
+from .device_ids import circuit_display_name, circuit_identifier, cylinder_identifier
 from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
@@ -50,13 +50,6 @@ mutation SetBoilerConfig($field: String!, $value: String!) {
   }
 }
 """
-
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
 
 _FM5_MODE_INTERPRETED = "INTERPRETED"
 
@@ -286,9 +279,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 def _fm5_mode(payload: dict[str, Any] | None) -> str:

--- a/custom_components/helianthus/select.py
+++ b/custom_components/helianthus/select.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
-from .device_ids import circuit_identifier
+from .device_ids import circuit_display_name, circuit_identifier
 from .entity_updates import async_write_entity_state_if_enabled
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
@@ -25,12 +25,6 @@ mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
 }
 """
 
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
 _OPTIONS = ["off", "modulating", "thermostat"]
 
 
@@ -47,9 +41,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -16,6 +16,7 @@ from .device_ids import (
     build_bus_device_key,
     cylinder_identifier,
     bus_identifier,
+    circuit_display_name,
     circuit_identifier,
     dhw_identifier,
     energy_identifier,
@@ -106,13 +107,6 @@ _SENSOR_STATE_CLASS_TOTAL_INCREASING = getattr(SensorStateClass, "TOTAL_INCREASI
 _RADIO_ROOM_CLASSES = {0x15, 0x35}
 _RADIO_STALE_GRACE_CYCLES = 3
 _FM5_MODE_INTERPRETED = "INTERPRETED"
-
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
 
 CIRCUIT_SENSOR_FIELDS = [
     CircuitSensorField(
@@ -455,9 +449,7 @@ def _fm5_mode(payload: dict[str, Any] | None) -> str:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 def _normalize_zone_id(zone_id: object | None) -> str | None:

--- a/custom_components/helianthus/switch.py
+++ b/custom_components/helianthus/switch.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .admission import assert_admission_trusted, status_admission_trusted
 from .const import DOMAIN
-from .device_ids import circuit_identifier, solar_identifier
+from .device_ids import circuit_display_name, circuit_identifier, solar_identifier
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
 _SET_CIRCUIT_CONFIG_MUTATION = """
@@ -23,13 +23,6 @@ mutation SetCircuitConfig($index: Int!, $field: String!, $value: String!) {
   }
 }
 """
-
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
 
 _FM5_MODE_INTERPRETED = "INTERPRETED"
 
@@ -47,9 +40,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 def _fm5_mode(payload: dict[str, Any] | None) -> str:

--- a/custom_components/helianthus/valve.py
+++ b/custom_components/helianthus/valve.py
@@ -11,7 +11,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .device_ids import boiler_hydraulics_identifier, circuit_identifier, zone_identifier
+from .device_ids import (
+    boiler_hydraulics_identifier,
+    circuit_display_name,
+    circuit_identifier,
+    zone_identifier,
+)
 
 try:
     from homeassistant.components.valve import ValveEntityFeature
@@ -21,14 +26,6 @@ except ImportError:  # pragma: no cover - test stub fallback
 
         def __new__(cls, value: int = 0):
             return int.__new__(cls, value)
-
-_CIRCUIT_TYPE_LABELS = {
-    "heating": "Heating",
-    "fixed_value": "Fixed Value",
-    "dhw": "DHW",
-    "return_increase": "Return Increase",
-}
-
 
 def _parse_circuit_index(value: object | None) -> int | None:
     if isinstance(value, bool):
@@ -43,9 +40,7 @@ def _parse_circuit_index(value: object | None) -> int | None:
 
 
 def _circuit_name(circuit: dict[str, Any], index: int) -> str:
-    token = str(circuit.get("circuit_type") or "").strip().lower()
-    label = _CIRCUIT_TYPE_LABELS.get(token, token.replace("_", " ").title() or "Circuit")
-    return f"Circuit {index + 1} ({label})"
+    return circuit_display_name(circuit, index)
 
 
 def _normalize_zone_id(zone_id: object | None) -> str | None:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -197,6 +197,24 @@ from custom_components.helianthus import valve as valve_platform
 from custom_components.helianthus.const import DOMAIN
 
 
+@pytest.mark.parametrize(
+    "platform",
+    [
+        binary_sensor_platform,
+        fan_platform,
+        number_platform,
+        select_platform,
+        sensor_platform,
+        switch_platform,
+        valve_platform,
+    ],
+)
+def test_circuit_name_labels_dhw_pseudo_circuit_by_role(platform) -> None:  # noqa: ANN001
+    assert platform._circuit_name({"circuit_type": "dhw"}, 9) == "DHW Circuit"
+    assert platform._circuit_name({"circuit_type": "dhw"}, 2) == "DHW Circuit 3"
+    assert platform._circuit_name({"circuit_type": "heating"}, 0) == "Circuit 1 (Heating)"
+
+
 class _FakeCoordinator:
     def __init__(self, data) -> None:  # noqa: ANN001
         self.data = data

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -8,7 +8,9 @@ from custom_components.helianthus.device_ids import (
     bus_identifier,
     build_bus_device_key,
     cylinder_identifier,
+    circuit_display_name,
     circuit_identifier,
+    circuit_type_display_name,
     daemon_identifier,
     dhw_identifier,
     energy_identifier,
@@ -25,6 +27,18 @@ from custom_components.helianthus.device_ids import (
     solar_identifier,
     zone_identifier,
 )
+
+
+def test_circuit_display_name_labels_dhw_pseudo_circuit_by_role() -> None:
+    assert circuit_display_name({"circuit_type": "dhw"}, 9) == "DHW Circuit"
+    assert circuit_display_name({"circuit_type": "dhw"}, 2) == "DHW Circuit 3"
+    assert circuit_display_name({"circuit_type": "heating"}, 0) == "Circuit 1 (Heating)"
+
+
+def test_circuit_type_display_name_formats_known_and_unknown_tokens() -> None:
+    assert circuit_type_display_name("fixed_value") == "Fixed Value"
+    assert circuit_type_display_name("return_increase") == "Return Increase"
+    assert circuit_type_display_name("vendor_specific") == "Vendor Specific"
 
 
 def test_build_bus_device_key_uses_stable_model_and_address_only() -> None:


### PR DESCRIPTION
## What
Centralizes circuit display-name formatting and labels the B524 `II=0x09` DHW pseudo-circuit as `DHW Circuit` across Home Assistant platforms.

## Why
Once the gateway publishes `index=9, circuit_type=dhw`, displaying it as a normal `Circuit 10 (DHW)` is misleading. The integration should preserve stable indexes internally while using role-first labels for the pseudo-circuit.

## Details
- Adds shared `circuit_type_display_name()` and `circuit_display_name()` helpers.
- Updates binary sensor, fan, number, select, sensor, switch, valve, and device-registry naming to use the shared helper.
- Keeps non-pseudo DHW circuits index-aware as `DHW Circuit N`.

## Verification
- `python3 -m pytest tests/test_device_ids.py tests/test_circuit.py -q`
- `python3 -m pytest -q`
- `git diff --check`

Depends on Project-Helianthus/helianthus-ebusgateway#688.

Closes #219.
