### PR TITLE
Cover exact PV M2M response size boundary

### DIFF
--- a/tests/test_pv_m2m.py
+++ b/tests/test_pv_m2m.py
@@ -244,6 +244,27 @@ def test_client_bounds_decompressed_response_before_text_or_json_materialization
     assert sum(response.content.read_sizes) == pv_m2m.M2M_MAX_RESPONSE_BYTES + 1
 
 
+def test_client_accepts_valid_response_at_exact_inclusive_size_limit() -> None:
+    raw = json.dumps(_success_envelope(), separators=(",", ":")).encode("utf-8")
+    raw += b" " * (pv_m2m.M2M_MAX_RESPONSE_BYTES - len(raw))
+    assert len(raw) == pv_m2m.M2M_MAX_RESPONSE_BYTES
+
+    response = _Response({})
+    response.content = _BodyStream(raw, max_chunk=65_536)
+    client = pv_m2m.PVM2MClient(
+        session=_Session([response]),
+        endpoint="https://pv.example.test/graphql/m2m/v1",
+        asset_ref="pv-asset-01",
+    )
+
+    snapshot = asyncio.run(client.async_current_snapshot())
+
+    assert snapshot.asset_ref == "pv-asset-01"
+    assert response.text_calls == 0
+    # The final one-byte read establishes EOF without materializing over-limit data.
+    assert sum(response.content.read_sizes) == pv_m2m.M2M_MAX_RESPONSE_BYTES + 1
+
+
 def test_client_rejects_excessive_json_depth_before_decoder(monkeypatch) -> None:  # noqa: ANN001
     response = _Response({})
     raw = b"[" * 65 + b"0" + b"]" * 65


### PR DESCRIPTION
Closes #232

## Summary
- add a deterministic valid GraphQL response at exactly the inclusive 1 MiB limit
- preserve the existing 1 MiB + 1 rejection proof

## Validation
- `python3 -m pytest tests/test_pv_m2m.py -q`: 41 passed
- `./scripts/ci_local.sh`: PASS

## Boundaries
Test-only. No public API, runtime, Home Assistant deployment, credential, or live I/O change. Docs gate not applicable.