### PR TITLE
MSP-09C: consume promoted eeBUS semantics in Home Assistant

### DIFF
--- a/custom_components/helianthus/binary_sensor.py
+++ b/custom_components/helianthus/binary_sensor.py
@@ -183,6 +183,15 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                     schedule_label=schedule_label,
                 )
             )
+        dhw_state = dhw.get("state") if isinstance(dhw, dict) else None
+        if isinstance(dhw_state, dict) and "overrun_active" in dhw_state:
+            entities.append(
+                HelianthusDhwOverrunBinarySensor(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    manufacturer=manufacturer,
+                )
+            )
 
     if boiler_coordinator and boiler_device_id:
         for key, label in [
@@ -374,14 +383,45 @@ class HelianthusScheduleBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 identifiers={identifier},
                 manufacturer=self._manufacturer,
             )
-        else:
-            identifier = dhw_identifier(self._entry_id)
-            return DeviceInfo(
-                identifiers={identifier},
-                manufacturer=self._manufacturer,
-                model="Virtual DHW",
-                name="Domestic Hot Water",
-            )
+        identifier = dhw_identifier(self._entry_id)
+        return DeviceInfo(
+            identifiers={identifier},
+            manufacturer=self._manufacturer,
+            model="Virtual DHW",
+            name="Domestic Hot Water",
+        )
+
+
+class HelianthusDhwOverrunBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Read-only DHW overrun state on the existing virtual DHW device."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:water-alert"
+
+    def __init__(self, *, coordinator, entry_id: str, manufacturer: str) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._manufacturer = manufacturer
+        self._attr_name = "Overrun Active"
+        self._attr_unique_id = f"{entry_id}-dhw-binary-overrun_active"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={dhw_identifier(self._entry_id)},
+            manufacturer=self._manufacturer,
+            model="Virtual DHW",
+            name="Domestic Hot Water",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        payload = self.coordinator.data or {}
+        dhw = payload.get("dhw") if isinstance(payload, dict) else None
+        state = dhw.get("state") if isinstance(dhw, dict) else None
+        value = state.get("overrun_active") if isinstance(state, dict) else None
+        return value if isinstance(value, bool) else None
 
 
 class HelianthusBoilerStateBinarySensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/helianthus/climate.py
+++ b/custom_components/helianthus/climate.py
@@ -414,6 +414,8 @@ class HelianthusZoneClimate(CoordinatorEntity, ClimateEntity):
         )
 
         for field, key in [
+            ("source_label", "source_label"),
+            ("operation_mode_changeable", "operation_mode_changeable"),
             ("quick_veto", "quick_veto"),
             ("quick_veto_setpoint_c", "quick_veto_setpoint"),
             ("quick_veto_duration_h", "quick_veto_duration"),

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -353,6 +353,62 @@ query Semantic {
 }
 """
 
+# MSP-09C intentionally uses a separate primary query.  An older gateway that
+# lacks any promoted field must continue through the established semantic
+# fallback chain below, rather than losing zones or DHW as a side effect.
+QUERY_SEMANTIC_PROMOTED = """
+query Semantic {
+  zones {
+    id
+    name
+    state {
+      current_temp_c
+      current_humidity_pct
+      hvac_action
+      special_function
+      heating_demand_pct
+      valve_position_pct
+    }
+    config {
+      operating_mode
+      operation_mode_changeable
+      source_label
+      preset
+      target_temp_c
+      allowed_modes
+      circuit_type
+      associated_circuit
+      room_temperature_zone_mapping
+      quick_veto
+      quick_veto_setpoint
+      quick_veto_duration
+      quick_veto_expiry
+      holiday_start_date
+      holiday_end_date
+      holiday_setpoint
+      holiday_start_time
+      holiday_end_time
+    }
+  }
+  dhw {
+    state {
+      current_temp_c
+      overrun_active
+      special_function
+      heating_demand_pct
+    }
+    config {
+      operating_mode
+      operation_mode_changeable
+      preset
+      target_temp_c
+      holiday_start_date
+      holiday_end_date
+    }
+  }
+}
+"""
+
 QUERY_SEMANTIC_NO_HOLIDAY = """
 query Semantic {
   zones {
@@ -473,6 +529,7 @@ query Semantic {
 _HOLIDAY_FIELDS = ["holiday_start_date", "holiday_end_date", "holiday_setpoint", "holiday_start_time", "holiday_end_time"]
 _QV_FIELDS = ["quick_veto", "quick_veto_setpoint", "quick_veto_duration", "quick_veto_expiry"]
 _SEMANTIC_RECOVERABLE_FIELDS = _HOLIDAY_FIELDS + _QV_FIELDS + ["room_temperature_zone_mapping"]
+_PROMOTED_SEMANTIC_FIELDS = ["operation_mode_changeable", "source_label", "overrun_active"]
 _STATUS_SCHEMA_FIELDS = [
     "busSummary",
     "status",
@@ -601,6 +658,15 @@ query System {
       system_scheme
       module_configuration_vr71
     }
+  }
+}
+"""
+
+QUERY_SYSTEM_GATEWAY_METADATA = """
+query SystemGatewayMetadata {
+  system {
+    gateway_brand
+    gateway_vendor
   }
 }
 """
@@ -830,7 +896,7 @@ class HelianthusSemanticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._client = client
 
     async def _async_update_data(self) -> dict[str, Any]:
-        queries = [QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY, QUERY_SEMANTIC_NO_QV, QUERY_SEMANTIC_LEGACY]
+        queries = [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY, QUERY_SEMANTIC_NO_QV, QUERY_SEMANTIC_LEGACY]
         payload = None
         for query in queries:
             try:
@@ -839,6 +905,8 @@ class HelianthusSemanticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except GraphQLResponseError as exc:
                 if _is_missing_field_error(exc.errors, ["zones", "dhw"]):
                     return {"zones": [], "dhw": None}
+                if _is_missing_field_error(exc.errors, _PROMOTED_SEMANTIC_FIELDS):
+                    continue
                 if _is_missing_field_error(exc.errors, _SEMANTIC_RECOVERABLE_FIELDS):
                     continue
                 raise UpdateFailed(str(exc)) from exc
@@ -1163,7 +1231,7 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self._system_sensitive_available is not False
 
     async def _async_update_data(self) -> dict[str, Any]:
-        empty = {"state": {}, "config": {}, "properties": {}}
+        empty = {"state": {}, "config": {}, "properties": {}, "metadata": {}}
         missing_fields = [
             "system",
             "state",
@@ -1209,7 +1277,25 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "state": state if isinstance(state, dict) else {},
             "config": config if isinstance(config, dict) else {},
             "properties": properties if isinstance(properties, dict) else {},
+            "metadata": {},
         }
+
+        # Keep gateway metadata optional and isolated from the base system
+        # query: older gateways must retain their system state/config payload.
+        try:
+            metadata_payload = await self._client.execute(QUERY_SYSTEM_GATEWAY_METADATA)
+            metadata_system = metadata_payload.get("system") if isinstance(metadata_payload, dict) else None
+            if isinstance(metadata_system, dict):
+                result["metadata"] = {
+                    key: metadata_system[key]
+                    for key in ("gateway_brand", "gateway_vendor")
+                    if key in metadata_system
+                }
+        except GraphQLResponseError as exc:
+            if not _is_missing_field_error(exc.errors, ["gateway_brand", "gateway_vendor"]):
+                raise UpdateFailed(str(exc)) from exc
+        except GraphQLClientError:
+            pass
 
         # Optional installer query (backward-compat with older gateways).
         if self._system_installer_available is not False:

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -1374,6 +1374,18 @@ class HelianthusSystemSensor(CoordinatorEntity, SensorEntity):
             return value
         return None
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        payload = self.coordinator.data or {}
+        metadata = payload.get("metadata") if isinstance(payload, dict) else None
+        if not isinstance(metadata, dict):
+            return {}
+        return {
+            key: metadata[key]
+            for key in ("gateway_brand", "gateway_vendor")
+            if key in metadata
+        }
+
 
 class HelianthusRadioSensor(CoordinatorEntity, SensorEntity):
     """Per-slot remote radio sensor."""

--- a/custom_components/helianthus/water_heater.py
+++ b/custom_components/helianthus/water_heater.py
@@ -177,6 +177,11 @@ class HelianthusDhwWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         special = state.get("special_function")
         if special is not None and str(special).strip() != "":
             attrs["special_function"] = special
+        for field in ("operation_mode_changeable",):
+            if field in config:
+                attrs[field] = config[field]
+        if "overrun_active" in state:
+            attrs["overrun_active"] = state["overrun_active"]
         return attrs
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -255,3 +255,43 @@ def test_zone_valve_binary_sensor_none_when_position_absent() -> None:
     ]
     assert len(valve_entities) == 1
     assert valve_entities[0].is_on is None
+
+
+def test_dhw_overrun_sensor_is_read_only_and_uses_existing_dhw_parent() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    payload["semantic_coordinator"] = _FakeCoordinator(
+        {"zones": [], "dhw": {"state": {"overrun_active": False}, "config": {}}}
+    )
+    hass = _FakeHass(payload)
+    entities: list = []
+
+    asyncio.run(binary_sensor_platform.async_setup_entry(hass, _FakeEntry("entry-1"), entities.extend))
+
+    overrun = next(entity for entity in entities if isinstance(entity, binary_sensor_platform.HelianthusDhwOverrunBinarySensor))
+    assert overrun._attr_unique_id == "entry-1-dhw-binary-overrun_active"
+    assert sum(isinstance(entity, binary_sensor_platform.HelianthusDhwOverrunBinarySensor) for entity in entities) == 1
+    assert len({entity._attr_unique_id for entity in entities}) == len(entities)
+    assert all("eebus" not in entity._attr_unique_id.lower() for entity in entities)
+    assert overrun.is_on is False
+    assert overrun.device_info["identifiers"] == {("helianthus", "entry-1-dhw")}
+    payload["semantic_coordinator"].data["dhw"]["state"]["overrun_active"] = None
+    assert overrun.is_on is None
+
+
+def test_dhw_overrun_sensor_is_absent_when_gateway_lacks_promoted_field() -> None:
+    payload = _build_payload(boiler_device_id=None)
+    payload["semantic_coordinator"] = _FakeCoordinator(
+        {"zones": [], "dhw": {"state": {}, "config": {}}}
+    )
+    entities: list = []
+
+    asyncio.run(
+        binary_sensor_platform.async_setup_entry(
+            _FakeHass(payload), _FakeEntry("entry-1"), entities.extend
+        )
+    )
+
+    assert not any(
+        isinstance(entity, binary_sensor_platform.HelianthusDhwOverrunBinarySensor)
+        for entity in entities
+    )

--- a/tests/test_climate_quickveto.py
+++ b/tests/test_climate_quickveto.py
@@ -226,6 +226,19 @@ def test_climate_write_omits_source_parameter() -> None:
     assert "source" not in client.calls[0]["variables"]["params"]
 
 
+def test_climate_promoted_metadata_preserves_false_and_source_label() -> None:
+    entity, _client, _coord = _make_entity(preset="manual")
+    entity.coordinator.data["zones"][0]["config"].update(
+        {"source_label": "Zone 1", "operation_mode_changeable": False}
+    )
+
+    attrs = entity.extra_state_attributes
+
+    assert attrs["source_label"] == "Zone 1"
+    assert attrs["operation_mode_changeable"] is False
+    assert entity._attr_unique_id == "entry-1-zone-zone-1"
+
+
 def test_climate_write_fails_closed_when_admission_untrusted() -> None:
     entity, client, _coord = _make_entity(preset="manual")
     entity._status_coordinator.data["admission"]["trusted"] = False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -50,6 +50,7 @@ from custom_components.helianthus.coordinator import (
     QUERY_FM5,
     QUERY_RADIO_DEVICES,
     QUERY_SEMANTIC,
+    QUERY_SEMANTIC_PROMOTED,
     QUERY_SEMANTIC_NO_HOLIDAY,
     QUERY_SEMANTIC_NO_QV,
     QUERY_SEMANTIC_LEGACY,
@@ -58,6 +59,7 @@ from custom_components.helianthus.coordinator import (
     QUERY_STATUS_MINIMAL,
     QUERY_STATUS_LEGACY,
     QUERY_SYSTEM,
+    QUERY_SYSTEM_GATEWAY_METADATA,
     UpdateFailed,
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
@@ -729,7 +731,7 @@ def test_system_query_missing_field_falls_back_to_empty_payload() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    assert data == {"state": {}, "config": {}, "properties": {}}
+    assert data == {"state": {}, "config": {}, "properties": {}, "metadata": {}}
     assert client.calls[0] == QUERY_SYSTEM
 
 
@@ -999,12 +1001,15 @@ def test_semantic_full_query_succeeds() -> None:
 
     assert len(result["zones"]) == 1
     assert result["zones"][0]["config"]["quick_veto"] is False
-    assert client.calls == [QUERY_SEMANTIC]
+    assert client.calls == [QUERY_SEMANTIC_PROMOTED]
 
 
 def test_semantic_falls_back_to_no_holiday() -> None:
     client = _ScriptedClient(
         [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
+            ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
             ),
@@ -1016,14 +1021,17 @@ def test_semantic_falls_back_to_no_holiday() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert len(result["zones"]) == 1
-    assert client.calls == [QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY]
+    assert client.calls == [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY]
 
 
 def test_semantic_falls_back_to_no_qv() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
+            ),
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
@@ -1036,14 +1044,22 @@ def test_semantic_falls_back_to_no_qv() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert len(result["zones"]) == 1
-    assert client.calls == [QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY, QUERY_SEMANTIC_NO_QV]
+    assert client.calls == [
+        QUERY_SEMANTIC_PROMOTED,
+        QUERY_SEMANTIC,
+        QUERY_SEMANTIC_NO_HOLIDAY,
+        QUERY_SEMANTIC_NO_QV,
+    ]
 
 
 def test_semantic_falls_back_to_legacy() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
+                [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
+            ),
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
@@ -1063,7 +1079,13 @@ def test_semantic_falls_back_to_legacy() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert len(result["zones"]) == 1
-    assert client.calls == [QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY, QUERY_SEMANTIC_NO_QV, QUERY_SEMANTIC_LEGACY]
+    assert client.calls == [
+        QUERY_SEMANTIC_PROMOTED,
+        QUERY_SEMANTIC,
+        QUERY_SEMANTIC_NO_HOLIDAY,
+        QUERY_SEMANTIC_NO_QV,
+        QUERY_SEMANTIC_LEGACY,
+    ]
 
 
 def test_semantic_returns_empty_on_zones_missing() -> None:
@@ -1079,3 +1101,93 @@ def test_semantic_returns_empty_on_zones_missing() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert result == {"zones": [], "dhw": None}
+
+
+def test_semantic_missing_promoted_fields_preserves_existing_zone_and_dhw_payload() -> None:
+    payload = _semantic_payload()
+    payload["dhw"] = {"state": {"current_temp_c": 0.0}, "config": {"target_temp_c": 0.0}}
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
+            ),
+            payload,
+        ]
+    )
+    coordinator = _build_semantic_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result == payload
+    assert client.calls == [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC]
+
+
+def test_promoted_semantic_queries_cover_all_public_leaves_without_protocol_leaks() -> None:
+    """Keep the 18-leaf MSP-09C contract at existing public query roots only."""
+    semantic_paths = {
+        "/dhw/operating_mode": "operating_mode",
+        "/dhw/operation_mode_changeable": "operation_mode_changeable",
+        "/dhw/overrun_active": "overrun_active",
+        "/dhw/target_temperature_c": "target_temp_c",
+        "/dhw/temperature_c": "current_temp_c",
+        "/system/gateway_brand": "gateway_brand",
+        "/system/gateway_vendor": "gateway_vendor",
+        "/system/outside_air_temperature_c": "outdoor_temperature",
+        "/zones/zone_1/name": "source_label",
+        "/zones/zone_1/operating_mode": "operating_mode",
+        "/zones/zone_1/operation_mode_changeable": "operation_mode_changeable",
+        "/zones/zone_1/room_temperature_c": "current_temp_c",
+        "/zones/zone_1/target_temperature_c": "target_temp_c",
+        "/zones/zone_2/name": "source_label",
+        "/zones/zone_2/operating_mode": "operating_mode",
+        "/zones/zone_2/operation_mode_changeable": "operation_mode_changeable",
+        "/zones/zone_2/room_temperature_c": "current_temp_c",
+        "/zones/zone_2/target_temperature_c": "target_temp_c",
+    }
+
+    assert len(semantic_paths) == 18
+    public_queries = "\n".join([QUERY_SEMANTIC_PROMOTED, QUERY_SYSTEM, QUERY_SYSTEM_GATEWAY_METADATA])
+    assert all(field in public_queries for field in semantic_paths.values())
+    assert all(
+        forbidden not in public_queries
+        for forbidden in (
+            "candidate_id",
+            "candidate_ref",
+            "remote_ski",
+            "ship_id",
+            "device_address",
+            "entity_address",
+            "feature_address",
+            "raw_value",
+            "ebus_selector",
+        )
+    )
+
+
+def test_system_gateway_metadata_is_optional_and_preserves_existing_system_payload() -> None:
+    payload = {
+        "system": {
+            "state": {"outdoor_temperature": 0.0},
+            "config": {"max_room_humidity": 0},
+            "properties": {"system_scheme": 0},
+        }
+    }
+    client = _ScriptedClient(
+        [
+            payload,
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "gateway_brand" on type "System".'}]
+            ),
+            {},
+            {},
+        ]
+    )
+    coordinator = _build_system_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result["state"] == {"outdoor_temperature": 0.0}
+    assert result["config"] == {"max_room_humidity": 0}
+    assert result["properties"] == {"system_scheme": 0}
+    assert result["metadata"] == {}
+    assert client.calls[:2] == [QUERY_SYSTEM, QUERY_SYSTEM_GATEWAY_METADATA]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -257,6 +257,7 @@ def _build_payload() -> tuple[dict, _FakeCoordinator, _FakeClient]:
                 "system_scheme": 3,
                 "module_configuration_vr71": 1,
             },
+            "metadata": {"gateway_brand": "Helianthus", "gateway_vendor": "Gateway Vendor"},
         }
     )
     client = _FakeClient()
@@ -313,6 +314,11 @@ def test_system_sensor_entities_attach_to_basv2_device() -> None:
     assert scheme.native_value == 3
     assert scheme._attr_entity_category == sensor_platform.EntityCategory.DIAGNOSTIC
     assert pressure.device_info["identifiers"] == {payload["regulator_device_id"]}
+    assert pressure.extra_state_attributes == {
+        "gateway_brand": "Helianthus",
+        "gateway_vendor": "Gateway Vendor",
+    }
+    assert pressure._attr_unique_id == "entry-1-system-sensor-system_water_pressure"
 
 
 def test_system_binary_sensors_expose_maintenance_and_adaptive_flags() -> None:

--- a/tests/test_water_heater_admission.py
+++ b/tests/test_water_heater_admission.py
@@ -147,6 +147,22 @@ def test_water_heater_write_omits_source_parameter() -> None:
     assert "source" not in client.calls[0]["variables"]["params"]
 
 
+def test_water_heater_promoted_metadata_preserves_false_zero_and_nil() -> None:
+    entity, _client = _make_entity()
+    entity.coordinator.data["dhw"] = {
+        "state": {"current_temp_c": 0.0, "overrun_active": False},
+        "config": {"target_temp_c": 0.0, "operation_mode_changeable": False},
+    }
+
+    assert entity.current_temperature == 0.0
+    assert entity.target_temperature == 0.0
+    assert entity.extra_state_attributes["operation_mode_changeable"] is False
+    assert entity.extra_state_attributes["overrun_active"] is False
+    entity.coordinator.data["dhw"]["state"]["overrun_active"] = None
+    assert entity.extra_state_attributes["overrun_active"] is None
+    assert entity._attr_unique_id == "entry-1-dhw"
+
+
 def test_water_heater_write_fails_closed_when_admission_untrusted() -> None:
     entity, client = _make_entity(admission_trusted=False)
 


### PR DESCRIPTION
Closes #222

## Summary
- query the 18 promoted semantic leaves with backward-compatible fallbacks
- enrich existing climate, water-heater, and system entities without changing unique IDs
- add one read-only DHW overrun sensor only when the promoted field exists
- keep gateway metadata as attributes and exclude raw protocol identity

## Validation
- `./scripts/ci_local.sh`: 333 passed
- gateway parity gate: PASS
- post-parity adoption: 50 passed
- private IPv4 gate: PASS

Docs gate: Project-Helianthus/helianthus-docs-ebus#423 (merged).
Depends on gateway #795 and #797 (merged).