### PR TITLE
Preserve validated zone parents across sparse radio inventory

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -715,6 +715,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .zone_parent import (
         build_zone_parent_device_ids,
         radio_mappings_by_zone_id,
+        resolve_retained_parent_bindings,
         should_reload_zone_parent_state,
         zone_ids_by_climate_unique_id,
     )
@@ -1874,9 +1875,61 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         initial_radio_payload,
         regulator_device,
     )
-    retained_zone_parent_ids = existing_zone_parent_device_ids(initial_zones)
-    retained_zone_parent_ids.update(initial_live_parent_ids)
-    retained_zone_parent_mappings = radio_mappings_by_zone_id(initial_zones)
+    initial_mappings = radio_mappings_by_zone_id(initial_zones)
+    binding_key = "zone_parent_bindings_v1"
+    retained_zone_parent_ids, retained_zone_parent_mappings, normalized_bindings = (
+        resolve_retained_parent_bindings(
+            existing_zone_parent_device_ids(initial_zones),
+            entry.data.get(binding_key),
+            current_mappings=initial_mappings,
+            allow_registry_bootstrap=binding_key not in entry.data,
+        )
+    )
+    for zone_id, parent_id in initial_live_parent_ids.items():
+        mapping = initial_mappings.get(zone_id)
+        if mapping is None:
+            continue
+        retained_zone_parent_ids[zone_id] = parent_id
+        retained_zone_parent_mappings[zone_id] = mapping
+        normalized_bindings[zone_id] = {
+            "identifier": parent_id[1],
+            "mapping": mapping,
+        }
+
+    def persist_retained_zone_parent_bindings() -> None:
+        if entry.data.get(binding_key) == normalized_bindings:
+            return
+        updated_data = dict(entry.data)
+        updated_data[binding_key] = dict(normalized_bindings)
+        hass.config_entries.async_update_entry(entry, data=updated_data)
+
+    persist_retained_zone_parent_bindings()
+
+    def adopt_current_live_parent_bindings() -> None:
+        payload = semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
+        zones = [zone for zone in (payload.get("zones", []) or []) if isinstance(zone, dict)]
+        radio_payload = radio_coordinator.data if isinstance(radio_coordinator.data, dict) else None
+        live_parent_ids, _ = build_zone_parent_device_ids(
+            entry.entry_id,
+            zones,
+            radio_payload,
+            regulator_device,
+        )
+        mappings = radio_mappings_by_zone_id(zones)
+        changed = False
+        for zone_id, parent_id in live_parent_ids.items():
+            mapping = mappings.get(zone_id)
+            if mapping is None:
+                continue
+            binding = {"identifier": parent_id[1], "mapping": mapping}
+            if normalized_bindings.get(zone_id) == binding:
+                continue
+            retained_zone_parent_ids[zone_id] = parent_id
+            retained_zone_parent_mappings[zone_id] = mapping
+            normalized_bindings[zone_id] = binding
+            changed = True
+        if changed:
+            persist_retained_zone_parent_bindings()
 
     def current_zone_parent_device_ids() -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
         payload = semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
@@ -1889,6 +1942,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             regulator_device,
             existing_parent_device_ids=retained_zone_parent_ids,
             existing_parent_mappings=retained_zone_parent_mappings,
+            allow_existing_parent_fallback=(
+                isinstance(radio_payload, dict)
+                and radio_payload.get("inventory_complete") is False
+            ),
         )
 
     zone_parent_device_ids, unresolved_zone_ids = current_zone_parent_device_ids()
@@ -2029,6 +2086,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         }
         has_new_zones = bool(current_zone_ids - known_zones)
         has_new_dhw = dhw is not None and not known_has_dhw
+        adopt_current_live_parent_bindings()
         current_zone_parent_ids, unresolved = current_zone_parent_device_ids()
         if should_reload_zone_parent_state(
             zone_parent_device_ids,
@@ -2069,6 +2127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "radio update",
             )
         current_keys = exportable_radio_bus_keys(radio_devices)
+        adopt_current_live_parent_bindings()
         current_zone_parent_ids, unresolved = current_zone_parent_device_ids()
         if should_reload_zone_parent_state(
             zone_parent_device_ids,

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -710,10 +710,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         resolve_boiler_via_device_id,
         should_export_radio_device,
         stable_bus_identity_model,
-        zone_identifier,
     )
     from .subscriptions import start_subscriptions
-    from .zone_parent import build_zone_parent_device_ids, should_reload_zone_parent_state
+    from .zone_parent import (
+        build_zone_parent_device_ids,
+        should_reload_zone_parent_state,
+        zone_ids_by_climate_unique_id,
+    )
 
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
@@ -1837,12 +1840,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def existing_zone_parent_device_ids(zones: list[dict]) -> dict[str, tuple[str, str]]:
         """Recover validated radio parents from existing climate registry entries."""
-        climate_unique_ids = {
-            str(zone.get("id")): zone_identifier(entry.entry_id, str(zone.get("id")))[1]
-            for zone in zones
-            if zone.get("id") is not None
-        }
-        zone_ids_by_unique_id = {unique_id: zone_id for zone_id, unique_id in climate_unique_ids.items()}
+        zone_ids_by_unique_id = zone_ids_by_climate_unique_id(entry.entry_id, zones)
         radio_identifier_prefix = f"{entry.entry_id}-radio-"
         existing: dict[str, tuple[str, str]] = {}
         for entity_entry in _entry_entities():

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -714,6 +714,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .subscriptions import start_subscriptions
     from .zone_parent import (
         build_zone_parent_device_ids,
+        radio_mappings_by_zone_id,
         should_reload_zone_parent_state,
         zone_ids_by_climate_unique_id,
     )
@@ -1856,6 +1857,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     break
         return existing
 
+    initial_semantic_payload = (
+        semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
+    )
+    initial_zones = [
+        zone
+        for zone in (initial_semantic_payload.get("zones", []) or [])
+        if isinstance(zone, dict)
+    ]
+    initial_radio_payload = (
+        radio_coordinator.data if isinstance(radio_coordinator.data, dict) else None
+    )
+    initial_live_parent_ids, _ = build_zone_parent_device_ids(
+        entry.entry_id,
+        initial_zones,
+        initial_radio_payload,
+        regulator_device,
+    )
+    retained_zone_parent_ids = existing_zone_parent_device_ids(initial_zones)
+    retained_zone_parent_ids.update(initial_live_parent_ids)
+    retained_zone_parent_mappings = radio_mappings_by_zone_id(initial_zones)
+
     def current_zone_parent_device_ids() -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
         payload = semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
         zones = [zone for zone in (payload.get("zones", []) or []) if isinstance(zone, dict)]
@@ -1865,7 +1887,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             zones,
             radio_payload,
             regulator_device,
-            existing_parent_device_ids=existing_zone_parent_device_ids(zones),
+            existing_parent_device_ids=retained_zone_parent_ids,
+            existing_parent_mappings=retained_zone_parent_mappings,
         )
 
     zone_parent_device_ids, unresolved_zone_ids = current_zone_parent_device_ids()

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -1835,6 +1835,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         cleanup_obsolete_devices(reason)
         cleanup_ran = True
 
+    def existing_zone_parent_device_ids(zones: list[dict]) -> dict[str, tuple[str, str]]:
+        """Recover validated radio parents from existing climate registry entries."""
+        climate_unique_ids = {
+            str(zone.get("id")): zone_identifier(entry.entry_id, str(zone.get("id")))[1]
+            for zone in zones
+            if zone.get("id") is not None
+        }
+        zone_ids_by_unique_id = {unique_id: zone_id for zone_id, unique_id in climate_unique_ids.items()}
+        radio_identifier_prefix = f"{entry.entry_id}-radio-"
+        existing: dict[str, tuple[str, str]] = {}
+        for entity_entry in _entry_entities():
+            zone_id = zone_ids_by_unique_id.get(entity_entry.unique_id)
+            if zone_id is None or entity_entry.device_id is None:
+                continue
+            device_entry = device_registry.async_get(entity_entry.device_id)
+            if device_entry is None:
+                continue
+            for identifier in sorted(device_entry.identifiers):
+                if identifier[0] == DOMAIN and identifier[1].startswith(radio_identifier_prefix):
+                    existing[zone_id] = identifier
+                    break
+        return existing
+
     def current_zone_parent_device_ids() -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
         payload = semantic_coordinator.data if isinstance(semantic_coordinator.data, dict) else {}
         zones = [zone for zone in (payload.get("zones", []) or []) if isinstance(zone, dict)]
@@ -1844,6 +1867,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             zones,
             radio_payload,
             regulator_device,
+            existing_parent_device_ids=existing_zone_parent_device_ids(zones),
         )
 
     zone_parent_device_ids, unresolved_zone_ids = current_zone_parent_device_ids()

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -1881,8 +1881,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         resolve_retained_parent_bindings(
             existing_zone_parent_device_ids(initial_zones),
             entry.data.get(binding_key),
-            current_mappings=initial_mappings,
-            allow_registry_bootstrap=binding_key not in entry.data,
         )
     )
     for zone_id, parent_id in initial_live_parent_ids.items():

--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -999,7 +999,11 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._stale_cycles: dict[tuple[int, int], int] = {}
 
     async def _async_update_data(self) -> dict[str, Any]:
-        empty = {"radio_devices": [], "radio_zone_candidates": {}}
+        empty = {
+            "radio_devices": [],
+            "radio_zone_candidates": {},
+            "inventory_complete": False,
+        }
         missing_fields = [
             "radio_devices",
             "group",
@@ -1100,6 +1104,8 @@ class HelianthusRadioDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {
             "radio_devices": radio_devices,
             "radio_zone_candidates": candidates,
+            # The GraphQL list has no snapshot-completeness contract yet.
+            "inventory_complete": False,
         }
 
 

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -260,6 +260,8 @@ def build_zone_parent_device_ids(
     zones: list[dict[str, Any]],
     radio_payload: dict[str, Any] | None,
     regulator_device_id: tuple[str, str] | None,
+    *,
+    existing_parent_device_ids: dict[str, tuple[str, str]] | None = None,
 ) -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
     radio_devices = radio_devices_from_payload(radio_payload)
     radio_zone_candidates = radio_zone_candidates_from_payload(radio_payload)
@@ -284,6 +286,8 @@ def build_zone_parent_device_ids(
             radio_device_ids,
             regulator_device_id,
         )
+        if parent_device_id is None and existing_parent_device_ids is not None:
+            parent_device_id = existing_parent_device_ids.get(zone_id)
         if parent_device_id is None:
             unresolved_zone_ids.append(zone_id)
             continue

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -241,30 +241,6 @@ def select_zone_radio_candidate(
             return candidate
         return None
 
-    def pick_thermostat_fallback(
-        items: list[dict[str, Any]],
-        target_remote_addr: int,
-    ) -> dict[str, Any] | None:
-        ranked = sorted(
-            (
-                candidate
-                for candidate in items
-                if candidate.get("group") == 0x0A
-            ),
-            key=lambda candidate: (
-                abs(
-                    (
-                        candidate.get("remote_control_address")
-                        if isinstance(candidate.get("remote_control_address"), int)
-                        else 255
-                    )
-                    - target_remote_addr
-                ),
-                int(candidate.get("instance") or 0),
-            ),
-        )
-        return ranked[0] if ranked else None
-
     if room_temperature_zone_mapping == 1:
         return (
             pick(candidates, 0x09, 0)
@@ -279,8 +255,6 @@ def select_zone_radio_candidate(
             pick(candidates, 0x0A, remote_addr)
             or pick(global_candidates, 0x0A, remote_addr)
             or pick(global_candidates_any, 0x0A, remote_addr)
-            or pick_thermostat_fallback(candidates, remote_addr)
-            or pick_thermostat_fallback(global_candidates, remote_addr)
         )
     if room_temperature_zone_mapping in (0, None):
         return None

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .device_ids import build_radio_bus_key, radio_device_identifier
+from .device_ids import build_radio_bus_key, radio_device_identifier, zone_identifier
 
 
 def parse_optional_int(value: object | None) -> int | None:
@@ -58,6 +58,19 @@ def zone_instance_from_id(zone_id: object | None) -> int | None:
     if value <= 0:
         return None
     return value - 1
+
+
+def zone_ids_by_climate_unique_id(
+    entry_id: str,
+    zones: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Map existing climate unique IDs to canonical zone IDs."""
+    out: dict[str, str] = {}
+    for zone in zones:
+        normalized = normalize_zone_id(zone.get("id"))
+        if normalized is not None:
+            out[zone_identifier(entry_id, normalized)[1]] = normalized
+    return out
 
 
 def radio_devices_from_payload(radio_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -286,7 +299,11 @@ def build_zone_parent_device_ids(
             radio_device_ids,
             regulator_device_id,
         )
-        if parent_device_id is None and existing_parent_device_ids is not None:
+        if (
+            parent_device_id is None
+            and mapping in (1, 2, 3, 4)
+            and existing_parent_device_ids is not None
+        ):
             parent_device_id = existing_parent_device_ids.get(zone_id)
         if parent_device_id is None:
             unresolved_zone_ids.append(zone_id)

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -88,9 +88,6 @@ def radio_mappings_by_zone_id(zones: list[dict[str, Any]]) -> dict[str, int]:
 def resolve_retained_parent_bindings(
     registry_parent_ids: dict[str, tuple[str, str]],
     stored_bindings: object,
-    *,
-    current_mappings: dict[str, int],
-    allow_registry_bootstrap: bool,
 ) -> tuple[
     dict[str, tuple[str, str]],
     dict[str, int],
@@ -109,8 +106,6 @@ def resolve_retained_parent_bindings(
             parsed = parse_optional_int(raw.get("mapping"))
             if parsed in (1, 2, 3, 4):
                 mapping = parsed
-        elif allow_registry_bootstrap:
-            mapping = current_mappings.get(zone_id)
         if mapping not in (1, 2, 3, 4):
             continue
         parent_ids[zone_id] = parent_id

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -85,6 +85,40 @@ def radio_mappings_by_zone_id(zones: list[dict[str, Any]]) -> dict[str, int]:
     return out
 
 
+def resolve_retained_parent_bindings(
+    registry_parent_ids: dict[str, tuple[str, str]],
+    stored_bindings: object,
+    *,
+    current_mappings: dict[str, int],
+    allow_registry_bootstrap: bool,
+) -> tuple[
+    dict[str, tuple[str, str]],
+    dict[str, int],
+    dict[str, dict[str, object]],
+]:
+    """Validate persisted parent provenance or migrate pre-V1 live bindings."""
+    stored = stored_bindings if isinstance(stored_bindings, dict) else {}
+    parent_ids: dict[str, tuple[str, str]] = {}
+    parent_mappings: dict[str, int] = {}
+    normalized: dict[str, dict[str, object]] = {}
+    for zone_id, parent_id in registry_parent_ids.items():
+        raw = stored.get(zone_id)
+        identifier = parent_id[1]
+        mapping: int | None = None
+        if isinstance(raw, dict) and raw.get("identifier") == identifier:
+            parsed = parse_optional_int(raw.get("mapping"))
+            if parsed in (1, 2, 3, 4):
+                mapping = parsed
+        elif allow_registry_bootstrap:
+            mapping = current_mappings.get(zone_id)
+        if mapping not in (1, 2, 3, 4):
+            continue
+        parent_ids[zone_id] = parent_id
+        parent_mappings[zone_id] = mapping
+        normalized[zone_id] = {"identifier": identifier, "mapping": mapping}
+    return parent_ids, parent_mappings, normalized
+
+
 def radio_devices_from_payload(radio_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(radio_payload, dict):
         return []
@@ -288,6 +322,7 @@ def build_zone_parent_device_ids(
     *,
     existing_parent_device_ids: dict[str, tuple[str, str]] | None = None,
     existing_parent_mappings: dict[str, int] | None = None,
+    allow_existing_parent_fallback: bool = False,
 ) -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
     radio_devices = radio_devices_from_payload(radio_payload)
     radio_zone_candidates = radio_zone_candidates_from_payload(radio_payload)
@@ -318,6 +353,7 @@ def build_zone_parent_device_ids(
             and existing_parent_device_ids is not None
             and existing_parent_mappings is not None
             and existing_parent_mappings.get(zone_id) == mapping
+            and allow_existing_parent_fallback
         ):
             parent_device_id = existing_parent_device_ids.get(zone_id)
         if parent_device_id is None:

--- a/custom_components/helianthus/zone_parent.py
+++ b/custom_components/helianthus/zone_parent.py
@@ -73,6 +73,18 @@ def zone_ids_by_climate_unique_id(
     return out
 
 
+def radio_mappings_by_zone_id(zones: list[dict[str, Any]]) -> dict[str, int]:
+    """Return canonical zone IDs with an active radio-controller mapping."""
+    out: dict[str, int] = {}
+    for zone in zones:
+        zone_id = normalize_zone_id(zone.get("id"))
+        config = zone.get("config")
+        mapping = parse_optional_int(config.get("room_temperature_zone_mapping")) if isinstance(config, dict) else None
+        if zone_id is not None and mapping in (1, 2, 3, 4):
+            out[zone_id] = mapping
+    return out
+
+
 def radio_devices_from_payload(radio_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(radio_payload, dict):
         return []
@@ -275,6 +287,7 @@ def build_zone_parent_device_ids(
     regulator_device_id: tuple[str, str] | None,
     *,
     existing_parent_device_ids: dict[str, tuple[str, str]] | None = None,
+    existing_parent_mappings: dict[str, int] | None = None,
 ) -> tuple[dict[str, tuple[str, str]], tuple[str, ...]]:
     radio_devices = radio_devices_from_payload(radio_payload)
     radio_zone_candidates = radio_zone_candidates_from_payload(radio_payload)
@@ -303,6 +316,8 @@ def build_zone_parent_device_ids(
             parent_device_id is None
             and mapping in (1, 2, 3, 4)
             and existing_parent_device_ids is not None
+            and existing_parent_mappings is not None
+            and existing_parent_mappings.get(zone_id) == mapping
         ):
             parent_device_id = existing_parent_device_ids.get(zone_id)
         if parent_device_id is None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -773,6 +773,7 @@ def test_radio_query_builds_candidates_and_inventory_slot() -> None:
     assert 1 in data["radio_zone_candidates"]
     assert data["radio_zone_candidates"][1][0]["group"] == 0x09
     assert data["radio_zone_candidates"][1][0]["instance"] == 1
+    assert data["inventory_complete"] is False
     assert client.calls == [QUERY_RADIO_DEVICES]
 
 

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -644,6 +644,70 @@ def test_build_zone_parent_device_ids_keeps_nonmatching_disconnected_slots_unres
     assert unresolved == ("zone-1", "zone-2")
 
 
+def test_build_zone_parent_device_ids_preserves_existing_parent_when_inventory_is_sparse() -> None:
+    existing_parent = ("helianthus", "entry-1-radio-g09-i01")
+
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [
+            {
+                "id": "zone-1",
+                "name": "Parter",
+                "config": {"room_temperature_zone_mapping": 1},
+            }
+        ],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x0C,
+                    "instance": 1,
+                    "device_connected": True,
+                }
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids={"zone-1": existing_parent},
+    )
+
+    assert zone_parent_device_ids == {"zone-1": existing_parent}
+    assert unresolved == ()
+
+
+def test_build_zone_parent_device_ids_prefers_live_parent_over_existing_parent() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [
+            {
+                "id": "zone-2",
+                "name": "Etaj",
+                "config": {"room_temperature_zone_mapping": 2},
+            }
+        ],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x0A,
+                    "instance": 2,
+                    "radio_bus_key": "g0a-i02",
+                    "device_connected": True,
+                    "remote_control_address": 1,
+                }
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids={
+            "zone-2": ("helianthus", "entry-1-radio-g0a-i01")
+        },
+    )
+
+    assert zone_parent_device_ids == {
+        "zone-2": ("helianthus", "entry-1-radio-g0a-i02")
+    }
+    assert unresolved == ()
+
+
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
     payload = {
         "semantic_coordinator": _FakeCoordinator(

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -789,8 +789,6 @@ def test_retained_parent_binding_preserves_validating_mapping_across_reload() ->
     parent_ids, parent_mappings, normalized = resolve_retained_parent_bindings(
         registry_parent_ids,
         stored,
-        current_mappings={"zone-1": 2},
-        allow_registry_bootstrap=False,
     )
 
     assert parent_ids == registry_parent_ids
@@ -798,35 +796,17 @@ def test_retained_parent_binding_preserves_validating_mapping_across_reload() ->
     assert normalized == stored
 
 
-def test_registry_parent_bootstraps_once_then_requires_persisted_provenance() -> None:
+def test_registry_parent_without_persisted_provenance_is_rejected() -> None:
     registry_parent_ids = {
         "zone-1": ("helianthus", "entry-1-radio-g09-i01")
     }
 
-    bootstrapped = resolve_retained_parent_bindings(
+    missing = resolve_retained_parent_bindings(
         registry_parent_ids,
         None,
-        current_mappings={"zone-1": 1},
-        allow_registry_bootstrap=True,
-    )
-    rejected = resolve_retained_parent_bindings(
-        registry_parent_ids,
-        {},
-        current_mappings={"zone-1": 1},
-        allow_registry_bootstrap=False,
     )
 
-    assert bootstrapped == (
-        registry_parent_ids,
-        {"zone-1": 1},
-        {
-            "zone-1": {
-                "identifier": "entry-1-radio-g09-i01",
-                "mapping": 1,
-            }
-        },
-    )
-    assert rejected == ({}, {}, {})
+    assert missing == ({}, {}, {})
 
 
 def test_mapping_change_stays_unresolved_across_reload_until_live_reparent() -> None:
@@ -839,8 +819,6 @@ def test_mapping_change_stays_unresolved_across_reload_until_live_reparent() -> 
                 "mapping": 1,
             }
         },
-        current_mappings={"zone-1": 2},
-        allow_registry_bootstrap=False,
     )
     zones = [
         {"id": "zone-1", "config": {"room_temperature_zone_mapping": 2}}
@@ -893,8 +871,6 @@ def test_changed_thermostat_mapping_rejects_nearest_sparse_candidate() -> None:
                 "mapping": 2,
             }
         },
-        current_mappings={"zone-1": 3},
-        allow_registry_bootstrap=False,
     )
 
     resolved, unresolved = build_zone_parent_device_ids(

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -883,6 +883,44 @@ def test_mapping_change_stays_unresolved_across_reload_until_live_reparent() -> 
     assert live_unresolved == ()
 
 
+def test_changed_thermostat_mapping_rejects_nearest_sparse_candidate() -> None:
+    old_parent = ("helianthus", "entry-1-radio-g0a-i01")
+    parent_ids, parent_mappings, _ = resolve_retained_parent_bindings(
+        {"zone-1": old_parent},
+        {
+            "zone-1": {
+                "identifier": old_parent[1],
+                "mapping": 2,
+            }
+        },
+        current_mappings={"zone-1": 3},
+        allow_registry_bootstrap=False,
+    )
+
+    resolved, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [{"id": "zone-1", "config": {"room_temperature_zone_mapping": 3}}],
+        {
+            "radio_devices": [
+                {
+                    "group": 0x0A,
+                    "instance": 1,
+                    "device_connected": True,
+                    "remote_control_address": 1,
+                }
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids=parent_ids,
+        existing_parent_mappings=parent_mappings,
+        allow_existing_parent_fallback=True,
+    )
+
+    assert resolved == {}
+    assert unresolved == ("zone-1",)
+
+
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:
     payload = {
         "semantic_coordinator": _FakeCoordinator(

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -669,6 +669,7 @@ def test_build_zone_parent_device_ids_preserves_existing_parent_when_inventory_i
         },
         ("helianthus", "entry-1-bus-BASV-15"),
         existing_parent_device_ids={"zone-1": existing_parent},
+        existing_parent_mappings={"zone-1": 1},
     )
 
     assert zone_parent_device_ids == {"zone-1": existing_parent}
@@ -701,6 +702,7 @@ def test_build_zone_parent_device_ids_prefers_live_parent_over_existing_parent()
         existing_parent_device_ids={
             "zone-2": ("helianthus", "entry-1-radio-g0a-i01")
         },
+        existing_parent_mappings={"zone-2": 2},
     )
 
     assert zone_parent_device_ids == {
@@ -728,6 +730,23 @@ def test_existing_radio_parent_does_not_override_nonradio_mapping() -> None:
         existing_parent_device_ids={
             "zone-1": ("helianthus", "entry-1-radio-g09-i01")
         },
+        existing_parent_mappings={"zone-1": 1},
+    )
+
+    assert zone_parent_device_ids == {}
+    assert unresolved == ("zone-1",)
+
+
+def test_existing_radio_parent_is_rejected_after_radio_mapping_changes() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [{"id": "zone-1", "config": {"room_temperature_zone_mapping": 2}}],
+        {"radio_devices": [], "radio_zone_candidates": {}},
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids={
+            "zone-1": ("helianthus", "entry-1-radio-g09-i01")
+        },
+        existing_parent_mappings={"zone-1": 1},
     )
 
     assert zone_parent_device_ids == {}

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -151,6 +151,7 @@ from custom_components.helianthus.const import DOMAIN
 from custom_components.helianthus.device_ids import radio_device_identifier
 from custom_components.helianthus.zone_parent import (
     build_zone_parent_device_ids,
+    resolve_retained_parent_bindings,
     should_reload_zone_parent_state,
     zone_ids_by_climate_unique_id,
 )
@@ -670,6 +671,7 @@ def test_build_zone_parent_device_ids_preserves_existing_parent_when_inventory_i
         ("helianthus", "entry-1-bus-BASV-15"),
         existing_parent_device_ids={"zone-1": existing_parent},
         existing_parent_mappings={"zone-1": 1},
+        allow_existing_parent_fallback=True,
     )
 
     assert zone_parent_device_ids == {"zone-1": existing_parent}
@@ -703,6 +705,7 @@ def test_build_zone_parent_device_ids_prefers_live_parent_over_existing_parent()
             "zone-2": ("helianthus", "entry-1-radio-g0a-i01")
         },
         existing_parent_mappings={"zone-2": 2},
+        allow_existing_parent_fallback=True,
     )
 
     assert zone_parent_device_ids == {
@@ -731,6 +734,7 @@ def test_existing_radio_parent_does_not_override_nonradio_mapping() -> None:
             "zone-1": ("helianthus", "entry-1-radio-g09-i01")
         },
         existing_parent_mappings={"zone-1": 1},
+        allow_existing_parent_fallback=True,
     )
 
     assert zone_parent_device_ids == {}
@@ -747,10 +751,136 @@ def test_existing_radio_parent_is_rejected_after_radio_mapping_changes() -> None
             "zone-1": ("helianthus", "entry-1-radio-g09-i01")
         },
         existing_parent_mappings={"zone-1": 1},
+        allow_existing_parent_fallback=True,
     )
 
     assert zone_parent_device_ids == {}
     assert unresolved == ("zone-1",)
+
+
+def test_complete_inventory_rejects_retained_parent_without_live_match() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [{"id": "zone-1", "config": {"room_temperature_zone_mapping": 1}}],
+        {"radio_devices": [], "radio_zone_candidates": {}},
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids={
+            "zone-1": ("helianthus", "entry-1-radio-g09-i01")
+        },
+        existing_parent_mappings={"zone-1": 1},
+        allow_existing_parent_fallback=False,
+    )
+
+    assert zone_parent_device_ids == {}
+    assert unresolved == ("zone-1",)
+
+
+def test_retained_parent_binding_preserves_validating_mapping_across_reload() -> None:
+    registry_parent_ids = {
+        "zone-1": ("helianthus", "entry-1-radio-g09-i01")
+    }
+    stored = {
+        "zone-1": {
+            "identifier": "entry-1-radio-g09-i01",
+            "mapping": 1,
+        }
+    }
+
+    parent_ids, parent_mappings, normalized = resolve_retained_parent_bindings(
+        registry_parent_ids,
+        stored,
+        current_mappings={"zone-1": 2},
+        allow_registry_bootstrap=False,
+    )
+
+    assert parent_ids == registry_parent_ids
+    assert parent_mappings == {"zone-1": 1}
+    assert normalized == stored
+
+
+def test_registry_parent_bootstraps_once_then_requires_persisted_provenance() -> None:
+    registry_parent_ids = {
+        "zone-1": ("helianthus", "entry-1-radio-g09-i01")
+    }
+
+    bootstrapped = resolve_retained_parent_bindings(
+        registry_parent_ids,
+        None,
+        current_mappings={"zone-1": 1},
+        allow_registry_bootstrap=True,
+    )
+    rejected = resolve_retained_parent_bindings(
+        registry_parent_ids,
+        {},
+        current_mappings={"zone-1": 1},
+        allow_registry_bootstrap=False,
+    )
+
+    assert bootstrapped == (
+        registry_parent_ids,
+        {"zone-1": 1},
+        {
+            "zone-1": {
+                "identifier": "entry-1-radio-g09-i01",
+                "mapping": 1,
+            }
+        },
+    )
+    assert rejected == ({}, {}, {})
+
+
+def test_mapping_change_stays_unresolved_across_reload_until_live_reparent() -> None:
+    old_parent = ("helianthus", "entry-1-radio-g09-i01")
+    parent_ids, parent_mappings, _ = resolve_retained_parent_bindings(
+        {"zone-1": old_parent},
+        {
+            "zone-1": {
+                "identifier": old_parent[1],
+                "mapping": 1,
+            }
+        },
+        current_mappings={"zone-1": 2},
+        allow_registry_bootstrap=False,
+    )
+    zones = [
+        {"id": "zone-1", "config": {"room_temperature_zone_mapping": 2}}
+    ]
+
+    sparse_ids, sparse_unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        zones,
+        {"radio_devices": [], "radio_zone_candidates": {}},
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids=parent_ids,
+        existing_parent_mappings=parent_mappings,
+        allow_existing_parent_fallback=True,
+    )
+    live_ids, live_unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        zones,
+        {
+            "radio_devices": [
+                {
+                    "group": 0x0A,
+                    "instance": 2,
+                    "device_connected": True,
+                    "remote_control_address": 1,
+                }
+            ],
+            "radio_zone_candidates": {},
+        },
+        ("helianthus", "entry-1-bus-BASV-15"),
+        existing_parent_device_ids=parent_ids,
+        existing_parent_mappings=parent_mappings,
+        allow_existing_parent_fallback=True,
+    )
+
+    assert sparse_ids == {}
+    assert sparse_unresolved == ("zone-1",)
+    assert live_ids == {
+        "zone-1": ("helianthus", "entry-1-radio-g0a-i02")
+    }
+    assert live_unresolved == ()
 
 
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:

--- a/tests/test_zone_valve.py
+++ b/tests/test_zone_valve.py
@@ -152,6 +152,7 @@ from custom_components.helianthus.device_ids import radio_device_identifier
 from custom_components.helianthus.zone_parent import (
     build_zone_parent_device_ids,
     should_reload_zone_parent_state,
+    zone_ids_by_climate_unique_id,
 )
 
 
@@ -706,6 +707,31 @@ def test_build_zone_parent_device_ids_prefers_live_parent_over_existing_parent()
         "zone-2": ("helianthus", "entry-1-radio-g0a-i02")
     }
     assert unresolved == ()
+
+
+def test_zone_parent_registry_keys_normalize_numeric_zone_ids() -> None:
+    assert zone_ids_by_climate_unique_id(
+        "entry-1",
+        [{"id": "1"}, {"id": "zone-2"}, {"id": None}],
+    ) == {
+        "entry-1-zone-zone-1": "zone-1",
+        "entry-1-zone-zone-2": "zone-2",
+    }
+
+
+def test_existing_radio_parent_does_not_override_nonradio_mapping() -> None:
+    zone_parent_device_ids, unresolved = build_zone_parent_device_ids(
+        "entry-1",
+        [{"id": "zone-1", "config": {"room_temperature_zone_mapping": 0}}],
+        {"radio_devices": [], "radio_zone_candidates": {}},
+        None,
+        existing_parent_device_ids={
+            "zone-1": ("helianthus", "entry-1-radio-g09-i01")
+        },
+    )
+
+    assert zone_parent_device_ids == {}
+    assert unresolved == ("zone-1",)
 
 
 def test_climate_setup_skips_mapped_zone_without_precomputed_parent() -> None:


### PR DESCRIPTION
Closes #224

## Summary
- retain an existing validated radio parent when the live radio inventory is temporarily sparse
- keep live radio resolution authoritative when it becomes available
- leave new unresolved zones skipped rather than inventing a parent

## Validation
- RED observed locally: 2 regression tests failed before implementation
- `./scripts/ci_local.sh`: 335 tests + 50 post-parity tests passed
- `ruff check` on changed production modules passed
- `git diff --check` passed