### PR TITLE
Bound stale radio registry cleanup to B524 inventory

### DIFF
--- a/custom_components/helianthus/__init__.py
+++ b/custom_components/helianthus/__init__.py
@@ -752,6 +752,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         resolve_boiler_physical_device_id,
         resolve_boiler_via_device_id,
         should_export_radio_device,
+        should_remove_missing_radio_bus_key,
         stable_bus_identity_model,
     )
     from .subscriptions import start_subscriptions
@@ -1711,7 +1712,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ):
                 remove_entry = True
             elif (radio_bus_key := _radio_bus_key_from_unique_id(unique_id)) is not None:
-                remove_entry = radio_bus_key not in known_radio_bus_keys
+                remove_entry = should_remove_missing_radio_bus_key(
+                    radio_bus_key,
+                    known_radio_bus_keys,
+                    set(b524_merge_targets),
+                )
             else:
                 cylinder_match = cylinder_unique_id_re.match(unique_id)
                 if cylinder_match and int(cylinder_match.group("index")) not in known_cylinder_indexes:
@@ -1741,9 +1746,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             radio_bus_key = _radio_bus_key_from_unique_id(unique_id)
             if radio_bus_key is None:
                 continue
-            if radio_bus_key not in radio_keys_to_remove and not (
-                is_b524_inventory_radio_bus_key(radio_bus_key)
-                and radio_bus_key not in known_radio_bus_keys
+            if radio_bus_key not in radio_keys_to_remove and not should_remove_missing_radio_bus_key(
+                radio_bus_key,
+                known_radio_bus_keys,
+                set(b524_merge_targets),
             ):
                 continue
             entity_registry.async_remove(entity_entry.entity_id)
@@ -1757,9 +1763,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if identifier_domain != DOMAIN or not token.startswith(radio_prefix):
                     continue
                 radio_bus_key = token[len(radio_prefix):]
-                if radio_bus_key in radio_keys_to_remove or (
-                    is_b524_inventory_radio_bus_key(radio_bus_key)
-                    and radio_bus_key not in known_radio_bus_keys
+                if radio_bus_key in radio_keys_to_remove or should_remove_missing_radio_bus_key(
+                    radio_bus_key,
+                    known_radio_bus_keys,
+                    set(b524_merge_targets),
                 ):
                     remove_device = True
                     break
@@ -1829,7 +1836,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 radio_prefix = f"{entry.entry_id}-radio-"
                 if token.startswith(radio_prefix):
                     radio_bus_key = token[len(radio_prefix):]
-                    if radio_bus_key not in known_radio_bus_keys or radio_bus_key in b524_merge_targets:
+                    if should_remove_missing_radio_bus_key(
+                        radio_bus_key,
+                        known_radio_bus_keys,
+                        set(b524_merge_targets),
+                    ):
                         remove_device = True
                         break
             if not remove_device:

--- a/custom_components/helianthus/device_ids.py
+++ b/custom_components/helianthus/device_ids.py
@@ -127,6 +127,18 @@ def is_b524_inventory_radio_bus_key(key: str | None) -> bool:
     return bool(key and key.startswith("g0c-i"))
 
 
+def should_remove_missing_radio_bus_key(
+    key: str,
+    known_keys: set[str],
+    merged_keys: set[str],
+) -> bool:
+    """Return whether a missing radio key is safe to remove from HA registries."""
+
+    return key in merged_keys or (
+        is_b524_inventory_radio_bus_key(key) and key not in known_keys
+    )
+
+
 def exportable_radio_bus_keys(devices: Iterable[object]) -> set[str]:
     """Return radio slot keys that should participate in HA inventory decisions."""
 

--- a/tests/test_device_ids.py
+++ b/tests/test_device_ids.py
@@ -23,6 +23,7 @@ from custom_components.helianthus.device_ids import (
     resolve_boiler_physical_device_id,
     resolve_boiler_via_device_id,
     resolve_bus_address,
+    should_remove_missing_radio_bus_key,
     should_export_radio_device,
     solar_identifier,
     zone_identifier,
@@ -163,6 +164,12 @@ def test_is_b524_inventory_radio_bus_key_matches_only_inventory_group() -> None:
     assert is_b524_inventory_radio_bus_key("g0c-i02")
     assert not is_b524_inventory_radio_bus_key("g09-i02")
     assert not is_b524_inventory_radio_bus_key("")
+
+
+def test_missing_radio_cleanup_is_limited_to_b524_inventory_and_merged_slots() -> None:
+    assert should_remove_missing_radio_bus_key("g0c-i02", set(), set())
+    assert should_remove_missing_radio_bus_key("g09-i02", {"g09-i01"}, {"g09-i02"})
+    assert not should_remove_missing_radio_bus_key("g09-i02", set(), set())
 
 
 def test_alias_faces_share_fallback_key_when_alias_addresses_match() -> None:


### PR DESCRIPTION
Closes #211

## Summary
- restrict automatic missing-radio cleanup to B524 inventory slots and explicitly merged slots
- retain absent non-inventory radio rows so a transient disconnect does not delete them
- keep cleanup of stale B524 inventory entries absent from the exported inventory

## TDD
- RED `66a8090d7c5e44aadb8b7360fd3d4908c8a26212`: missing cleanup predicate import failed collection
- GREEN is this PR head

## Validation
- `python3 -m pytest tests/test_device_ids.py -q`: 20 passed
- `./scripts/ci_local.sh`: 523 passed plus 50 adoption checks

## Gates and boundaries
- Docs gate: not applicable; no public API/entity contract changes.
- Smoke: intentionally not run. Issue acceptance requires a separate operator-confirmed live smoke after merge.
- No Home Assistant deployment, credential, or live I/O.