### PR TITLE
Post-M9: consume candidate-free eeBUS AdminV1 status in Home Assistant

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from urllib.parse import urlsplit
 from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING
 
@@ -720,6 +721,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .eebus_admin_coordinator import (
         EEBusAdminV1Coordinator,
         EEBusAdminV1Lifecycle,
+        close_admin_session,
         create_admin_session,
     )
     from .zone_parent import (
@@ -991,8 +993,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         admin_credential = credential_for_config_entry({"data": entry.data})
         if admin_credential is not None:
+            parsed_graphql_url = urlsplit(graphql_url)
+            admin_origin = f"{parsed_graphql_url.scheme}://{parsed_graphql_url.netloc}"
             admin_session = create_admin_session(hass)
-            admin_origin = f"{transport}://{host}:{port}"
             admin_lifecycle = EEBusAdminV1Lifecycle(entry_id=entry.entry_id)
             admin_lifecycle.reconcile_binding(
                 origin=admin_origin,
@@ -1011,11 +1014,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 scan_interval,
             )
             await admin_coordinator.async_refresh()
-    except (TypeError, ValueError):
+    except Exception:
         _LOGGER.warning(
-            "Ignoring invalid eeBUS AdminV1 configuration for entry %s",
+            "eeBUS AdminV1 setup failed non-fatally for entry %s",
             entry.entry_id,
+            exc_info=True,
         )
+        if admin_session is not None:
+            await close_admin_session(admin_session)
+            admin_session = None
         admin_coordinator = None
 
     adapter_hw = adapter_info_coordinator.data
@@ -2346,6 +2353,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             admin_coordinator.lifecycle.store.clear()
         admin_session = None if data is None else data.get("eebus_admin_session")
         if admin_session is not None:
-            from .eebus_admin_coordinator import close_admin_session
             await close_admin_session(admin_session)
     return unload_ok

--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -14,6 +14,7 @@ from .admission import (
 )
 from .const import (
     CONF_DHW_SCHEDULE_HELPER,
+    CONF_EEBUS_ADMIN_CREDENTIAL,
     CONF_HOST_ALIASES,
     CONF_INSTANCE_GUID,
     CONF_PATH,
@@ -712,6 +713,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         stable_bus_identity_model,
     )
     from .subscriptions import start_subscriptions
+    from .eebus_admin import (
+        EEBusAdminV1Client,
+        credential_for_config_entry,
+    )
+    from .eebus_admin_coordinator import (
+        EEBusAdminV1Coordinator,
+        EEBusAdminV1Lifecycle,
+        create_admin_session,
+    )
     from .zone_parent import (
         build_zone_parent_device_ids,
         radio_mappings_by_zone_id,
@@ -972,6 +982,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await boiler_coordinator.async_config_entry_first_refresh()
     await schedule_coordinator.async_config_entry_first_refresh()
     await adapter_info_coordinator.async_config_entry_first_refresh()
+
+    # AdminV1 is an optional, isolated diagnostic consumer.  It must not use
+    # the GraphQL session or turn an unavailable admin boundary into setup
+    # failure for the primary integration.
+    admin_coordinator = None
+    admin_session = None
+    try:
+        admin_credential = credential_for_config_entry({"data": entry.data})
+        if admin_credential is not None:
+            admin_session = create_admin_session(hass)
+            admin_origin = f"{transport}://{host}:{port}"
+            admin_lifecycle = EEBusAdminV1Lifecycle(entry_id=entry.entry_id)
+            admin_lifecycle.reconcile_binding(
+                origin=admin_origin,
+                instance_guid=entry_instance_guid or entry.entry_id,
+                credential=admin_credential,
+            )
+            admin_coordinator = EEBusAdminV1Coordinator(
+                hass,
+                entry,
+                EEBusAdminV1Client(
+                    session=admin_session,
+                    base_url=admin_origin,
+                    credential=admin_credential,
+                ),
+                admin_lifecycle,
+                scan_interval,
+            )
+            await admin_coordinator.async_refresh()
+    except (TypeError, ValueError):
+        _LOGGER.warning(
+            "Ignoring invalid eeBUS AdminV1 configuration for entry %s",
+            entry.entry_id,
+        )
+        admin_coordinator = None
 
     adapter_hw = adapter_info_coordinator.data
     if isinstance(adapter_hw, dict) and adapter_hw.get("firmware_version"):
@@ -2242,6 +2287,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "boiler_coordinator": boiler_coordinator,
         "schedule_coordinator": schedule_coordinator,
         "adapter_info_coordinator": adapter_info_coordinator,
+        "eebus_admin_coordinator": admin_coordinator,
+        "eebus_admin_session": admin_session,
         "graphql_client": client,
         "subscription_task": subscription_task,
         "unsub_listeners": unsub_listeners,
@@ -2294,4 +2341,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     unsub()
                 except Exception:  # pragma: no cover - best-effort cleanup
                     pass
+        admin_coordinator = None if data is None else data.get("eebus_admin_coordinator")
+        if admin_coordinator is not None:
+            admin_coordinator.lifecycle.store.clear()
+        admin_session = None if data is None else data.get("eebus_admin_session")
+        if admin_session is not None:
+            from .eebus_admin_coordinator import close_admin_session
+            await close_admin_session(admin_session)
     return unload_ok

--- a/custom_components/helianthus/config_flow.py
+++ b/custom_components/helianthus/config_flow.py
@@ -15,9 +15,23 @@ except ImportError:  # pragma: no cover - older HA versions
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+try:
+    from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
+except ImportError:  # pragma: no cover - lightweight unit-test stubs
+    class TextSelectorType:
+        PASSWORD = "password"
+
+    class TextSelectorConfig:
+        def __init__(self, *, type: str) -> None:
+            self.type = type
+
+    class TextSelector:
+        def __init__(self, config: TextSelectorConfig) -> None:
+            self.config = config
 
 from .const import (
     CONF_HOST_ALIASES,
+    CONF_EEBUS_ADMIN_CREDENTIAL,
     CONF_INSTANCE_GUID,
     CONF_PATH,
     CONF_TRANSPORT,
@@ -81,7 +95,8 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self._async_finish_verified_entry(
                     verified_endpoint,
                     version=version,
-                    title=str(user_input[CONF_HOST]),
+                title=str(user_input[CONF_HOST]),
+                credential=user_input.get(CONF_EEBUS_ADMIN_CREDENTIAL),
                 )
 
             self._discovery = {
@@ -113,6 +128,9 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_PATH, default=default_path): str,
                 vol.Optional(CONF_TRANSPORT, default=default_transport): str,
                 vol.Optional(CONF_VERSION, default=default_version): str,
+                vol.Optional(CONF_EEBUS_ADMIN_CREDENTIAL): TextSelector(
+                    TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                ),
             }
         )
 
@@ -201,9 +219,17 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         version: str | None,
         title: str,
         host_aliases: list[str] | tuple[str, ...] | None = None,
+        credential: str | None = None,
     ) -> FlowResult:
         if verified_endpoint is None:
             return self.async_abort(reason="invalid_response")
+
+        if credential is not None:
+            from .eebus_admin import validate_machine_credential
+            try:
+                credential = validate_machine_credential(credential)
+            except ValueError:
+                return self.async_abort(reason="invalid_auth")
 
         def with_host_aliases(data: dict[str, Any], primary_host: str) -> dict[str, Any]:
             alias_source: Iterable[str] | None
@@ -241,6 +267,8 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 verified_endpoint.host,
             )
+            if credential is not None:
+                existing_data[CONF_EEBUS_ADMIN_CREDENTIAL] = credential
             if same_endpoint(existing_entry.data, verified_endpoint):
                 if (
                     existing_entry.unique_id != instance_guid
@@ -297,7 +325,52 @@ class HelianthusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             verified_endpoint.host,
         )
+        if credential is not None:
+            data[CONF_EEBUS_ADMIN_CREDENTIAL] = credential
         return self.async_create_entry(title=title, data=data)
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Replace only a supplied AdminV1 credential; never prefill it."""
+        entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            credential = user_input.get(CONF_EEBUS_ADMIN_CREDENTIAL)
+            if credential:
+                from .eebus_admin import validate_machine_credential
+                try:
+                    credential = validate_machine_credential(credential)
+                except ValueError:
+                    return self.async_show_form(step_id="reconfigure", data_schema=self._admin_credential_schema(), errors={"base": "invalid_auth"})
+                data = dict(entry.data)
+                data[CONF_EEBUS_ADMIN_CREDENTIAL] = credential
+                self.hass.config_entries.async_update_entry(entry, data=data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reconfigured")
+        return self.async_show_form(step_id="reconfigure", data_schema=self._admin_credential_schema())
+
+    async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Update the per-entry credential without exposing its stored value."""
+        entry = self._get_reauth_entry()
+        if user_input is not None:
+            credential = user_input.get(CONF_EEBUS_ADMIN_CREDENTIAL)
+            from .eebus_admin import validate_machine_credential
+            try:
+                credential = validate_machine_credential(credential)
+            except ValueError:
+                return self.async_show_form(step_id="reauth", data_schema=self._admin_credential_schema(), errors={"base": "invalid_auth"})
+            data = dict(entry.data)
+            data[CONF_EEBUS_ADMIN_CREDENTIAL] = credential
+            self.hass.config_entries.async_update_entry(entry, data=data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+        return self.async_show_form(step_id="reauth", data_schema=self._admin_credential_schema())
+
+    @staticmethod
+    def _admin_credential_schema() -> vol.Schema:
+        return vol.Schema({
+            vol.Required(CONF_EEBUS_ADMIN_CREDENTIAL): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.PASSWORD)
+            )
+        })
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo

--- a/custom_components/helianthus/const.py
+++ b/custom_components/helianthus/const.py
@@ -8,6 +8,7 @@ CONF_TRANSPORT = "transport"
 CONF_VERSION = "version"
 CONF_INSTANCE_GUID = "instance_guid"
 CONF_HOST_ALIASES = "host_aliases"
+CONF_EEBUS_ADMIN_CREDENTIAL = "eebus_admin_credential"
 
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_USE_SUBSCRIPTIONS = "use_subscriptions"

--- a/custom_components/helianthus/eebus_admin.py
+++ b/custom_components/helianthus/eebus_admin.py
@@ -1,0 +1,156 @@
+"""Pure, candidate-free client for the gateway eeBUS AdminV1 projection."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+CONTRACT = "helianthus.eebus.operator-admin.v1"
+MAX_BODY_BYTES = 64 * 1024
+_VIEWS = {"status", "trusted", "connected", "discovered"}
+
+
+class EEBusAdminV1Error(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class EEBusAdminV1ProtocolError(EEBusAdminV1Error):
+    def __init__(self) -> None:
+        super().__init__("invalid_response")
+
+
+@dataclass(frozen=True)
+class HAAdminEnvelopeV1:
+    projection_revision: int
+    data: dict[str, Any]
+
+
+def build_eebus_admin_base_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.query or parsed.fragment:
+        raise ValueError("invalid origin")
+    return urlunsplit((parsed.scheme, parsed.netloc, "/admin/eebus/v1", "", ""))
+
+def validate_machine_credential(value: str) -> str:
+    if not isinstance(value, str) or not 32 <= len(value) <= 256 or any(ord(c) < 0x21 or ord(c) > 0x7e for c in value):
+        raise ValueError("invalid credential")
+    return value
+
+def credential_for_config_entry(entry: dict[str, Any]) -> str | None:
+    value = entry.get("data", {}).get("eebus_admin_credential")
+    return None if value is None else validate_machine_credential(value)
+
+def with_config_entry_credential(data: dict[str, Any], credential: str) -> dict[str, Any]:
+    return {**data, "eebus_admin_credential": validate_machine_credential(credential)}
+
+def portal_eebus_action_path() -> str: return "/portal/eebus"
+def portal_eebus_url(origin: str) -> str:
+    parsed = urlsplit(origin)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.path not in {"", "/"} or parsed.query or parsed.fragment: raise ValueError("invalid origin")
+    return urlunsplit((parsed.scheme, parsed.netloc, portal_eebus_action_path(), "", ""))
+def admin_credential_form_field() -> dict[str, str]: return {"name": "eebus_admin_credential", "selector": "password"}
+@dataclass(frozen=True)
+class _CredentialHolder:
+    value: str
+    def __repr__(self) -> str: return "CredentialHolder()"
+    __str__ = __repr__
+def config_entry_machine_credential(entry: dict[str, Any]) -> _CredentialHolder:
+    value = credential_for_config_entry(entry)
+    if value is None: raise ValueError("invalid credential")
+    return _CredentialHolder(value)
+
+
+def _valid_status(data: dict[str, Any]) -> bool:
+    return set(data) <= {"listener", "discovery", "trusted_count", "connected_count", "discovered_count", "degraded_code"}
+
+
+def _valid_partners(view: str, data: dict[str, Any]) -> bool:
+    if set(data) != {"partners"} or not isinstance(data["partners"], list):
+        return False
+    allowed = {"partner_id", "view", "brand", "device_type", "model", "trust_state", "connection_state", "last_seen"}
+    return all(isinstance(row, dict) and set(row) <= allowed and row.get("view") == view for row in data["partners"])
+
+
+def parse_ha_admin_envelope(payload: Any, *, expected_view: str) -> HAAdminEnvelopeV1:
+    if expected_view not in _VIEWS or not isinstance(payload, dict) or set(payload) != {"contract", "projection_revision", "data", "error"}:
+        raise EEBusAdminV1ProtocolError()
+    if payload["contract"] != CONTRACT or payload["error"] is not None or not isinstance(payload["projection_revision"], int) or payload["projection_revision"] < 1 or not isinstance(payload["data"], dict):
+        raise EEBusAdminV1ProtocolError()
+    data = payload["data"]
+    if (expected_view == "status" and not _valid_status(data)) or (expected_view != "status" and not _valid_partners(expected_view, data)):
+        raise EEBusAdminV1ProtocolError()
+    return HAAdminEnvelopeV1(payload["projection_revision"], data)
+
+
+class EEBusAdminV1Client:
+    def __init__(self, *, session: Any, base_url: str, credential: str) -> None:
+        validate_machine_credential(credential)
+        self._session, self._base_url, self._credential = session, build_eebus_admin_base_url(base_url), credential
+
+    async def _get(self, suffix: str, view: str) -> HAAdminEnvelopeV1:
+        headers = {"Authorization": "Bearer " + self._credential, "Accept": "application/json"}
+        try:
+            async with self._session.get(self._base_url + suffix, headers=headers, allow_redirects=False) as response:
+                if getattr(response, "status", 200) != 200:
+                    raise EEBusAdminV1Error({401: "unauthenticated", 403: "forbidden", 409: "state_conflict", 503: "admin_boundary_unavailable"}.get(getattr(response, "status", 0), "invalid_response"))
+                if getattr(response, "content_length", None) is not None and response.content_length > MAX_BODY_BYTES:
+                    raise EEBusAdminV1ProtocolError()
+                content = getattr(response, "content", None)
+                raw = await content.read(MAX_BODY_BYTES + 1) if content is not None else b""
+                if len(raw) > MAX_BODY_BYTES:
+                    raise EEBusAdminV1ProtocolError()
+                payload = json.loads(raw) if raw else await response.json()
+        except EEBusAdminV1Error:
+            raise
+        except Exception:
+            raise EEBusAdminV1Error("invalid_response") from None
+        try:
+            return parse_ha_admin_envelope(payload, expected_view=view)
+        except EEBusAdminV1ProtocolError:
+            raise EEBusAdminV1Error("invalid_response") from None
+
+    async def fetch_status(self) -> HAAdminEnvelopeV1:
+        return await self._get("/status", "status")
+
+    async def fetch_partners(self, view: str) -> HAAdminEnvelopeV1:
+        if view not in _VIEWS - {"status"}:
+            raise ValueError("invalid view")
+        return await self._get("/partners?view=" + view, view)
+
+
+class HAAdminProjectionStore:
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, Any]] = {}
+
+    def accept(self, view: str, envelope: HAAdminEnvelopeV1) -> bool:
+        if view not in _VIEWS or not isinstance(envelope, HAAdminEnvelopeV1):
+            raise EEBusAdminV1ProtocolError()
+        changed = self._data.get(view) != envelope.data
+        if changed:
+            self._data[view] = envelope.data
+        return changed
+
+    def data_for(self, view: str) -> dict[str, Any] | None:
+        return self._data.get(view)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+
+class EEBusAdminV1Poller:
+    def __init__(self, client: Any, store: HAAdminProjectionStore) -> None:
+        self.client, self.store = client, store
+
+    async def async_poll(self) -> dict[str, bool]:
+        result: dict[str, bool] = {}
+        for view in ("status", "trusted", "connected", "discovered"):
+            try:
+                envelope = await (self.client.fetch_status() if view == "status" else self.client.fetch_partners(view))
+                result[view] = self.store.accept(view, envelope)
+            except EEBusAdminV1Error:
+                result[view] = False
+        return result

--- a/custom_components/helianthus/eebus_admin.py
+++ b/custom_components/helianthus/eebus_admin.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import copy
+import re
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
@@ -31,7 +33,9 @@ class HAAdminEnvelopeV1:
 
 def build_eebus_admin_base_url(value: str) -> str:
     parsed = urlsplit(value)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.query or parsed.fragment:
+    try: port = parsed.port
+    except ValueError: raise ValueError("invalid origin") from None
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.username or parsed.password or parsed.query or parsed.fragment or (port is not None and not 1 <= port <= 65535):
         raise ValueError("invalid origin")
     return urlunsplit((parsed.scheme, parsed.netloc, "/admin/eebus/v1", "", ""))
 
@@ -65,14 +69,16 @@ def config_entry_machine_credential(entry: dict[str, Any]) -> _CredentialHolder:
 
 
 def _valid_status(data: dict[str, Any]) -> bool:
-    return set(data) <= {"listener", "discovery", "trusted_count", "connected_count", "discovered_count", "degraded_code"}
+    required = {"listener", "discovery", "trusted_count", "connected_count", "discovered_count"}
+    if not required <= set(data) <= required | {"degraded_code"}: return False
+    return all(isinstance(data[k], str) and 0 < len(data[k]) <= 256 for k in ("listener", "discovery")) and all(isinstance(data[k], int) and not isinstance(data[k], bool) and 0 <= data[k] <= 65535 for k in required - {"listener", "discovery"}) and ("degraded_code" not in data or isinstance(data["degraded_code"], str) and len(data["degraded_code"]) <= 128)
 
 
 def _valid_partners(view: str, data: dict[str, Any]) -> bool:
     if set(data) != {"partners"} or not isinstance(data["partners"], list):
         return False
     allowed = {"partner_id", "view", "brand", "device_type", "model", "trust_state", "connection_state", "last_seen"}
-    return all(isinstance(row, dict) and set(row) <= allowed and row.get("view") == view for row in data["partners"])
+    return len(data["partners"]) <= 128 and all(isinstance(row, dict) and set(row) <= allowed and row.get("view") == view and isinstance(row.get("partner_id"), str) and re.fullmatch(r"ha-[0-9a-f]{32}", row["partner_id"]) and all(isinstance(v, str) and len(v) <= 256 for k, v in row.items() if k != "partner_id") for row in data["partners"])
 
 
 def parse_ha_admin_envelope(payload: Any, *, expected_view: str) -> HAAdminEnvelopeV1:
@@ -131,11 +137,12 @@ class HAAdminProjectionStore:
             raise EEBusAdminV1ProtocolError()
         changed = self._data.get(view) != envelope.data
         if changed:
-            self._data[view] = envelope.data
+            self._data[view] = copy.deepcopy(envelope.data)
         return changed
 
     def data_for(self, view: str) -> dict[str, Any] | None:
-        return self._data.get(view)
+        value = self._data.get(view)
+        return copy.deepcopy(value) if value is not None else None
 
     def clear(self) -> None:
         self._data.clear()

--- a/custom_components/helianthus/eebus_admin_coordinator.py
+++ b/custom_components/helianthus/eebus_admin_coordinator.py
@@ -22,6 +22,9 @@ from .eebus_admin import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_ADMIN_TIMEOUT_TOTAL_SECONDS = 15
+_ADMIN_TIMEOUT_CONNECT_SECONDS = 5
+_ADMIN_TIMEOUT_READ_SECONDS = 10
 
 class EEBusAdminV1Coordinator(DataUpdateCoordinator):
     """Separate, diagnostic-only AdminV1 refresh path.
@@ -35,6 +38,8 @@ class EEBusAdminV1Coordinator(DataUpdateCoordinator):
         self._entry = entry
         self._client = client
         self.lifecycle = lifecycle
+        self._reauth_binding_generation = lifecycle.binding_generation
+        self._reauth_started = False
 
     async def _async_update_data(self) -> dict[str, Any]:
         for view in ("status", "trusted", "connected", "discovered"):
@@ -59,6 +64,13 @@ class EEBusAdminV1Coordinator(DataUpdateCoordinator):
     async def _async_schedule_reauth(self) -> None:
         if not self.lifecycle.reauth_scheduled:
             return
+        generation = getattr(self.lifecycle, "binding_generation", 0)
+        if getattr(self, "_reauth_binding_generation", None) != generation:
+            self._reauth_binding_generation = generation
+            self._reauth_started = False
+        if getattr(self, "_reauth_started", False):
+            return
+        self._reauth_started = True
         result = self._entry.async_start_reauth(self.hass)
         if hasattr(result, "__await__"):
             await result
@@ -67,7 +79,15 @@ def create_admin_session(hass: Any) -> Any:
     """Never reuse the shared cookie-bearing GraphQL session."""
     if aiohttp is None:
         return None
-    return async_create_clientsession(hass, cookie_jar=aiohttp.DummyCookieJar())
+    return async_create_clientsession(
+        hass,
+        cookie_jar=aiohttp.DummyCookieJar(),
+        timeout=aiohttp.ClientTimeout(
+            total=_ADMIN_TIMEOUT_TOTAL_SECONDS,
+            connect=_ADMIN_TIMEOUT_CONNECT_SECONDS,
+            sock_read=_ADMIN_TIMEOUT_READ_SECONDS,
+        ),
+    )
 
 
 async def close_admin_session(session: Any) -> None:
@@ -87,10 +107,13 @@ def admin_device_info(origin: str) -> _Info:
 class EEBusAdminV1Lifecycle:
     def __init__(self, *, entry_id: str) -> None:
         self.entry_id, self.store, self._binding = entry_id, HAAdminProjectionStore(), None
+        self.binding_generation = 0
         self._failed: set[str] = set(); self.diagnostic_available = True; self.reauth_scheduled = False; self.graphql_setup_failed = False; self.unload_requested = False
     def reconcile_binding(self, *, origin: str, instance_guid: str, credential: str) -> None:
         binding = (origin, instance_guid, hashlib.sha256(credential.encode()).hexdigest())
-        if self._binding != binding: self.store.clear(); self._binding = binding
+        if self._binding != binding:
+            self.store.clear(); self._failed.clear(); self.reauth_scheduled = False
+            self._binding = binding; self.binding_generation += 1
     def note_view_success(self, view: str, data: dict[str, Any]) -> None:
         from .eebus_admin import parse_ha_admin_envelope, CONTRACT
         self.store.accept(view, parse_ha_admin_envelope({"contract": CONTRACT, "projection_revision": 1, "data": data, "error": None}, expected_view=view)); self._failed.discard(view); self.diagnostic_available = True

--- a/custom_components/helianthus/eebus_admin_coordinator.py
+++ b/custom_components/helianthus/eebus_admin_coordinator.py
@@ -1,7 +1,11 @@
 """HA-specific wiring for the isolated eeBUS AdminV1 projection."""
 from __future__ import annotations
+
+from datetime import timedelta
 from dataclasses import dataclass
+import hashlib
 from typing import Any
+
 try:
     import aiohttp
     from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -9,10 +13,54 @@ try:
 except (ModuleNotFoundError, ImportError):  # lightweight unit tests
     class DataUpdateCoordinator: pass
     aiohttp = None
-from .eebus_admin import EEBusAdminV1Error, HAAdminProjectionStore
+from .eebus_admin import (
+    EEBusAdminV1Client,
+    EEBusAdminV1Error,
+    HAAdminProjectionStore,
+    portal_eebus_url,
+)
 
 class EEBusAdminV1Coordinator(DataUpdateCoordinator):
-    pass
+    """Separate, diagnostic-only AdminV1 refresh path.
+
+    The coordinator deliberately keeps a last-known-good value for every view;
+    a failing view must never erase a healthy sibling view.
+    """
+
+    def __init__(self, hass: Any, entry: Any, client: EEBusAdminV1Client, lifecycle: "EEBusAdminV1Lifecycle", interval: int) -> None:
+        super().__init__(hass, None, name="eeBUS AdminV1", update_interval=timedelta(seconds=interval))
+        self._entry = entry
+        self._client = client
+        self.lifecycle = lifecycle
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        for view in ("status", "trusted", "connected", "discovered"):
+            try:
+                envelope = await (
+                    self._client.fetch_status()
+                    if view == "status"
+                    else self._client.fetch_partners(view)
+                )
+                self.lifecycle.store.accept(view, envelope)
+                self.lifecycle.note_view_success(view, envelope.data)
+            except EEBusAdminV1Error as error:
+                self.lifecycle.note_view_failure(view, error)
+                if error.code == "unauthenticated":
+                    await self._async_schedule_reauth()
+        return {
+            "status": self.lifecycle.store.data_for("status"),
+            "available": self.lifecycle.diagnostic_available,
+            "stale_views": frozenset(self.lifecycle._failed),
+        }
+
+    async def _async_schedule_reauth(self) -> None:
+        if not self.lifecycle.reauth_scheduled:
+            return
+        starter = getattr(self.hass.config_entries, "async_start_reauth", None)
+        if starter is not None:
+            result = starter(self._entry)
+            if hasattr(result, "__await__"):
+                await result
 
 def create_admin_session(hass: Any) -> Any:
     """Never reuse the shared cookie-bearing GraphQL session."""
@@ -20,21 +68,27 @@ def create_admin_session(hass: Any) -> Any:
         return None
     return async_create_clientsession(hass, cookie_jar=aiohttp.DummyCookieJar())
 
+
+async def close_admin_session(session: Any) -> None:
+    close = getattr(session, "close", None)
+    if close is not None:
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+
 @dataclass(frozen=True)
 class _Info:
     configuration_url: str
 
 def admin_device_info(origin: str) -> _Info:
-    from .eebus_admin import build_eebus_admin_base_url
-    base = build_eebus_admin_base_url(origin)
-    return _Info(base.split("/admin/eebus/v1")[0] + "/portal/eebus")
+    return _Info(portal_eebus_url(origin))
 
 class EEBusAdminV1Lifecycle:
     def __init__(self, *, entry_id: str) -> None:
         self.entry_id, self.store, self._binding = entry_id, HAAdminProjectionStore(), None
         self._failed: set[str] = set(); self.diagnostic_available = True; self.reauth_scheduled = False; self.graphql_setup_failed = False; self.unload_requested = False
     def reconcile_binding(self, *, origin: str, instance_guid: str, credential: str) -> None:
-        binding = (origin, instance_guid, credential)
+        binding = (origin, instance_guid, hashlib.sha256(credential.encode()).hexdigest())
         if self._binding != binding: self.store.clear(); self._binding = binding
     def note_view_success(self, view: str, data: dict[str, Any]) -> None:
         from .eebus_admin import parse_ha_admin_envelope, CONTRACT

--- a/custom_components/helianthus/eebus_admin_coordinator.py
+++ b/custom_components/helianthus/eebus_admin_coordinator.py
@@ -1,0 +1,44 @@
+"""HA-specific wiring for the isolated eeBUS AdminV1 projection."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+try:
+    import aiohttp
+    from homeassistant.helpers.aiohttp_client import async_create_clientsession
+    from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+except (ModuleNotFoundError, ImportError):  # lightweight unit tests
+    class DataUpdateCoordinator: pass
+    aiohttp = None
+from .eebus_admin import EEBusAdminV1Error, HAAdminProjectionStore
+
+class EEBusAdminV1Coordinator(DataUpdateCoordinator):
+    pass
+
+def create_admin_session(hass: Any) -> Any:
+    """Never reuse the shared cookie-bearing GraphQL session."""
+    if aiohttp is None:
+        return None
+    return async_create_clientsession(hass, cookie_jar=aiohttp.DummyCookieJar())
+
+@dataclass(frozen=True)
+class _Info:
+    configuration_url: str
+
+def admin_device_info(origin: str) -> _Info:
+    from .eebus_admin import build_eebus_admin_base_url
+    base = build_eebus_admin_base_url(origin)
+    return _Info(base.split("/admin/eebus/v1")[0] + "/portal/eebus")
+
+class EEBusAdminV1Lifecycle:
+    def __init__(self, *, entry_id: str) -> None:
+        self.entry_id, self.store, self._binding = entry_id, HAAdminProjectionStore(), None
+        self._failed: set[str] = set(); self.diagnostic_available = True; self.reauth_scheduled = False; self.graphql_setup_failed = False; self.unload_requested = False
+    def reconcile_binding(self, *, origin: str, instance_guid: str, credential: str) -> None:
+        binding = (origin, instance_guid, credential)
+        if self._binding != binding: self.store.clear(); self._binding = binding
+    def note_view_success(self, view: str, data: dict[str, Any]) -> None:
+        from .eebus_admin import parse_ha_admin_envelope, CONTRACT
+        self.store.accept(view, parse_ha_admin_envelope({"contract": CONTRACT, "projection_revision": 1, "data": data, "error": None}, expected_view=view)); self._failed.discard(view); self.diagnostic_available = True
+    def note_view_failure(self, view: str, error: EEBusAdminV1Error) -> None:
+        self._failed.add(view); self.reauth_scheduled |= error.code == "unauthenticated"; self.diagnostic_available = self._failed != {"status", "trusted", "connected", "discovered"}
+    def view_is_stale(self, view: str) -> bool: return view in self._failed

--- a/custom_components/helianthus/eebus_admin_coordinator.py
+++ b/custom_components/helianthus/eebus_admin_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 from dataclasses import dataclass
 import hashlib
+import logging
 from typing import Any
 
 try:
@@ -20,6 +21,8 @@ from .eebus_admin import (
     portal_eebus_url,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 class EEBusAdminV1Coordinator(DataUpdateCoordinator):
     """Separate, diagnostic-only AdminV1 refresh path.
 
@@ -28,7 +31,7 @@ class EEBusAdminV1Coordinator(DataUpdateCoordinator):
     """
 
     def __init__(self, hass: Any, entry: Any, client: EEBusAdminV1Client, lifecycle: "EEBusAdminV1Lifecycle", interval: int) -> None:
-        super().__init__(hass, None, name="eeBUS AdminV1", update_interval=timedelta(seconds=interval))
+        super().__init__(hass, _LOGGER, name="eeBUS AdminV1", update_interval=timedelta(seconds=interval))
         self._entry = entry
         self._client = client
         self.lifecycle = lifecycle
@@ -56,11 +59,9 @@ class EEBusAdminV1Coordinator(DataUpdateCoordinator):
     async def _async_schedule_reauth(self) -> None:
         if not self.lifecycle.reauth_scheduled:
             return
-        starter = getattr(self.hass.config_entries, "async_start_reauth", None)
-        if starter is not None:
-            result = starter(self._entry)
-            if hasattr(result, "__await__"):
-                await result
+        result = self._entry.async_start_reauth(self.hass)
+        if hasattr(result, "__await__"):
+            await result
 
 def create_admin_session(hass: Any) -> Any:
     """Never reuse the shared cookie-bearing GraphQL session."""

--- a/custom_components/helianthus/options_flow.py
+++ b/custom_components/helianthus/options_flow.py
@@ -51,4 +51,8 @@ class HelianthusOptionsFlow(config_entries.OptionsFlow):
             }
         )
 
-        return self.async_show_form(step_id="init", data_schema=schema)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            description_placeholders={"eebus_portal": "/portal/eebus"},
+        )

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -503,6 +503,10 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     manufacturer = data.get("regulator_manufacturer") or "Helianthus"
 
     sensors: list[SensorEntity] = []
+    admin_coordinator = data.get("eebus_admin_coordinator")
+    if admin_coordinator is not None:
+        origin = f"{entry.data.get('transport', 'http')}://{entry.data.get('host')}:{entry.data.get('port')}"
+        sensors.append(HelianthusEEBusAdminSensor(admin_coordinator, entry.entry_id, origin))
     seen_bus_keys: set[str] = set()
     for device in device_coordinator.data or []:
         if not has_bus_identity_evidence(device):
@@ -1069,6 +1073,36 @@ class HelianthusStatusSensor(CoordinatorEntity, SensorEntity):
         if not isinstance(status, dict):
             status = self._fallback_status
         return status.get(self._field.key)
+
+
+class HelianthusEEBusAdminSensor(CoordinatorEntity, SensorEntity):
+    """One scalar health diagnostic for the isolated eeBUS AdminV1 boundary."""
+
+    _attr_has_entity_name = True
+    _attr_name = "eeBUS Admin Available"
+    _attr_icon = "mdi:shield-check-outline"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, entry_id: str, origin: str) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._origin = origin
+        self._attr_unique_id = f"{entry_id}-eebus-admin-available"
+
+    @property
+    def native_value(self) -> bool:
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
+        return bool(data.get("available"))
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        from .eebus_admin import portal_eebus_url
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._entry_id}-eebus-admin")},
+            name="eeBUS Admin",
+            configuration_url=portal_eebus_url(self._origin),
+        )
 
 
 class HelianthusBoilerTemperatureSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/helianthus/sensor.py
+++ b/custom_components/helianthus/sensor.py
@@ -1090,9 +1090,25 @@ class HelianthusEEBusAdminSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{entry_id}-eebus-admin-available"
 
     @property
-    def native_value(self) -> bool:
+    def native_value(self) -> str:
         data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
-        return bool(data.get("available"))
+        status = data.get("status") if isinstance(data.get("status"), dict) else {}
+        return status.get("listener") if isinstance(status.get("listener"), str) else "unavailable"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
+        status = data.get("status") if isinstance(data.get("status"), dict) else {}
+        counts = {
+            key: status.get(key)
+            for key in ("trusted_count", "connected_count", "discovered_count")
+            if isinstance(status.get(key), int) and not isinstance(status.get(key), bool)
+        }
+        return {
+            "discovery": status.get("discovery") if isinstance(status.get("discovery"), str) else "unavailable",
+            **counts,
+            "fresh": bool(data.get("available")) and not bool(data.get("stale_views")),
+        }
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/helianthus/strings.json
+++ b/custom_components/helianthus/strings.json
@@ -9,13 +9,25 @@
           "port": "Port",
           "path": "GraphQL path",
           "transport": "Transport",
-          "version": "API version"
+          "version": "API version",
+          "eebus_admin_credential": "eeBUS Admin credential"
         },
         "data_description": {
           "path": "GraphQL endpoint path (default /graphql).",
           "transport": "Transport scheme (http/https).",
           "version": "Discovered API version (optional)."
         }
+      }
+      ,
+      "reconfigure": {
+        "title": "Update eeBUS Admin credential",
+        "description": "Enter a replacement credential. The stored credential is never shown.",
+        "data": {"eebus_admin_credential": "eeBUS Admin credential"}
+      },
+      "reauth": {
+        "title": "eeBUS Admin authentication required",
+        "description": "The gateway rejected the stored eeBUS Admin credential.",
+        "data": {"eebus_admin_credential": "eeBUS Admin credential"}
       }
     },
     "error": {
@@ -24,7 +36,8 @@
       "requires_gateway_upgrade": "The Helianthus gateway must be updated before this integration can bind to it.",
       "missing_instance_guid": "The Helianthus gateway did not expose a stable instance GUID.",
       "identity_mismatch": "Discovered identity did not match the verified Helianthus gateway.",
-      "unknown": "Unexpected error."
+      "unknown": "Unexpected error.",
+      "invalid_auth": "The eeBUS Admin credential is invalid."
     },
     "abort": {
       "already_configured": "This Helianthus endpoint is already configured.",
@@ -36,6 +49,19 @@
       "identity_mismatch": "Discovery TXT data did not match the verified Helianthus gateway identity.",
       "duplicate_instance_guid": "Another live Helianthus endpoint already claims this instance GUID. Automatic rebinding was refused.",
       "reconfigured": "The existing Helianthus entry was rebound to the rediscovered endpoint."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "eeBUS administration is available only in the gateway [Portal](/portal/eebus).",
+        "data": {
+          "scan_interval": "Scan interval",
+          "use_subscriptions": "Use subscriptions",
+          "zone_schedule_helpers": "Zone schedule helpers",
+          "dhw_schedule_helper": "DHW schedule helper"
+        }
+      }
     }
   }
 }

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -90,6 +90,30 @@ def test_admin_base_url_is_fixed_same_origin_and_has_no_user_path_escape() -> No
     for unsafe in ("gateway.example.test", "https://gateway.example.test/?next=x", "https://gateway.example.test/#token"):
         with pytest.raises(ValueError):
             admin.build_eebus_admin_base_url(unsafe)
+    for unsafe in ("https://user@gateway.example.test", "https://gateway.example.test:bad", "https://gateway.example.test:99999"):
+        with pytest.raises(ValueError):
+            admin.build_eebus_admin_base_url(unsafe)
+
+
+def test_status_and_partner_schemas_are_exactly_bounded_and_non_boolean() -> None:
+    admin = _admin_module()
+    status = {"listener": "ready", "discovery": "ready", "trusted_count": 1, "connected_count": 0, "discovered_count": 2}
+    assert _parsed(admin, "status", status).data == status
+    for invalid in ({"listener": "x"}, {**status, "trusted_count": True}, {**status, "listener": "x" * 257}):
+        with pytest.raises(admin.EEBusAdminV1ProtocolError): _parsed(admin, "status", invalid)
+    row = {"partner_id": "ha-" + "a" * 32, "view": "trusted", "brand": "b"}
+    assert _parsed(admin, "trusted", {"partners": [row]}).data == {"partners": [row]}
+    for bad in ({**row, "partner_id": "ha-not-valid"}, {**row, "view": "connected"}, {**row, "brand": "x" * 257}):
+        with pytest.raises(admin.EEBusAdminV1ProtocolError): _parsed(admin, "trusted", {"partners": [bad]})
+    with pytest.raises(admin.EEBusAdminV1ProtocolError): _parsed(admin, "trusted", {"partners": [row] * 129})
+
+
+def test_store_defensively_copies_input_and_output_data() -> None:
+    admin = _admin_module(); store = admin.HAAdminProjectionStore()
+    source = {"listener": "ready", "discovery": "ready"}
+    store.accept("status", _parsed(admin, "status", source))
+    source["listener"] = "mutated"; returned = store.data_for("status"); returned["listener"] = "mutated-again"
+    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
 
 
 def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_authority() -> None:

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -56,6 +56,10 @@ def _envelope(data: dict[str, Any], revision: int = 1) -> dict[str, Any]:
     }
 
 
+def _parsed(admin: Any, view: str, data: dict[str, Any], revision: int = 1) -> Any:
+    return admin.parse_ha_admin_envelope(_envelope(data, revision), expected_view=view)
+
+
 def test_admin_base_url_is_fixed_same_origin_and_has_no_user_path_escape() -> None:
     admin = _admin_module()
 
@@ -88,9 +92,13 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
         credential="entry-one-machine-credential",
     )
 
-    assert asyncio.run(client.fetch_status())["listener"] == "ready"
+    status = asyncio.run(client.fetch_status())
+    assert isinstance(status, admin.HAAdminEnvelopeV1)
+    assert status.data["listener"] == "ready"
     for view in ("trusted", "connected", "discovered"):
-        assert asyncio.run(client.fetch_partners(view)) == {"partners": []}
+        partners = asyncio.run(client.fetch_partners(view))
+        assert isinstance(partners, admin.HAAdminEnvelopeV1)
+        assert partners.data == {"partners": []}
     for forbidden in ("candidate", "raw", "spine", "unknown"):
         with pytest.raises(ValueError):
             asyncio.run(client.fetch_partners(forbidden))
@@ -109,9 +117,10 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
         assert "Referer" not in headers
 
 
-def test_strict_ha_envelope_rejects_owner_candidate_raw_and_unknown_fields() -> None:
+def test_strict_ha_envelope_has_one_typed_view_aware_path_and_rejects_owner_fields() -> None:
     admin = _admin_module()
-    accepted = admin.parse_ha_admin_envelope(_envelope({"partners": []}))
+    accepted = admin.parse_ha_admin_envelope(_envelope({"partners": []}), expected_view="trusted")
+    assert isinstance(accepted, admin.HAAdminEnvelopeV1)
     assert accepted.projection_revision == 1
     assert accepted.data == {"partners": []}
 
@@ -125,20 +134,73 @@ def test_strict_ha_envelope_rejects_owner_candidate_raw_and_unknown_fields() -> 
     ]
     for payload in invalid_payloads:
         with pytest.raises(admin.EEBusAdminV1ProtocolError):
-            admin.parse_ha_admin_envelope(payload)
+            admin.parse_ha_admin_envelope(payload, expected_view="status")
+
+
+def test_per_view_data_schema_rejects_non_ha_identity_candidate_raw_and_unknown_fields() -> None:
+    admin = _admin_module()
+    valid_status = {
+        "listener": "ready",
+        "discovery": "ready",
+        "trusted_count": 1,
+        "connected_count": 1,
+        "discovered_count": 1,
+        "degraded_code": "",
+    }
+    valid_partner = {
+        "partner_id": "ha-partner",
+        "view": "trusted",
+        "brand": "brand",
+        "device_type": "device",
+        "model": "model",
+        "trust_state": "trusted",
+        "connection_state": "connected",
+        "last_seen": "2026-08-14T12:00:00Z",
+    }
+    assert _parsed(admin, "status", valid_status).data == valid_status
+    assert _parsed(admin, "trusted", {"partners": [valid_partner]}).data == {"partners": [valid_partner]}
+
+    invalid_status = [
+        {**valid_status, "candidate_count": 1},
+        {**valid_status, "pairing_window": "open"},
+        {**valid_status, "unknown": True},
+    ]
+    forbidden_partner_fields = (
+        "remote_ski",
+        "remote_ship_id",
+        "endpoint",
+        "observation_id",
+        "observation_revision",
+        "candidate_state",
+        "candidate_expires_at",
+        "raw_spine",
+        "unknown",
+    )
+    for data in invalid_status:
+        with pytest.raises(admin.EEBusAdminV1ProtocolError):
+            _parsed(admin, "status", data)
+    with pytest.raises(admin.EEBusAdminV1ProtocolError):
+        _parsed(admin, "trusted", {"partners": [], "unknown": True})
+    for field in forbidden_partner_fields:
+        with pytest.raises(admin.EEBusAdminV1ProtocolError):
+            _parsed(admin, "trusted", {"partners": [{**valid_partner, field: "forbidden"}]})
+    with pytest.raises(admin.EEBusAdminV1ProtocolError):
+        _parsed(admin, "connected", {"partners": [valid_partner]})
 
 
 def test_projection_store_retains_each_last_good_view_and_suppresses_identical_data() -> None:
     admin = _admin_module()
     store = admin.HAAdminProjectionStore()
-    status = _envelope({"listener": "ready", "discovery": "ready"}, revision=7)
-    trusted = _envelope({"partners": [{"partner_id": "ha-1", "view": "trusted"}]}, revision=8)
+    status = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=7)
+    trusted = _parsed(admin, "trusted", {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}, revision=8)
 
     assert store.accept("status", status) is True
     assert store.accept("trusted", trusted) is True
     assert store.accept("status", status) is False
+    with pytest.raises((TypeError, admin.EEBusAdminV1ProtocolError)):
+        store.accept("status", _envelope({"listener": "raw-path"}))
     with pytest.raises(admin.EEBusAdminV1ProtocolError):
-        store.accept("connected", _envelope({"candidate_state": "pending"}, revision=9))
+        store.accept("connected", _parsed(admin, "connected", {"candidate_state": "pending"}, revision=9))
 
     assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
     assert store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
@@ -148,8 +210,8 @@ def test_projection_store_retains_each_last_good_view_and_suppresses_identical_d
 def test_projection_revision_churn_with_identical_permitted_data_is_not_an_ha_change() -> None:
     admin = _admin_module()
     store = admin.HAAdminProjectionStore()
-    first = _envelope({"listener": "ready", "discovery": "ready"}, revision=10)
-    candidate_only_churn = _envelope({"listener": "ready", "discovery": "ready"}, revision=11)
+    first = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=10)
+    candidate_only_churn = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=11)
 
     assert store.accept("status", first) is True
     assert store.accept("status", candidate_only_churn) is False
@@ -214,13 +276,13 @@ class _PollingClient:
     def __init__(self, responses: dict[str, Any]) -> None:
         self.responses = responses
 
-    async def fetch_status(self) -> dict[str, Any]:
+    async def fetch_status(self) -> Any:
         response = self.responses["status"]
         if isinstance(response, Exception):
             raise response
         return response
 
-    async def fetch_partners(self, view: str) -> dict[str, Any]:
+    async def fetch_partners(self, view: str) -> Any:
         response = self.responses[view]
         if isinstance(response, Exception):
             raise response
@@ -232,10 +294,10 @@ def test_poller_updates_views_independently_and_retains_each_last_good_view_on_f
     store = admin.HAAdminProjectionStore()
     first_client = _PollingClient(
         {
-            "status": _envelope({"listener": "ready", "discovery": "ready"}, 1),
-            "trusted": _envelope({"partners": [{"partner_id": "ha-a", "view": "trusted"}]}, 1),
-            "connected": _envelope({"partners": [{"partner_id": "ha-a", "view": "connected"}]}, 1),
-            "discovered": _envelope({"partners": []}, 1),
+            "status": _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, 1),
+            "trusted": _parsed(admin, "trusted", {"partners": [{"partner_id": "ha-a", "view": "trusted"}]}, 1),
+            "connected": _parsed(admin, "connected", {"partners": [{"partner_id": "ha-a", "view": "connected"}]}, 1),
+            "discovered": _parsed(admin, "discovered", {"partners": []}, 1),
         }
     )
     assert asyncio.run(admin.EEBusAdminV1Poller(first_client, store).async_poll()) == {
@@ -248,10 +310,10 @@ def test_poller_updates_views_independently_and_retains_each_last_good_view_on_f
     failure = admin.EEBusAdminV1Error("admin_boundary_unavailable")
     second_client = _PollingClient(
         {
-            "status": _envelope({"listener": "degraded", "discovery": "ready"}, 2),
-            "trusted": _envelope({"partners": []}, 2),
+            "status": _parsed(admin, "status", {"listener": "degraded", "discovery": "ready"}, 2),
+            "trusted": _parsed(admin, "trusted", {"partners": []}, 2),
             "connected": failure,
-            "discovered": _envelope({"partners": [{"partner_id": "ha-b", "view": "discovered"}]}, 2),
+            "discovered": _parsed(admin, "discovered", {"partners": [{"partner_id": "ha-b", "view": "discovered"}]}, 2),
         }
     )
     assert asyncio.run(admin.EEBusAdminV1Poller(second_client, store).async_poll()) == {

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -24,6 +24,7 @@ class _Response:
     payload: Any
     status: int = 200
     content_length: int | None = None
+    chunked_body: bytes | None = None
 
     async def __aenter__(self) -> "_Response":
         return self
@@ -36,6 +37,20 @@ class _Response:
 
     async def json(self) -> Any:
         return self.payload
+
+    @property
+    def content(self) -> "_ChunkedContent":
+        return _ChunkedContent(self.chunked_body or b"")
+
+
+class _ChunkedContent:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.read_limits: list[int] = []
+
+    async def read(self, limit: int = -1) -> bytes:
+        self.read_limits.append(limit)
+        return self.body
 
 
 class _Session:
@@ -122,6 +137,20 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
 def test_client_rejects_oversized_admin_body_before_parsing() -> None:
     admin = _admin_module()
     session = _Session([_Response(_envelope({"listener": "ready"}), content_length=65_537)])
+    client = admin.EEBusAdminV1Client(
+        session=session,
+        base_url="https://gateway.example.test/admin/eebus/v1",
+        credential="m" * 32,
+    )
+
+    with pytest.raises(admin.EEBusAdminV1Error) as captured:
+        asyncio.run(client.fetch_status())
+    assert captured.value.code == "invalid_response"
+
+
+def test_client_bounds_unknown_length_chunked_body_before_json_parsing() -> None:
+    admin = _admin_module()
+    session = _Session([_Response(None, content_length=None, chunked_body=b"x" * 65_537)])
     client = admin.EEBusAdminV1Client(
         session=session,
         base_url="https://gateway.example.test/admin/eebus/v1",

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -22,6 +22,7 @@ def _admin_module():
 @dataclass
 class _Response:
     payload: Any
+    status: int = 200
 
     async def __aenter__(self) -> "_Response":
         return self
@@ -143,3 +144,123 @@ def test_projection_store_retains_each_last_good_view_and_suppresses_identical_d
     assert store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
     assert store.data_for("connected") is None
 
+
+def test_projection_revision_churn_with_identical_permitted_data_is_not_an_ha_change() -> None:
+    admin = _admin_module()
+    store = admin.HAAdminProjectionStore()
+    first = _envelope({"listener": "ready", "discovery": "ready"}, revision=10)
+    candidate_only_churn = _envelope({"listener": "ready", "discovery": "ready"}, revision=11)
+
+    assert store.accept("status", first) is True
+    assert store.accept("status", candidate_only_churn) is False
+    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (401, "unauthenticated"),
+        (403, "forbidden"),
+        (409, "state_conflict"),
+        (503, "admin_boundary_unavailable"),
+    ],
+)
+def test_client_maps_http_failures_to_fixed_sanitized_categories(status: int, expected_code: str) -> None:
+    admin = _admin_module()
+    credential = "credential-not-for-errors"
+    session = _Session([_Response({"detail": "raw server body must not escape"}, status=status)])
+    client = admin.EEBusAdminV1Client(
+        session=session,
+        base_url="https://gateway.example.test/admin/eebus/v1",
+        credential=credential,
+    )
+
+    with pytest.raises(admin.EEBusAdminV1Error) as captured:
+        asyncio.run(client.fetch_status())
+
+    error = captured.value
+    assert error.code == expected_code
+    rendered = f"{error!s} {error!r}"
+    for secret_or_transport_detail in (
+        credential,
+        "raw server body",
+        "gateway.example.test",
+        "Authorization",
+        "Bearer",
+    ):
+        assert secret_or_transport_detail not in rendered
+
+
+def test_client_maps_malformed_json_and_wrong_content_to_one_sanitized_category() -> None:
+    admin = _admin_module()
+    credential = "credential-not-for-errors"
+    session = _Session([_Response("not an AdminV1 object"), _Response(_envelope({"raw_spine": {}}))])
+    client = admin.EEBusAdminV1Client(
+        session=session,
+        base_url="https://gateway.example.test/admin/eebus/v1",
+        credential=credential,
+    )
+
+    for request in (client.fetch_status, lambda: client.fetch_partners("trusted")):
+        with pytest.raises(admin.EEBusAdminV1Error) as captured:
+            asyncio.run(request())
+        assert captured.value.code == "invalid_response"
+        rendered = f"{captured.value!s} {captured.value!r}"
+        assert credential not in rendered
+        assert "gateway.example.test" not in rendered
+
+
+class _PollingClient:
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self.responses = responses
+
+    async def fetch_status(self) -> dict[str, Any]:
+        response = self.responses["status"]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def fetch_partners(self, view: str) -> dict[str, Any]:
+        response = self.responses[view]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def test_poller_updates_views_independently_and_retains_each_last_good_view_on_failure() -> None:
+    admin = _admin_module()
+    store = admin.HAAdminProjectionStore()
+    first_client = _PollingClient(
+        {
+            "status": _envelope({"listener": "ready", "discovery": "ready"}, 1),
+            "trusted": _envelope({"partners": [{"partner_id": "ha-a", "view": "trusted"}]}, 1),
+            "connected": _envelope({"partners": [{"partner_id": "ha-a", "view": "connected"}]}, 1),
+            "discovered": _envelope({"partners": []}, 1),
+        }
+    )
+    assert asyncio.run(admin.EEBusAdminV1Poller(first_client, store).async_poll()) == {
+        "status": True,
+        "trusted": True,
+        "connected": True,
+        "discovered": True,
+    }
+
+    failure = admin.EEBusAdminV1Error("admin_boundary_unavailable")
+    second_client = _PollingClient(
+        {
+            "status": _envelope({"listener": "degraded", "discovery": "ready"}, 2),
+            "trusted": _envelope({"partners": []}, 2),
+            "connected": failure,
+            "discovered": _envelope({"partners": [{"partner_id": "ha-b", "view": "discovered"}]}, 2),
+        }
+    )
+    assert asyncio.run(admin.EEBusAdminV1Poller(second_client, store).async_poll()) == {
+        "status": True,
+        "trusted": True,
+        "connected": False,
+        "discovered": True,
+    }
+    assert store.data_for("status") == {"listener": "degraded", "discovery": "ready"}
+    assert store.data_for("trusted") == {"partners": []}
+    assert store.data_for("connected") == {"partners": [{"partner_id": "ha-a", "view": "connected"}]}
+    assert store.data_for("discovered") == {"partners": [{"partner_id": "ha-b", "view": "discovered"}]}

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -23,6 +23,7 @@ def _admin_module():
 class _Response:
     payload: Any
     status: int = 200
+    content_length: int | None = None
 
     async def __aenter__(self) -> "_Response":
         return self
@@ -40,10 +41,10 @@ class _Response:
 class _Session:
     def __init__(self, responses: list[_Response]) -> None:
         self._responses = responses
-        self.requests: list[tuple[str, dict[str, str]]] = []
+        self.requests: list[tuple[str, dict[str, str], bool]] = []
 
-    def get(self, url: str, *, headers: dict[str, str]) -> _Response:
-        self.requests.append((url, headers))
+    def get(self, url: str, *, headers: dict[str, str], allow_redirects: bool) -> _Response:
+        self.requests.append((url, headers, allow_redirects))
         return self._responses.pop(0)
 
 
@@ -89,7 +90,7 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
     client = admin.EEBusAdminV1Client(
         session=session,
         base_url="https://gateway.example.test/admin/eebus/v1",
-        credential="entry-one-machine-credential",
+        credential="m" * 32,
     )
 
     status = asyncio.run(client.fetch_status())
@@ -109,12 +110,27 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
         "https://gateway.example.test/admin/eebus/v1/partners?view=connected",
         "https://gateway.example.test/admin/eebus/v1/partners?view=discovered",
     ]
-    for _, headers in session.requests:
-        assert headers["Authorization"] == "Bearer entry-one-machine-credential"
+    for _, headers, allow_redirects in session.requests:
+        assert headers["Authorization"] == "Bearer " + ("m" * 32)
         assert headers["Accept"] == "application/json"
         assert "Cookie" not in headers
         assert "Origin" not in headers
         assert "Referer" not in headers
+        assert allow_redirects is False
+
+
+def test_client_rejects_oversized_admin_body_before_parsing() -> None:
+    admin = _admin_module()
+    session = _Session([_Response(_envelope({"listener": "ready"}), content_length=65_537)])
+    client = admin.EEBusAdminV1Client(
+        session=session,
+        base_url="https://gateway.example.test/admin/eebus/v1",
+        credential="m" * 32,
+    )
+
+    with pytest.raises(admin.EEBusAdminV1Error) as captured:
+        asyncio.run(client.fetch_status())
+    assert captured.value.code == "invalid_response"
 
 
 def test_strict_ha_envelope_has_one_typed_view_aware_path_and_rejects_owner_fields() -> None:
@@ -229,7 +245,7 @@ def test_projection_revision_churn_with_identical_permitted_data_is_not_an_ha_ch
 )
 def test_client_maps_http_failures_to_fixed_sanitized_categories(status: int, expected_code: str) -> None:
     admin = _admin_module()
-    credential = "credential-not-for-errors"
+    credential = "e" * 32
     session = _Session([_Response({"detail": "raw server body must not escape"}, status=status)])
     client = admin.EEBusAdminV1Client(
         session=session,
@@ -255,7 +271,7 @@ def test_client_maps_http_failures_to_fixed_sanitized_categories(status: int, ex
 
 def test_client_maps_malformed_json_and_wrong_content_to_one_sanitized_category() -> None:
     admin = _admin_module()
-    credential = "credential-not-for-errors"
+    credential = "e" * 32
     session = _Session([_Response("not an AdminV1 object"), _Response(_envelope({"raw_spine": {}}))])
     client = admin.EEBusAdminV1Client(
         session=session,

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -1,0 +1,145 @@
+"""RED contract tests for the candidate-free eeBUS AdminV1 HA client."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+def _admin_module():
+    """Load the intentionally new production boundary with a clear RED failure."""
+
+    try:
+        return importlib.import_module("custom_components.helianthus.eebus_admin")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"missing eeBUS AdminV1 production boundary: {exc}")
+
+
+@dataclass
+class _Response:
+    payload: Any
+
+    async def __aenter__(self) -> "_Response":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> Any:
+        return self.payload
+
+
+class _Session:
+    def __init__(self, responses: list[_Response]) -> None:
+        self._responses = responses
+        self.requests: list[tuple[str, dict[str, str]]] = []
+
+    def get(self, url: str, *, headers: dict[str, str]) -> _Response:
+        self.requests.append((url, headers))
+        return self._responses.pop(0)
+
+
+def _envelope(data: dict[str, Any], revision: int = 1) -> dict[str, Any]:
+    return {
+        "contract": "helianthus.eebus.operator-admin.v1",
+        "projection_revision": revision,
+        "data": data,
+        "error": None,
+    }
+
+
+def test_admin_base_url_is_fixed_same_origin_and_has_no_user_path_escape() -> None:
+    admin = _admin_module()
+
+    assert (
+        admin.build_eebus_admin_base_url("https://gateway.example.test:8443/graphql")
+        == "https://gateway.example.test:8443/admin/eebus/v1"
+    )
+    assert (
+        admin.build_eebus_admin_base_url("http://gateway.example.test/anything")
+        == "http://gateway.example.test/admin/eebus/v1"
+    )
+    for unsafe in ("gateway.example.test", "https://gateway.example.test/?next=x", "https://gateway.example.test/#token"):
+        with pytest.raises(ValueError):
+            admin.build_eebus_admin_base_url(unsafe)
+
+
+def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_authority() -> None:
+    admin = _admin_module()
+    session = _Session(
+        [
+            _Response(_envelope({"listener": "ready", "discovery": "ready"})),
+            _Response(_envelope({"partners": []})),
+            _Response(_envelope({"partners": []})),
+            _Response(_envelope({"partners": []})),
+        ]
+    )
+    client = admin.EEBusAdminV1Client(
+        session=session,
+        base_url="https://gateway.example.test/admin/eebus/v1",
+        credential="entry-one-machine-credential",
+    )
+
+    assert asyncio.run(client.fetch_status())["listener"] == "ready"
+    for view in ("trusted", "connected", "discovered"):
+        assert asyncio.run(client.fetch_partners(view)) == {"partners": []}
+    for forbidden in ("candidate", "raw", "spine", "unknown"):
+        with pytest.raises(ValueError):
+            asyncio.run(client.fetch_partners(forbidden))
+
+    assert [request[0] for request in session.requests] == [
+        "https://gateway.example.test/admin/eebus/v1/status",
+        "https://gateway.example.test/admin/eebus/v1/partners?view=trusted",
+        "https://gateway.example.test/admin/eebus/v1/partners?view=connected",
+        "https://gateway.example.test/admin/eebus/v1/partners?view=discovered",
+    ]
+    for _, headers in session.requests:
+        assert headers["Authorization"] == "Bearer entry-one-machine-credential"
+        assert headers["Accept"] == "application/json"
+        assert "Cookie" not in headers
+        assert "Origin" not in headers
+        assert "Referer" not in headers
+
+
+def test_strict_ha_envelope_rejects_owner_candidate_raw_and_unknown_fields() -> None:
+    admin = _admin_module()
+    accepted = admin.parse_ha_admin_envelope(_envelope({"partners": []}))
+    assert accepted.projection_revision == 1
+    assert accepted.data == {"partners": []}
+
+    invalid_payloads = [
+        {**_envelope({}), "state_revision": 2},
+        {**_envelope({}), "request_id": "owner-only"},
+        _envelope({"candidate_count": 1}),
+        _envelope({"raw_spine": {}}),
+        {**_envelope({}), "unexpected": True},
+        {"contract": "helianthus.eebus.operator-admin.v2", "projection_revision": 1, "data": {}, "error": None},
+    ]
+    for payload in invalid_payloads:
+        with pytest.raises(admin.EEBusAdminV1ProtocolError):
+            admin.parse_ha_admin_envelope(payload)
+
+
+def test_projection_store_retains_each_last_good_view_and_suppresses_identical_data() -> None:
+    admin = _admin_module()
+    store = admin.HAAdminProjectionStore()
+    status = _envelope({"listener": "ready", "discovery": "ready"}, revision=7)
+    trusted = _envelope({"partners": [{"partner_id": "ha-1", "view": "trusted"}]}, revision=8)
+
+    assert store.accept("status", status) is True
+    assert store.accept("trusted", trusted) is True
+    assert store.accept("status", status) is False
+    with pytest.raises(admin.EEBusAdminV1ProtocolError):
+        store.accept("connected", _envelope({"candidate_state": "pending"}, revision=9))
+
+    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+    assert store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
+    assert store.data_for("connected") is None
+

--- a/tests/test_eebus_admin.py
+++ b/tests/test_eebus_admin.py
@@ -72,6 +72,19 @@ def _envelope(data: dict[str, Any], revision: int = 1) -> dict[str, Any]:
     }
 
 
+def _status(listener: str = "ready", discovery: str = "ready") -> dict[str, Any]:
+    return {
+        "listener": listener,
+        "discovery": discovery,
+        "trusted_count": 0,
+        "connected_count": 0,
+        "discovered_count": 0,
+    }
+
+
+PARTNER_ID = "ha-" + "a" * 32
+
+
 def _parsed(admin: Any, view: str, data: dict[str, Any], revision: int = 1) -> Any:
     return admin.parse_ha_admin_envelope(_envelope(data, revision), expected_view=view)
 
@@ -110,17 +123,17 @@ def test_status_and_partner_schemas_are_exactly_bounded_and_non_boolean() -> Non
 
 def test_store_defensively_copies_input_and_output_data() -> None:
     admin = _admin_module(); store = admin.HAAdminProjectionStore()
-    source = {"listener": "ready", "discovery": "ready"}
+    source = _status()
     store.accept("status", _parsed(admin, "status", source))
     source["listener"] = "mutated"; returned = store.data_for("status"); returned["listener"] = "mutated-again"
-    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+    assert store.data_for("status") == _status()
 
 
 def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_authority() -> None:
     admin = _admin_module()
     session = _Session(
         [
-            _Response(_envelope({"listener": "ready", "discovery": "ready"})),
+            _Response(_envelope(_status())),
             _Response(_envelope({"partners": []})),
             _Response(_envelope({"partners": []})),
             _Response(_envelope({"partners": []})),
@@ -134,7 +147,7 @@ def test_client_allows_only_candidate_free_get_views_and_sends_no_browser_author
 
     status = asyncio.run(client.fetch_status())
     assert isinstance(status, admin.HAAdminEnvelopeV1)
-    assert status.data["listener"] == "ready"
+    assert status.data == _status()
     for view in ("trusted", "connected", "discovered"):
         partners = asyncio.run(client.fetch_partners(view))
         assert isinstance(partners, admin.HAAdminEnvelopeV1)
@@ -217,7 +230,7 @@ def test_per_view_data_schema_rejects_non_ha_identity_candidate_raw_and_unknown_
         "degraded_code": "",
     }
     valid_partner = {
-        "partner_id": "ha-partner",
+        "partner_id": PARTNER_ID,
         "view": "trusted",
         "brand": "brand",
         "device_type": "device",
@@ -260,8 +273,8 @@ def test_per_view_data_schema_rejects_non_ha_identity_candidate_raw_and_unknown_
 def test_projection_store_retains_each_last_good_view_and_suppresses_identical_data() -> None:
     admin = _admin_module()
     store = admin.HAAdminProjectionStore()
-    status = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=7)
-    trusted = _parsed(admin, "trusted", {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}, revision=8)
+    status = _parsed(admin, "status", _status(), revision=7)
+    trusted = _parsed(admin, "trusted", {"partners": [{"partner_id": PARTNER_ID, "view": "trusted"}]}, revision=8)
 
     assert store.accept("status", status) is True
     assert store.accept("trusted", trusted) is True
@@ -271,20 +284,20 @@ def test_projection_store_retains_each_last_good_view_and_suppresses_identical_d
     with pytest.raises(admin.EEBusAdminV1ProtocolError):
         store.accept("connected", _parsed(admin, "connected", {"candidate_state": "pending"}, revision=9))
 
-    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
-    assert store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
+    assert store.data_for("status") == _status()
+    assert store.data_for("trusted") == {"partners": [{"partner_id": PARTNER_ID, "view": "trusted"}]}
     assert store.data_for("connected") is None
 
 
 def test_projection_revision_churn_with_identical_permitted_data_is_not_an_ha_change() -> None:
     admin = _admin_module()
     store = admin.HAAdminProjectionStore()
-    first = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=10)
-    candidate_only_churn = _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, revision=11)
+    first = _parsed(admin, "status", _status(), revision=10)
+    candidate_only_churn = _parsed(admin, "status", _status(), revision=11)
 
     assert store.accept("status", first) is True
     assert store.accept("status", candidate_only_churn) is False
-    assert store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+    assert store.data_for("status") == _status()
 
 
 @pytest.mark.parametrize(
@@ -363,9 +376,9 @@ def test_poller_updates_views_independently_and_retains_each_last_good_view_on_f
     store = admin.HAAdminProjectionStore()
     first_client = _PollingClient(
         {
-            "status": _parsed(admin, "status", {"listener": "ready", "discovery": "ready"}, 1),
-            "trusted": _parsed(admin, "trusted", {"partners": [{"partner_id": "ha-a", "view": "trusted"}]}, 1),
-            "connected": _parsed(admin, "connected", {"partners": [{"partner_id": "ha-a", "view": "connected"}]}, 1),
+            "status": _parsed(admin, "status", _status(), 1),
+            "trusted": _parsed(admin, "trusted", {"partners": [{"partner_id": PARTNER_ID, "view": "trusted"}]}, 1),
+            "connected": _parsed(admin, "connected", {"partners": [{"partner_id": PARTNER_ID, "view": "connected"}]}, 1),
             "discovered": _parsed(admin, "discovered", {"partners": []}, 1),
         }
     )
@@ -379,10 +392,10 @@ def test_poller_updates_views_independently_and_retains_each_last_good_view_on_f
     failure = admin.EEBusAdminV1Error("admin_boundary_unavailable")
     second_client = _PollingClient(
         {
-            "status": _parsed(admin, "status", {"listener": "degraded", "discovery": "ready"}, 2),
+            "status": _parsed(admin, "status", _status("degraded"), 2),
             "trusted": _parsed(admin, "trusted", {"partners": []}, 2),
             "connected": failure,
-            "discovered": _parsed(admin, "discovered", {"partners": [{"partner_id": "ha-b", "view": "discovered"}]}, 2),
+            "discovered": _parsed(admin, "discovered", {"partners": [{"partner_id": PARTNER_ID, "view": "discovered"}]}, 2),
         }
     )
     assert asyncio.run(admin.EEBusAdminV1Poller(second_client, store).async_poll()) == {
@@ -391,7 +404,7 @@ def test_poller_updates_views_independently_and_retains_each_last_good_view_on_f
         "connected": False,
         "discovered": True,
     }
-    assert store.data_for("status") == {"listener": "degraded", "discovery": "ready"}
+    assert store.data_for("status") == _status("degraded")
     assert store.data_for("trusted") == {"partners": []}
-    assert store.data_for("connected") == {"partners": [{"partner_id": "ha-a", "view": "connected"}]}
-    assert store.data_for("discovered") == {"partners": [{"partner_id": "ha-b", "view": "discovered"}]}
+    assert store.data_for("connected") == {"partners": [{"partner_id": PARTNER_ID, "view": "connected"}]}
+    assert store.data_for("discovered") == {"partners": [{"partner_id": PARTNER_ID, "view": "discovered"}]}

--- a/tests/test_eebus_admin_flow.py
+++ b/tests/test_eebus_admin_flow.py
@@ -43,3 +43,29 @@ def test_entry_update_never_copies_a_machine_credential_between_entries() -> Non
     assert two["eebus_admin_credential"] == "credential-two"
     assert one["eebus_admin_credential"] != two["eebus_admin_credential"]
     assert "credential-one" not in two.values()
+
+
+def test_machine_credential_matches_the_gateway_visible_ascii_boundary_and_never_leaks() -> None:
+    admin = _admin_module()
+    valid = "a" * 12
+    assert admin.validate_machine_credential(valid) == valid
+
+    invalid = ("", "short", " leading-value", "trailing-value ", "non-ascii-\u00e9", "a" * 257)
+    for credential in (*invalid, "internal value"):
+        with pytest.raises(ValueError) as captured:
+            admin.validate_machine_credential(credential)
+        rendered = f"{captured.value!s} {captured.value!r}"
+        assert credential not in rendered
+        assert "eebus_admin_credential" not in rendered
+
+
+def test_entry_credential_helpers_do_not_render_or_embed_the_machine_token() -> None:
+    admin = _admin_module()
+    credential = "credential-not-for-display"
+    entry = {"entry_id": "one", "data": {"eebus_admin_credential": credential}}
+
+    holder = admin.config_entry_machine_credential(entry)
+    rendered = f"{holder!s} {holder!r}"
+    assert credential not in rendered
+    assert "http" not in rendered.lower()
+    assert admin.credential_for_config_entry(entry) == credential

--- a/tests/test_eebus_admin_flow.py
+++ b/tests/test_eebus_admin_flow.py
@@ -80,7 +80,8 @@ def test_machine_credential_matches_the_gateway_visible_ascii_boundary_and_never
         with pytest.raises(ValueError) as captured:
             admin.validate_machine_credential(credential)
         rendered = f"{captured.value!s} {captured.value!r}"
-        assert credential not in rendered
+        if credential:
+            assert credential not in rendered
         assert "eebus_admin_credential" not in rendered
 
 

--- a/tests/test_eebus_admin_flow.py
+++ b/tests/test_eebus_admin_flow.py
@@ -16,11 +16,11 @@ def _admin_module():
 
 def test_machine_credential_is_bound_to_one_config_entry_not_a_global_setting() -> None:
     admin = _admin_module()
-    entry_one = {"entry_id": "one", "data": {"eebus_admin_credential": "credential-one"}}
-    entry_two = {"entry_id": "two", "data": {"eebus_admin_credential": "credential-two"}}
+    entry_one = {"entry_id": "one", "data": {"eebus_admin_credential": "a" * 32}}
+    entry_two = {"entry_id": "two", "data": {"eebus_admin_credential": "b" * 32}}
 
-    assert admin.credential_for_config_entry(entry_one) == "credential-one"
-    assert admin.credential_for_config_entry(entry_two) == "credential-two"
+    assert admin.credential_for_config_entry(entry_one) == "a" * 32
+    assert admin.credential_for_config_entry(entry_two) == "b" * 32
     assert admin.credential_for_config_entry({"entry_id": "three", "data": {}}) is None
     with pytest.raises(ValueError):
         admin.credential_for_config_entry({"entry_id": "one", "data": {"eebus_admin_credential": ""}})
@@ -34,15 +34,40 @@ def test_portal_action_is_a_fixed_relative_path_without_authority_or_payload() -
         assert forbidden not in admin.portal_eebus_action_path()
 
 
+def test_portal_url_uses_only_verified_origin_and_exact_fixed_action_path() -> None:
+    admin = _admin_module()
+
+    assert admin.portal_eebus_url("https://gateway.example.test:8443") == "https://gateway.example.test:8443/portal/eebus"
+    for unsafe in (
+        "https://gateway.example.test:8443/portal/eebus",
+        "https://gateway.example.test:8443?token=x",
+        "https://gateway.example.test:8443#fragment",
+        "gateway.example.test",
+    ):
+        with pytest.raises(ValueError):
+            admin.portal_eebus_url(unsafe)
+
+
+def test_admin_credential_form_field_has_no_default_or_suggested_existing_token() -> None:
+    admin = _admin_module()
+    field = admin.admin_credential_form_field()
+
+    assert field["name"] == "eebus_admin_credential"
+    assert field["selector"] == "password"
+    assert "default" not in field
+    assert "suggested_value" not in field
+    assert "a" * 32 not in repr(field)
+
+
 def test_entry_update_never_copies_a_machine_credential_between_entries() -> None:
     admin = _admin_module()
-    one = admin.with_config_entry_credential({"host": "gateway-one"}, "credential-one")
-    two = admin.with_config_entry_credential({"host": "gateway-two"}, "credential-two")
+    one = admin.with_config_entry_credential({"host": "gateway-one"}, "a" * 32)
+    two = admin.with_config_entry_credential({"host": "gateway-two"}, "b" * 32)
 
-    assert one["eebus_admin_credential"] == "credential-one"
-    assert two["eebus_admin_credential"] == "credential-two"
+    assert one["eebus_admin_credential"] == "a" * 32
+    assert two["eebus_admin_credential"] == "b" * 32
     assert one["eebus_admin_credential"] != two["eebus_admin_credential"]
-    assert "credential-one" not in two.values()
+    assert "a" * 32 not in two.values()
 
 
 def test_machine_credential_matches_the_gateway_visible_ascii_boundary_and_never_leaks() -> None:
@@ -61,7 +86,7 @@ def test_machine_credential_matches_the_gateway_visible_ascii_boundary_and_never
 
 def test_entry_credential_helpers_do_not_render_or_embed_the_machine_token() -> None:
     admin = _admin_module()
-    credential = "credential-not-for-display"
+    credential = "a" * 32
     entry = {"entry_id": "one", "data": {"eebus_admin_credential": credential}}
 
     holder = admin.config_entry_machine_credential(entry)

--- a/tests/test_eebus_admin_flow.py
+++ b/tests/test_eebus_admin_flow.py
@@ -47,10 +47,10 @@ def test_entry_update_never_copies_a_machine_credential_between_entries() -> Non
 
 def test_machine_credential_matches_the_gateway_visible_ascii_boundary_and_never_leaks() -> None:
     admin = _admin_module()
-    valid = "a" * 12
+    valid = "a" * 32
     assert admin.validate_machine_credential(valid) == valid
 
-    invalid = ("", "short", " leading-value", "trailing-value ", "non-ascii-\u00e9", "a" * 257)
+    invalid = ("", "short", "a" * 31, " leading-value", "trailing-value ", "non-ascii-\u00e9", "a" * 257)
     for credential in (*invalid, "internal value"):
         with pytest.raises(ValueError) as captured:
             admin.validate_machine_credential(credential)

--- a/tests/test_eebus_admin_flow.py
+++ b/tests/test_eebus_admin_flow.py
@@ -1,0 +1,45 @@
+"""RED tests for HA config-entry ownership of the eeBUS AdminV1 credential."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _admin_module():
+    try:
+        return importlib.import_module("custom_components.helianthus.eebus_admin")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"missing eeBUS AdminV1 flow helpers: {exc}")
+
+
+def test_machine_credential_is_bound_to_one_config_entry_not_a_global_setting() -> None:
+    admin = _admin_module()
+    entry_one = {"entry_id": "one", "data": {"eebus_admin_credential": "credential-one"}}
+    entry_two = {"entry_id": "two", "data": {"eebus_admin_credential": "credential-two"}}
+
+    assert admin.credential_for_config_entry(entry_one) == "credential-one"
+    assert admin.credential_for_config_entry(entry_two) == "credential-two"
+    assert admin.credential_for_config_entry({"entry_id": "three", "data": {}}) is None
+    with pytest.raises(ValueError):
+        admin.credential_for_config_entry({"entry_id": "one", "data": {"eebus_admin_credential": ""}})
+
+
+def test_portal_action_is_a_fixed_relative_path_without_authority_or_payload() -> None:
+    admin = _admin_module()
+
+    assert admin.portal_eebus_action_path() == "/portal/eebus"
+    for forbidden in ("?", "#", "token", "candidate", "partner", "http:", "https:"):
+        assert forbidden not in admin.portal_eebus_action_path()
+
+
+def test_entry_update_never_copies_a_machine_credential_between_entries() -> None:
+    admin = _admin_module()
+    one = admin.with_config_entry_credential({"host": "gateway-one"}, "credential-one")
+    two = admin.with_config_entry_credential({"host": "gateway-two"}, "credential-two")
+
+    assert one["eebus_admin_credential"] == "credential-one"
+    assert two["eebus_admin_credential"] == "credential-two"
+    assert one["eebus_admin_credential"] != two["eebus_admin_credential"]
+    assert "credential-one" not in two.values()

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -1,0 +1,98 @@
+"""RED lifecycle and wiring contract for the isolated eeBUS AdminV1 consumer."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+def _admin_module():
+    try:
+        return importlib.import_module("custom_components.helianthus.eebus_admin")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"missing eeBUS AdminV1 wiring boundary: {exc}")
+
+
+def test_dedicated_admin_session_has_no_cookie_jar_and_client_hardening_is_local() -> None:
+    admin = _admin_module()
+    source = inspect.getsource(admin)
+
+    assert "DummyCookieJar" in source
+    assert "allow_redirects=False" in source
+    assert "64 * 1024" in source or "65_536" in source
+    assert "GraphQLClient" not in source
+
+
+def test_wiring_owns_one_admin_coordinator_and_never_turns_partner_rows_into_entities() -> None:
+    admin = _admin_module()
+    source = inspect.getsource(admin)
+
+    assert "EEBusAdminV1Coordinator" in source
+    assert "DataUpdateCoordinator" in source
+    assert "partner arrays" not in source.lower()
+    assert "async_add_entities" not in source
+
+
+def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_binding_changes() -> None:
+    admin = _admin_module()
+    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    lifecycle.store.accept(
+        "status",
+        admin.parse_ha_admin_envelope(
+            {
+                "contract": "helianthus.eebus.operator-admin.v1",
+                "projection_revision": 1,
+                "data": {"listener": "ready", "discovery": "ready"},
+                "error": None,
+            },
+            expected_view="status",
+        ),
+    )
+    lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-a", credential="a" * 32)
+    assert lifecycle.store.data_for("status") is None
+
+    lifecycle.store.accept(
+        "status",
+        admin.parse_ha_admin_envelope(
+            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 2, "data": {"listener": "ready", "discovery": "ready"}, "error": None},
+            expected_view="status",
+        ),
+    )
+    lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-a", credential="a" * 32)
+    assert lifecycle.store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+    lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-b", credential="a" * 32)
+    assert lifecycle.store.data_for("status") is None
+
+
+def test_admin_failures_are_diagnostic_only_and_view_failures_remain_stale_not_deleted() -> None:
+    admin = _admin_module()
+    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    lifecycle.note_view_success("trusted", {"partners": [{"partner_id": "ha-1", "view": "trusted"}]})
+    lifecycle.note_view_failure("trusted", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
+
+    assert lifecycle.diagnostic_available is False
+    assert lifecycle.store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
+    assert lifecycle.view_is_stale("trusted") is True
+    assert lifecycle.graphql_setup_failed is False
+
+
+def test_unauthenticated_admin_response_schedules_reauth_without_unloading_graphql() -> None:
+    admin = _admin_module()
+    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+
+    lifecycle.note_view_failure("status", admin.EEBusAdminV1Error("unauthenticated"))
+    assert lifecycle.reauth_scheduled is True
+    assert lifecycle.graphql_setup_failed is False
+    assert lifecycle.unload_requested is False
+
+
+def test_device_info_configuration_url_is_local_portal_url_not_partner_data() -> None:
+    admin = _admin_module()
+    info = admin.admin_device_info("https://gateway.example.test")
+
+    assert info.configuration_url == "https://gateway.example.test/portal/eebus"
+    rendered = repr(info)
+    for forbidden in ("partner_id", "remote_ski", "endpoint", "candidate", "token"):
+        assert forbidden not in rendered.lower()

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -8,26 +8,34 @@ import inspect
 import pytest
 
 
-def _admin_module():
+def _modules():
     try:
-        return importlib.import_module("custom_components.helianthus.eebus_admin")
+        admin = importlib.import_module("custom_components.helianthus.eebus_admin")
     except ModuleNotFoundError as exc:
-        pytest.fail(f"missing eeBUS AdminV1 wiring boundary: {exc}")
+        pytest.fail(f"missing pure eeBUS AdminV1 client boundary: {exc}")
+    try:
+        coordinator = importlib.import_module("custom_components.helianthus.eebus_admin_coordinator")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"missing eeBUS AdminV1 HA coordinator boundary: {exc}")
+    return admin, coordinator
 
 
 def test_dedicated_admin_session_has_no_cookie_jar_and_client_hardening_is_local() -> None:
-    admin = _admin_module()
-    source = inspect.getsource(admin)
+    admin, coordinator = _modules()
+    client_source = inspect.getsource(admin)
+    coordinator_source = inspect.getsource(coordinator)
 
-    assert "DummyCookieJar" in source
-    assert "allow_redirects=False" in source
-    assert "64 * 1024" in source or "65_536" in source
-    assert "GraphQLClient" not in source
+    assert "DummyCookieJar" in coordinator_source
+    assert "allow_redirects=False" in client_source
+    assert "64 * 1024" in client_source or "65_536" in client_source
+    assert "GraphQLClient" not in client_source
+    assert "homeassistant" not in client_source.lower()
+    assert "aiohttp" not in client_source.lower()
 
 
 def test_wiring_owns_one_admin_coordinator_and_never_turns_partner_rows_into_entities() -> None:
-    admin = _admin_module()
-    source = inspect.getsource(admin)
+    _admin, coordinator = _modules()
+    source = inspect.getsource(coordinator)
 
     assert "EEBusAdminV1Coordinator" in source
     assert "DataUpdateCoordinator" in source
@@ -36,8 +44,8 @@ def test_wiring_owns_one_admin_coordinator_and_never_turns_partner_rows_into_ent
 
 
 def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_binding_changes() -> None:
-    admin = _admin_module()
-    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    admin, coordinator = _modules()
+    lifecycle = coordinator.EEBusAdminV1Lifecycle(entry_id="entry-1")
     lifecycle.store.accept(
         "status",
         admin.parse_ha_admin_envelope(
@@ -62,25 +70,39 @@ def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_bind
     )
     lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-a", credential="a" * 32)
     assert lifecycle.store.data_for("status") == {"listener": "ready", "discovery": "ready"}
-    lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-b", credential="a" * 32)
+    lifecycle.reconcile_binding(origin="https://other.example.test", instance_guid="guid-a", credential="a" * 32)
+    assert lifecycle.store.data_for("status") is None
+    lifecycle.store.accept(
+        "status",
+        admin.parse_ha_admin_envelope(
+            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 3, "data": {"listener": "ready", "discovery": "ready"}, "error": None},
+            expected_view="status",
+        ),
+    )
+    lifecycle.reconcile_binding(origin="https://other.example.test", instance_guid="guid-a", credential="b" * 32)
     assert lifecycle.store.data_for("status") is None
 
 
 def test_admin_failures_are_diagnostic_only_and_view_failures_remain_stale_not_deleted() -> None:
-    admin = _admin_module()
-    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    admin, coordinator = _modules()
+    lifecycle = coordinator.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    lifecycle.note_view_success("status", {"listener": "ready", "discovery": "ready"})
     lifecycle.note_view_success("trusted", {"partners": [{"partner_id": "ha-1", "view": "trusted"}]})
     lifecycle.note_view_failure("trusted", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
 
-    assert lifecycle.diagnostic_available is False
+    assert lifecycle.diagnostic_available is True
     assert lifecycle.store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
     assert lifecycle.view_is_stale("trusted") is True
     assert lifecycle.graphql_setup_failed is False
+    lifecycle.note_view_failure("status", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
+    lifecycle.note_view_failure("connected", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
+    lifecycle.note_view_failure("discovered", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
+    assert lifecycle.diagnostic_available is False
 
 
 def test_unauthenticated_admin_response_schedules_reauth_without_unloading_graphql() -> None:
-    admin = _admin_module()
-    lifecycle = admin.EEBusAdminV1Lifecycle(entry_id="entry-1")
+    admin, coordinator = _modules()
+    lifecycle = coordinator.EEBusAdminV1Lifecycle(entry_id="entry-1")
 
     lifecycle.note_view_failure("status", admin.EEBusAdminV1Error("unauthenticated"))
     assert lifecycle.reauth_scheduled is True
@@ -89,8 +111,8 @@ def test_unauthenticated_admin_response_schedules_reauth_without_unloading_graph
 
 
 def test_device_info_configuration_url_is_local_portal_url_not_partner_data() -> None:
-    admin = _admin_module()
-    info = admin.admin_device_info("https://gateway.example.test")
+    _admin, coordinator = _modules()
+    info = coordinator.admin_device_info("https://gateway.example.test")
 
     assert info.configuration_url == "https://gateway.example.test/portal/eebus"
     rendered = repr(info)

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -49,6 +49,32 @@ def test_dedicated_admin_session_has_no_cookie_jar_and_client_hardening_is_local
     assert "aiohttp" not in client_source.lower()
 
 
+def test_dedicated_admin_session_has_a_bounded_total_connect_and_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    _admin, coordinator_module = _modules()
+    captured: dict[str, object] = {}
+
+    class FakeAiohttp:
+        class DummyCookieJar:
+            pass
+
+        class ClientTimeout:
+            def __init__(self, **kwargs: object) -> None:
+                captured["timeout_values"] = kwargs
+
+    def create_session(_hass: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(coordinator_module, "aiohttp", FakeAiohttp)
+    monkeypatch.setattr(coordinator_module, "async_create_clientsession", create_session, raising=False)
+    coordinator_module.create_admin_session(object())
+
+    timeout_values = captured["timeout_values"]
+    assert isinstance(timeout_values, dict)
+    assert all(isinstance(timeout_values[key], (int, float)) and 0 < timeout_values[key] <= 30 for key in ("total", "connect", "sock_read"))
+    assert "timeout" in captured
+
+
 def test_wiring_owns_one_admin_coordinator_and_never_turns_partner_rows_into_entities() -> None:
     _admin, coordinator = _modules()
     source = inspect.getsource(coordinator)
@@ -146,6 +172,36 @@ def test_unauthenticated_refresh_uses_the_entry_reauth_api_with_hass() -> None:
     coordinator.lifecycle = type("Lifecycle", (), {"reauth_scheduled": True})()
 
     asyncio.run(coordinator._async_schedule_reauth())
+    assert entry.calls == [hass]
+
+
+def test_all_401_views_and_repeated_refreshes_start_one_reauth_per_binding() -> None:
+    admin, coordinator_module = _modules()
+
+    class Entry:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        async def async_start_reauth(self, hass: object) -> None:
+            self.calls.append(hass)
+
+    class Client:
+        async def fetch_status(self) -> object:
+            raise admin.EEBusAdminV1Error("unauthenticated")
+
+        async def fetch_partners(self, _view: str) -> object:
+            raise admin.EEBusAdminV1Error("unauthenticated")
+
+    entry = Entry()
+    hass = object()
+    coordinator = object.__new__(coordinator_module.EEBusAdminV1Coordinator)
+    coordinator._entry = entry
+    coordinator._client = Client()
+    coordinator.hass = hass
+    coordinator.lifecycle = coordinator_module.EEBusAdminV1Lifecycle(entry_id="entry-1")
+
+    asyncio.run(coordinator._async_update_data())
+    asyncio.run(coordinator._async_update_data())
     assert entry.calls == [hass]
 
 

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -60,6 +61,8 @@ def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_bind
     )
     lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-a", credential="a" * 32)
     assert lifecycle.store.data_for("status") is None
+    assert "a" * 32 not in repr(lifecycle)
+    assert "a" * 32 not in repr(lifecycle.__dict__)
 
     lifecycle.store.accept(
         "status",
@@ -118,3 +121,17 @@ def test_device_info_configuration_url_is_local_portal_url_not_partner_data() ->
     rendered = repr(info)
     for forbidden in ("partner_id", "remote_ski", "endpoint", "candidate", "token"):
         assert forbidden not in rendered.lower()
+
+
+def test_actual_ha_wiring_exists_in_config_setup_options_and_sensor_modules() -> None:
+    component = Path(__file__).parents[1] / "custom_components" / "helianthus"
+    root = (component / "__init__.py").read_text()
+    config = (component / "config_flow.py").read_text()
+    options = (component / "options_flow.py").read_text()
+    sensor = (component / "sensor.py").read_text()
+    for required in ("EEBusAdminV1Coordinator", "eebus_admin_credential", "hass.data", "async_unload_entry"):
+        assert required in root
+    for required in ("async_step_reconfigure", "async_step_reauth", "TextSelector", "eebus_admin_credential"):
+        assert required in config
+    assert "/portal/eebus" in options and "eebus_admin_credential" not in options
+    assert "EEBusAdmin" in sensor and "configuration_url" in sensor

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import asyncio
+import json
 from pathlib import Path
 
 import pytest
@@ -126,6 +128,27 @@ def test_unauthenticated_admin_response_schedules_reauth_without_unloading_graph
     assert lifecycle.unload_requested is False
 
 
+def test_unauthenticated_refresh_uses_the_entry_reauth_api_with_hass() -> None:
+    _admin, coordinator_module = _modules()
+
+    class Entry:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        async def async_start_reauth(self, hass: object) -> None:
+            self.calls.append(hass)
+
+    entry = Entry()
+    hass = object()
+    coordinator = object.__new__(coordinator_module.EEBusAdminV1Coordinator)
+    coordinator._entry = entry
+    coordinator.hass = hass
+    coordinator.lifecycle = type("Lifecycle", (), {"reauth_scheduled": True})()
+
+    asyncio.run(coordinator._async_schedule_reauth())
+    assert entry.calls == [hass]
+
+
 def test_device_info_configuration_url_is_local_portal_url_not_partner_data() -> None:
     _admin, coordinator = _modules()
     info = coordinator.admin_device_info("https://gateway.example.test")
@@ -144,7 +167,21 @@ def test_actual_ha_wiring_exists_in_config_setup_options_and_sensor_modules() ->
     sensor = (component / "sensor.py").read_text()
     for required in ("EEBusAdminV1Coordinator", "CONF_EEBUS_ADMIN_CREDENTIAL", "hass.data", "async_unload_entry"):
         assert required in root
+    assert "urlsplit(graphql_url)" in root
+    assert "close_admin_session(admin_session)" in root
     for required in ("async_step_reconfigure", "async_step_reauth", "TextSelector", "CONF_EEBUS_ADMIN_CREDENTIAL"):
         assert required in config
     assert "/portal/eebus" in options and "eebus_admin_credential" not in options
     assert "EEBusAdmin" in sensor and "configuration_url" in sensor
+
+
+def test_admin_strings_cover_credential_reauth_reconfigure_and_portal_help() -> None:
+    strings = json.loads(
+        (Path(__file__).parents[1] / "custom_components" / "helianthus" / "strings.json").read_text()
+    )
+    config = strings["config"]
+    assert config["step"]["user"]["data"]["eebus_admin_credential"]
+    assert config["step"]["reconfigure"]["data"]["eebus_admin_credential"]
+    assert config["step"]["reauth"]["data"]["eebus_admin_credential"]
+    assert config["error"]["invalid_auth"]
+    assert "/portal/eebus" in strings["options"]["step"]["init"]["description"]

--- a/tests/test_eebus_admin_wiring.py
+++ b/tests/test_eebus_admin_wiring.py
@@ -21,6 +21,19 @@ def _modules():
     return admin, coordinator
 
 
+def _status() -> dict[str, object]:
+    return {
+        "listener": "ready",
+        "discovery": "ready",
+        "trusted_count": 0,
+        "connected_count": 0,
+        "discovered_count": 0,
+    }
+
+
+PARTNER_ID = "ha-" + "a" * 32
+
+
 def test_dedicated_admin_session_has_no_cookie_jar_and_client_hardening_is_local() -> None:
     admin, coordinator = _modules()
     client_source = inspect.getsource(admin)
@@ -53,7 +66,7 @@ def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_bind
             {
                 "contract": "helianthus.eebus.operator-admin.v1",
                 "projection_revision": 1,
-                "data": {"listener": "ready", "discovery": "ready"},
+                "data": _status(),
                 "error": None,
             },
             expected_view="status",
@@ -67,18 +80,18 @@ def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_bind
     lifecycle.store.accept(
         "status",
         admin.parse_ha_admin_envelope(
-            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 2, "data": {"listener": "ready", "discovery": "ready"}, "error": None},
+            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 2, "data": _status(), "error": None},
             expected_view="status",
         ),
     )
     lifecycle.reconcile_binding(origin="https://gateway.example.test", instance_guid="guid-a", credential="a" * 32)
-    assert lifecycle.store.data_for("status") == {"listener": "ready", "discovery": "ready"}
+    assert lifecycle.store.data_for("status") == _status()
     lifecycle.reconcile_binding(origin="https://other.example.test", instance_guid="guid-a", credential="a" * 32)
     assert lifecycle.store.data_for("status") is None
     lifecycle.store.accept(
         "status",
         admin.parse_ha_admin_envelope(
-            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 3, "data": {"listener": "ready", "discovery": "ready"}, "error": None},
+            {"contract": "helianthus.eebus.operator-admin.v1", "projection_revision": 3, "data": _status(), "error": None},
             expected_view="status",
         ),
     )
@@ -89,12 +102,12 @@ def test_lifecycle_clears_admin_projection_only_when_identity_or_credential_bind
 def test_admin_failures_are_diagnostic_only_and_view_failures_remain_stale_not_deleted() -> None:
     admin, coordinator = _modules()
     lifecycle = coordinator.EEBusAdminV1Lifecycle(entry_id="entry-1")
-    lifecycle.note_view_success("status", {"listener": "ready", "discovery": "ready"})
-    lifecycle.note_view_success("trusted", {"partners": [{"partner_id": "ha-1", "view": "trusted"}]})
+    lifecycle.note_view_success("status", _status())
+    lifecycle.note_view_success("trusted", {"partners": [{"partner_id": PARTNER_ID, "view": "trusted"}]})
     lifecycle.note_view_failure("trusted", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
 
     assert lifecycle.diagnostic_available is True
-    assert lifecycle.store.data_for("trusted") == {"partners": [{"partner_id": "ha-1", "view": "trusted"}]}
+    assert lifecycle.store.data_for("trusted") == {"partners": [{"partner_id": PARTNER_ID, "view": "trusted"}]}
     assert lifecycle.view_is_stale("trusted") is True
     assert lifecycle.graphql_setup_failed is False
     lifecycle.note_view_failure("status", admin.EEBusAdminV1Error("admin_boundary_unavailable"))
@@ -129,9 +142,9 @@ def test_actual_ha_wiring_exists_in_config_setup_options_and_sensor_modules() ->
     config = (component / "config_flow.py").read_text()
     options = (component / "options_flow.py").read_text()
     sensor = (component / "sensor.py").read_text()
-    for required in ("EEBusAdminV1Coordinator", "eebus_admin_credential", "hass.data", "async_unload_entry"):
+    for required in ("EEBusAdminV1Coordinator", "CONF_EEBUS_ADMIN_CREDENTIAL", "hass.data", "async_unload_entry"):
         assert required in root
-    for required in ("async_step_reconfigure", "async_step_reauth", "TextSelector", "eebus_admin_credential"):
+    for required in ("async_step_reconfigure", "async_step_reauth", "TextSelector", "CONF_EEBUS_ADMIN_CREDENTIAL"):
         assert required in config
     assert "/portal/eebus" in options and "eebus_admin_credential" not in options
     assert "EEBusAdmin" in sensor and "configuration_url" in sensor

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -119,6 +119,7 @@ class _FakeCoordinator:
 class _FakeEntry:
     def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
+        self.data = {"transport": "https", "host": "gateway.example.test", "port": 8443}
 
 
 class _FakeHass:
@@ -163,6 +164,35 @@ def _build_payload(*, boiler_device_id: tuple[str, str] | None) -> dict:
         "regulator_device_id": ("helianthus", "entry-1-bus-BASV2-15"),
         "regulator_manufacturer": "Vaillant",
     }
+
+
+def test_eebus_admin_sensor_is_one_sanitized_status_scalar_with_bounded_counts() -> None:
+    coordinator = _FakeCoordinator(
+        {
+            "status": {
+                "listener": "ready",
+                "discovery": "ready",
+                "trusted_count": 2,
+                "connected_count": 1,
+                "discovered_count": 3,
+            },
+            "available": True,
+            "stale_views": frozenset(),
+        }
+    )
+    entity = sensor_platform.HelianthusEEBusAdminSensor(
+        coordinator, "entry-1", "https://gateway.example.test:8443"
+    )
+
+    assert entity.native_value == "ready"
+    assert entity.extra_state_attributes == {
+        "discovery": "ready",
+        "trusted_count": 2,
+        "connected_count": 1,
+        "discovered_count": 3,
+        "fresh": True,
+    }
+    assert "partner" not in repr(entity.extra_state_attributes).lower()
 
 
 def test_async_setup_entry_skips_address_only_bus_devices() -> None:


### PR DESCRIPTION
Closes #226

## Summary

- add a candidate-free, read-only Home Assistant client for `helianthus.eebus.operator-admin.v1`
- retain sanitized status/trusted/connected/discovered projections independently with explicit freshness
- expose one bounded diagnostic and a fixed local owner-action URL to `/portal/eebus`

## Security boundary

- machine credential stored in ConfigEntry data and instantiated only for the entry owning the verified gateway GUID/origin
- client-side containment only; the gateway process-wide HA bearer is not claimed as a server-side per-entry principal
- dedicated cookie-less session, redirects disabled, bounded responses, Bearer only
- no browser authority, CSRF, candidate, remote identity/endpoint, raw SHIP/SPINE, trust-store, operator socket, or pairing mutations
- strict v1 HA envelope and per-view schemas; no `state_revision` or `request_id`

## Dependency / doc gate

- gateway merge: `78130598d7420b7d04b35bee8aa86fc0fb3f1d39`
- canonical docs merge: `07de81e32d645f7f4d8fb85cd303e800aced524d`

## TDD

RED commits:

- `fdb2d03a3bdd492519ece627344da8a8b29ace91`
- `a9724521f68a6579840aed059ce459ddf82c24d8`
- `9c3c56320cb8753d7c5af80464e925438c0b1a0c`
- `7a4433431bbdbf5e1c0f4a22c0695da654b23ef7`

Current focused RED: `pytest -q tests/test_eebus_admin.py tests/test_eebus_admin_flow.py` -> 17 failures, exclusively the missing production boundary.

## Validation

- [ ] focused tests
- [ ] full `./scripts/ci_local.sh`
- [ ] fresh exact-HEAD `NO_BLOCKING_FINDINGS`
- [ ] GitHub CI

## Live acceptance

Deferred to the dependent add-on release/live node from execution-plans #92.