### PR TITLE
refactor: split coordinator phases

### DIFF
--- a/custom_components/helianthus/coordinator.py
+++ b/custom_components/helianthus/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from copy import deepcopy
 from datetime import timedelta
 import logging
@@ -15,6 +14,20 @@ from .admission import (
     daemon_status_with_admission,
     schema_incompatible_admission,
     source_selection_from_status_payload,
+)
+from .coordinator_availability import (
+    hold_last_known_energy_totals,
+    next_optional_query_state,
+    optional_query_available,
+)
+from .coordinator_fetch import fetch_device_inventory
+from .coordinator_merge import (
+    build_radio_zone_candidates as _build_radio_zone_candidates,
+    is_active_radio_device as _is_active_radio_device,
+    normalize_energy_totals_payload as _normalize_energy_totals_payload,
+    normalize_radio_device as _normalize_radio_device,
+    parse_optional_int as _parse_optional_int,
+    radio_bus_key as _radio_bus_key,
 )
 from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
 
@@ -526,10 +539,27 @@ query Semantic {
 }
 """
 
-_HOLIDAY_FIELDS = ["holiday_start_date", "holiday_end_date", "holiday_setpoint", "holiday_start_time", "holiday_end_time"]
-_QV_FIELDS = ["quick_veto", "quick_veto_setpoint", "quick_veto_duration", "quick_veto_expiry"]
-_SEMANTIC_RECOVERABLE_FIELDS = _HOLIDAY_FIELDS + _QV_FIELDS + ["room_temperature_zone_mapping"]
-_PROMOTED_SEMANTIC_FIELDS = ["operation_mode_changeable", "source_label", "overrun_active"]
+_HOLIDAY_FIELDS = [
+    "holiday_start_date",
+    "holiday_end_date",
+    "holiday_setpoint",
+    "holiday_start_time",
+    "holiday_end_time",
+]
+_QV_FIELDS = [
+    "quick_veto",
+    "quick_veto_setpoint",
+    "quick_veto_duration",
+    "quick_veto_expiry",
+]
+_SEMANTIC_RECOVERABLE_FIELDS = (
+    _HOLIDAY_FIELDS + _QV_FIELDS + ["room_temperature_zone_mapping"]
+)
+_PROMOTED_SEMANTIC_FIELDS = [
+    "operation_mode_changeable",
+    "source_label",
+    "overrun_active",
+]
 _STATUS_SCHEMA_FIELDS = [
     "busSummary",
     "status",
@@ -734,6 +764,7 @@ _RADIO_GROUP_ZONE_VR92 = 0x0A
 _RADIO_GROUP_INVENTORY = 0x0C
 _RADIO_STALE_GRACE_CYCLES = 3
 
+
 class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     """Coordinator fetching GraphQL device inventory."""
 
@@ -747,67 +778,18 @@ class HelianthusCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self._client = client
 
     async def _async_update_data(self) -> list[dict[str, Any]]:
-        async def fetch(query: str) -> list[dict[str, Any]]:
-            payload = await self._client.execute(query)
-            if isinstance(payload, dict):
-                return list(payload.get("devices", []))
-            return []
-
-        async def fetch_with_addresses(
-            query_with_addresses: str, query_without_addresses: str
-        ) -> list[dict[str, Any]]:
-            try:
-                return await fetch(query_with_addresses)
-            except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["addresses"]):
-                    return await fetch(query_without_addresses)
-                raise
-
-        async def fetch_base_devices() -> list[dict[str, Any]]:
-            try:
-                return await fetch_with_addresses(QUERY_BASE, QUERY_BASE_NO_ADDRESSES)
-            except GraphQLClientError as exc:
-                raise UpdateFailed(str(exc)) from exc
-            except GraphQLResponseError as exc:
-                raise UpdateFailed(str(exc)) from exc
-
-        async def fetch_v2_devices() -> list[dict[str, Any]]:
-            try:
-                return await fetch_with_addresses(QUERY_EXTENDED_V2, QUERY_EXTENDED_V2_NO_ADDRESSES)
-            except GraphQLClientError as exc:
-                raise UpdateFailed(str(exc)) from exc
-            except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
-                    return await fetch_base_devices()
-                raise UpdateFailed(str(exc)) from exc
-
-        async def fetch_v3_no_part_devices() -> list[dict[str, Any]]:
-            try:
-                return await fetch_with_addresses(
-                    QUERY_EXTENDED_V3_NO_PART,
-                    QUERY_EXTENDED_V3_NO_PART_NO_ADDRESSES,
-                )
-            except GraphQLClientError as exc:
-                raise UpdateFailed(str(exc)) from exc
-            except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["display_name", "product_family", "product_model"]):
-                    return await fetch_v2_devices()
-                if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
-                    return await fetch_base_devices()
-                raise UpdateFailed(str(exc)) from exc
-
-        try:
-            return await fetch_with_addresses(QUERY_EXTENDED_V3, QUERY_EXTENDED_V3_NO_ADDRESSES)
-        except GraphQLResponseError as exc:
-            if _is_missing_field_error(exc.errors, ["part_number"]):
-                return await fetch_v3_no_part_devices()
-            if _is_missing_field_error(exc.errors, ["display_name", "product_family", "product_model"]):
-                return await fetch_v2_devices()
-            if _is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
-                return await fetch_base_devices()
-            raise UpdateFailed(str(exc)) from exc
-        except GraphQLClientError as exc:
-            raise UpdateFailed(str(exc)) from exc
+        return await fetch_device_inventory(
+            self._client,
+            query_v3=QUERY_EXTENDED_V3,
+            query_v3_no_addresses=QUERY_EXTENDED_V3_NO_ADDRESSES,
+            query_v3_no_part=QUERY_EXTENDED_V3_NO_PART,
+            query_v3_no_part_no_addresses=QUERY_EXTENDED_V3_NO_PART_NO_ADDRESSES,
+            query_v2=QUERY_EXTENDED_V2,
+            query_v2_no_addresses=QUERY_EXTENDED_V2_NO_ADDRESSES,
+            query_base=QUERY_BASE,
+            query_base_no_addresses=QUERY_BASE_NO_ADDRESSES,
+            is_missing_field_error=_is_missing_field_error,
+        )
 
 
 class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -874,7 +856,9 @@ class HelianthusStatusCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
             if force_schema_incompatible
             else source_selection_from_status_payload(payload)
         )
-        daemon = daemon_status_with_admission(payload.get("daemon_status", {}) or {}, raw_admission)
+        daemon = daemon_status_with_admission(
+            payload.get("daemon_status", {}) or {}, raw_admission
+        )
         return {
             "daemon": daemon,
             "adapter": payload.get("adapter_status", {}) or {},
@@ -896,7 +880,13 @@ class HelianthusSemanticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._client = client
 
     async def _async_update_data(self) -> dict[str, Any]:
-        queries = [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY, QUERY_SEMANTIC_NO_QV, QUERY_SEMANTIC_LEGACY]
+        queries = [
+            QUERY_SEMANTIC_PROMOTED,
+            QUERY_SEMANTIC,
+            QUERY_SEMANTIC_NO_HOLIDAY,
+            QUERY_SEMANTIC_NO_QV,
+            QUERY_SEMANTIC_LEGACY,
+        ]
         payload = None
         for query in queries:
             try:
@@ -976,11 +966,7 @@ class HelianthusCircuitCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not isinstance(circuits, list):
             return {"circuits": []}
         return {
-            "circuits": [
-                circuit
-                for circuit in circuits
-                if isinstance(circuit, dict)
-            ]
+            "circuits": [circuit for circuit in circuits if isinstance(circuit, dict)]
         }
 
 
@@ -1230,11 +1216,11 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @property
     def system_installer_available(self) -> bool:
-        return self._system_installer_available is not False
+        return optional_query_available(self._system_installer_available)
 
     @property
     def system_sensitive_available(self) -> bool:
-        return self._system_sensitive_available is not False
+        return optional_query_available(self._system_sensitive_available)
 
     async def _async_update_data(self) -> dict[str, Any]:
         empty = {"state": {}, "config": {}, "properties": {}, "metadata": {}}
@@ -1290,7 +1276,11 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # query: older gateways must retain their system state/config payload.
         try:
             metadata_payload = await self._client.execute(QUERY_SYSTEM_GATEWAY_METADATA)
-            metadata_system = metadata_payload.get("system") if isinstance(metadata_payload, dict) else None
+            metadata_system = (
+                metadata_payload.get("system")
+                if isinstance(metadata_payload, dict)
+                else None
+            )
             if isinstance(metadata_system, dict):
                 result["metadata"] = {
                     key: metadata_system[key]
@@ -1298,7 +1288,9 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if key in metadata_system
                 }
         except GraphQLResponseError as exc:
-            if not _is_missing_field_error(exc.errors, ["gateway_brand", "gateway_vendor"]):
+            if not _is_missing_field_error(
+                exc.errors, ["gateway_brand", "gateway_vendor"]
+            ):
                 raise UpdateFailed(str(exc)) from exc
         except GraphQLClientError:
             pass
@@ -1307,15 +1299,29 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._system_installer_available is not False:
             try:
                 inst_payload = await self._client.execute(QUERY_SYSTEM_INSTALLER)
-                inst_sys = inst_payload.get("system", {}) if isinstance(inst_payload, dict) else {}
-                inst_cfg = inst_sys.get("config", {}) if isinstance(inst_sys, dict) else {}
+                inst_sys = (
+                    inst_payload.get("system", {})
+                    if isinstance(inst_payload, dict)
+                    else {}
+                )
+                inst_cfg = (
+                    inst_sys.get("config", {}) if isinstance(inst_sys, dict) else {}
+                )
                 if isinstance(inst_cfg, dict):
                     result["config"].update(inst_cfg)
-                if self._system_installer_available is None:
-                    self._system_installer_available = True
+                self._system_installer_available = next_optional_query_state(
+                    self._system_installer_available,
+                    response_received=True,
+                )
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["maintenance_date", "installer_name", "installer_phone"]):
-                    self._system_installer_available = False
+                if _is_missing_field_error(
+                    exc.errors,
+                    ["maintenance_date", "installer_name", "installer_phone"],
+                ):
+                    self._system_installer_available = next_optional_query_state(
+                        self._system_installer_available,
+                        schema_field_missing=True,
+                    )
             except GraphQLClientError:
                 pass  # transient — retry next cycle
 
@@ -1323,15 +1329,26 @@ class HelianthusSystemCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._system_sensitive_available is not False:
             try:
                 sens_payload = await self._client.execute(QUERY_SYSTEM_SENSITIVE)
-                sens_sys = sens_payload.get("system", {}) if isinstance(sens_payload, dict) else {}
-                sens_cfg = sens_sys.get("config", {}) if isinstance(sens_sys, dict) else {}
+                sens_sys = (
+                    sens_payload.get("system", {})
+                    if isinstance(sens_payload, dict)
+                    else {}
+                )
+                sens_cfg = (
+                    sens_sys.get("config", {}) if isinstance(sens_sys, dict) else {}
+                )
                 if isinstance(sens_cfg, dict):
                     result["config"].update(sens_cfg)
-                if self._system_sensitive_available is None:
-                    self._system_sensitive_available = True
+                self._system_sensitive_available = next_optional_query_state(
+                    self._system_sensitive_available,
+                    response_received=True,
+                )
             except GraphQLResponseError as exc:
                 if _is_missing_field_error(exc.errors, ["installer_menu_code"]):
-                    self._system_sensitive_available = False
+                    self._system_sensitive_available = next_optional_query_state(
+                        self._system_sensitive_available,
+                        schema_field_missing=True,
+                    )
             except GraphQLClientError:
                 pass  # transient — retry next cycle
 
@@ -1376,10 +1393,9 @@ class HelianthusEnergyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {"energy_totals": deepcopy(totals)}
 
     def _hold_last_valid_energy_totals(self) -> dict[str, Any]:
-        totals = getattr(self, "_last_valid_energy_totals", None)
-        if isinstance(totals, dict):
-            return {"energy_totals": deepcopy(totals)}
-        return {"energy_totals": None}
+        return hold_last_known_energy_totals(
+            getattr(self, "_last_valid_energy_totals", None)
+        )
 
 
 QUERY_BOILER_INSTALLER = """
@@ -1425,11 +1441,11 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @property
     def boiler_installer_available(self) -> bool:
-        return self._boiler_installer_available is not False
+        return optional_query_available(self._boiler_installer_available)
 
     @property
     def boiler_sensitive_available(self) -> bool:
-        return self._boiler_sensitive_available is not False
+        return optional_query_available(self._boiler_sensitive_available)
 
     async def _async_update_data(self) -> dict[str, Any]:
         try:
@@ -1490,15 +1506,30 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._boiler_installer_available is not False:
             try:
                 inst_payload = await self._client.execute(QUERY_BOILER_INSTALLER)
-                inst_boiler = inst_payload.get("boiler_status", {}) if isinstance(inst_payload, dict) else {}
-                inst_cfg = inst_boiler.get("config", {}) if isinstance(inst_boiler, dict) else {}
+                inst_boiler = (
+                    inst_payload.get("boiler_status", {})
+                    if isinstance(inst_payload, dict)
+                    else {}
+                )
+                inst_cfg = (
+                    inst_boiler.get("config", {})
+                    if isinstance(inst_boiler, dict)
+                    else {}
+                )
                 if isinstance(inst_cfg, dict):
                     config.update(inst_cfg)
-                if self._boiler_installer_available is None:
-                    self._boiler_installer_available = True
+                self._boiler_installer_available = next_optional_query_state(
+                    self._boiler_installer_available,
+                    response_received=True,
+                )
             except GraphQLResponseError as exc:
-                if _is_missing_field_error(exc.errors, ["phone_number", "hours_till_service"]):
-                    self._boiler_installer_available = False
+                if _is_missing_field_error(
+                    exc.errors, ["phone_number", "hours_till_service"]
+                ):
+                    self._boiler_installer_available = next_optional_query_state(
+                        self._boiler_installer_available,
+                        schema_field_missing=True,
+                    )
             except GraphQLClientError:
                 pass
 
@@ -1506,15 +1537,28 @@ class HelianthusBoilerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._boiler_sensitive_available is not False:
             try:
                 sens_payload = await self._client.execute(QUERY_BOILER_SENSITIVE)
-                sens_boiler = sens_payload.get("boiler_status", {}) if isinstance(sens_payload, dict) else {}
-                sens_cfg = sens_boiler.get("config", {}) if isinstance(sens_boiler, dict) else {}
+                sens_boiler = (
+                    sens_payload.get("boiler_status", {})
+                    if isinstance(sens_payload, dict)
+                    else {}
+                )
+                sens_cfg = (
+                    sens_boiler.get("config", {})
+                    if isinstance(sens_boiler, dict)
+                    else {}
+                )
                 if isinstance(sens_cfg, dict):
                     config.update(sens_cfg)
-                if self._boiler_sensitive_available is None:
-                    self._boiler_sensitive_available = True
+                self._boiler_sensitive_available = next_optional_query_state(
+                    self._boiler_sensitive_available,
+                    response_received=True,
+                )
             except GraphQLResponseError as exc:
                 if _is_missing_field_error(exc.errors, ["installer_menu_code"]):
-                    self._boiler_sensitive_available = False
+                    self._boiler_sensitive_available = next_optional_query_state(
+                        self._boiler_sensitive_available,
+                        schema_field_missing=True,
+                    )
             except GraphQLClientError:
                 pass
 
@@ -1595,150 +1639,6 @@ class HelianthusScheduleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return {"programs": programs}
 
 
-def _parse_optional_int(value: Any) -> int | None:
-    if isinstance(value, bool):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _parse_optional_float(value: Any) -> float | None:
-    if isinstance(value, bool):
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _normalize_radio_device(raw: dict[str, Any]) -> dict[str, Any] | None:
-    group = _parse_optional_int(raw.get("group"))
-    instance = _parse_optional_int(raw.get("instance"))
-    if group is None or instance is None:
-        return None
-    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
-        return None
-
-    normalized: dict[str, Any] = {
-        "group": group,
-        "instance": instance,
-        "slot_mode": str(raw.get("slot_mode") or "").strip() or "active",
-    }
-
-    connected = raw.get("device_connected")
-    if isinstance(connected, bool):
-        normalized["device_connected"] = connected
-    class_address = _parse_optional_int(raw.get("device_class_address"))
-    if class_address is not None and 0 <= class_address <= 0xFF:
-        normalized["device_class_address"] = class_address
-
-    device_model = str(raw.get("device_model") or "").strip()
-    if device_model:
-        normalized["device_model"] = device_model
-    firmware = str(raw.get("firmware_version") or "").strip()
-    if firmware:
-        normalized["firmware_version"] = firmware
-
-    hardware_identifier = _parse_optional_int(raw.get("hardware_identifier"))
-    if hardware_identifier is not None and hardware_identifier >= 0:
-        normalized["hardware_identifier"] = hardware_identifier
-    remote_control_address = _parse_optional_int(raw.get("remote_control_address"))
-    if remote_control_address is not None and remote_control_address >= 0:
-        normalized["remote_control_address"] = remote_control_address
-    paired = raw.get("device_paired")
-    if isinstance(paired, bool):
-        normalized["device_paired"] = paired
-    reception_strength = _parse_optional_int(raw.get("reception_strength"))
-    if reception_strength is not None:
-        normalized["reception_strength"] = reception_strength
-    zone_assignment = _parse_optional_int(raw.get("zone_assignment"))
-    if zone_assignment is not None and zone_assignment >= 0:
-        normalized["zone_assignment"] = zone_assignment
-    room_temperature = _parse_optional_float(raw.get("room_temperature_c"))
-    if room_temperature is not None:
-        normalized["room_temperature_c"] = room_temperature
-    room_humidity = _parse_optional_float(raw.get("room_humidity_pct"))
-    if room_humidity is not None:
-        normalized["room_humidity_pct"] = room_humidity
-
-    return normalized
-
-
-def _has_radio_identity_evidence(device: dict[str, Any]) -> bool:
-    class_address = _parse_optional_int(device.get("device_class_address"))
-    if class_address == 0x26:
-        return True
-    if str(device.get("device_model") or "").strip():
-        return True
-    if str(device.get("firmware_version") or "").strip():
-        return True
-    hardware_identifier = _parse_optional_int(device.get("hardware_identifier"))
-    if hardware_identifier is not None and hardware_identifier > 0:
-        return True
-    return False
-
-
-def _is_active_radio_device(device: dict[str, Any]) -> bool:
-    group = _parse_optional_int(device.get("group"))
-    if group is None:
-        return False
-    connected = device.get("device_connected") is True
-    if group in (_RADIO_GROUP_ZONE_VRC, _RADIO_GROUP_ZONE_VR92):
-        return connected
-    if group == _RADIO_GROUP_INVENTORY:
-        return _has_radio_identity_evidence(device)
-    return connected or _has_radio_identity_evidence(device)
-
-
-def _radio_bus_key(group: int, instance: int) -> str:
-    return f"g{group:02x}-i{instance:02d}"
-
-
-def _build_radio_zone_candidates(
-    active_by_slot: dict[tuple[int, int], dict[str, Any]],
-) -> dict[int, list[dict[str, Any]]]:
-    by_zone: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
-    for (_, _), device in active_by_slot.items():
-        group = _parse_optional_int(device.get("group"))
-        instance = _parse_optional_int(device.get("instance"))
-        if group not in (_RADIO_GROUP_ZONE_VRC, _RADIO_GROUP_ZONE_VR92):
-            continue
-        if instance is None:
-            continue
-        if device.get("device_connected") is not True:
-            continue
-        zone_assignment = _parse_optional_int(device.get("zone_assignment"))
-        if zone_assignment is None or zone_assignment <= 0:
-            continue
-        zone_instance = zone_assignment - 1
-        by_zone[zone_instance].append(
-            {
-                "group": group,
-                "instance": instance,
-                "remote_control_address": _parse_optional_int(device.get("remote_control_address")),
-                "radio_bus_key": _radio_bus_key(group, instance),
-            }
-        )
-
-    out: dict[int, list[dict[str, Any]]] = {}
-    for zone_instance, candidates in by_zone.items():
-        candidates.sort(
-            key=lambda item: (
-                int(item.get("group") or 0),
-                (
-                    int(item["remote_control_address"])
-                    if isinstance(item.get("remote_control_address"), int)
-                    else 255
-                ),
-                int(item.get("instance") or 0),
-            )
-        )
-        out[zone_instance] = candidates
-    return out
-
-
 def _is_missing_field_error(errors: object, fields: list[str]) -> bool:
     if not isinstance(errors, list):
         return False
@@ -1752,26 +1652,6 @@ def _is_missing_field_error(errors: object, fields: list[str]) -> bool:
             if f'Cannot query field "{field}"' in message:
                 return True
     return False
-
-
-def _normalize_energy_totals_payload(payload: Any) -> dict[str, Any] | None:
-    if not isinstance(payload, dict):
-        return None
-    totals = payload.get("energy_totals")
-    if not isinstance(totals, dict):
-        return None
-
-    for channel_name in ("gas", "electric", "solar"):
-        channel = totals.get(channel_name)
-        if not isinstance(channel, dict):
-            return None
-        for usage in ("dhw", "climate"):
-            series = channel.get(usage)
-            if not isinstance(series, dict):
-                return None
-            if "today" not in series or "yearly" not in series:
-                return None
-    return totals
 
 
 QUERY_ADAPTER_HARDWARE_INFO = """
@@ -1854,11 +1734,16 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
         self._client = client
         self._hardware_info_supported: bool | None = None
         self._hardware_info_reprobe_at: float | None = None
-        self._hardware_info_reprobe_delay_s = _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S
+        self._hardware_info_reprobe_delay_s = (
+            _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S
+        )
 
     async def _async_update_data(self) -> dict[str, Any] | None:
         now = time.monotonic()
-        if self._hardware_info_reprobe_at is not None and now < self._hardware_info_reprobe_at:
+        if (
+            self._hardware_info_reprobe_at is not None
+            and now < self._hardware_info_reprobe_at
+        ):
             return None
 
         query = (
@@ -1879,9 +1764,13 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
                 ):
                     self._hardware_info_supported = False
                 try:
-                    payload = await self._client.execute(QUERY_ADAPTER_HARDWARE_INFO_MINIMAL)
+                    payload = await self._client.execute(
+                        QUERY_ADAPTER_HARDWARE_INFO_MINIMAL
+                    )
                 except GraphQLResponseError as minimal_exc:
-                    if _is_missing_field_error(minimal_exc.errors, ["adapter_hardware_info"]):
+                    if _is_missing_field_error(
+                        minimal_exc.errors, ["adapter_hardware_info"]
+                    ):
                         self._schedule_hardware_info_reprobe(now)
                     return None
                 except GraphQLClientError:
@@ -1912,4 +1801,6 @@ class HelianthusAdapterInfoCoordinator(DataUpdateCoordinator[dict[str, Any] | No
 
     def _reset_hardware_info_reprobe(self) -> None:
         self._hardware_info_reprobe_at = None
-        self._hardware_info_reprobe_delay_s = _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S
+        self._hardware_info_reprobe_delay_s = (
+            _ADAPTER_HARDWARE_INFO_REPROBE_INITIAL_DELAY_S
+        )

--- a/custom_components/helianthus/coordinator_availability.py
+++ b/custom_components/helianthus/coordinator_availability.py
@@ -1,0 +1,35 @@
+"""Private availability and last-known-data phases for coordinators."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def optional_query_available(state: bool | None) -> bool:
+    """Return the established public availability projection for an optional query."""
+
+    return state is not False
+
+
+def next_optional_query_state(
+    state: bool | None,
+    *,
+    schema_field_missing: bool = False,
+    response_received: bool = False,
+) -> bool | None:
+    """Advance optional-query support state without treating transient failures as absent."""
+
+    if schema_field_missing:
+        return False
+    if response_received and state is None:
+        return True
+    return state
+
+
+def hold_last_known_energy_totals(totals: dict[str, Any] | None) -> dict[str, Any]:
+    """Return an isolated copy of the last valid energy-total snapshot."""
+
+    if isinstance(totals, dict):
+        return {"energy_totals": deepcopy(totals)}
+    return {"energy_totals": None}

--- a/custom_components/helianthus/coordinator_fetch.py
+++ b/custom_components/helianthus/coordinator_fetch.py
@@ -1,0 +1,89 @@
+"""Private fetch phases shared by Helianthus coordinators."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from .graphql import GraphQLClient, GraphQLClientError, GraphQLResponseError
+
+
+async def fetch_device_inventory(
+    client: GraphQLClient,
+    *,
+    query_v3: str,
+    query_v3_no_addresses: str,
+    query_v3_no_part: str,
+    query_v3_no_part_no_addresses: str,
+    query_v2: str,
+    query_v2_no_addresses: str,
+    query_base: str,
+    query_base_no_addresses: str,
+    is_missing_field_error: Callable[[object, list[str]], bool],
+) -> list[dict[str, Any]]:
+    """Fetch device inventory through the established schema fallback order."""
+
+    async def fetch(query: str) -> list[dict[str, Any]]:
+        payload = await client.execute(query)
+        if isinstance(payload, dict):
+            return list(payload.get("devices", []))
+        return []
+
+    async def fetch_with_addresses(
+        query_with_addresses: str, query_without_addresses: str
+    ) -> list[dict[str, Any]]:
+        try:
+            return await fetch(query_with_addresses)
+        except GraphQLResponseError as exc:
+            if is_missing_field_error(exc.errors, ["addresses"]):
+                return await fetch(query_without_addresses)
+            raise
+
+    async def fetch_base_devices() -> list[dict[str, Any]]:
+        try:
+            return await fetch_with_addresses(query_base, query_base_no_addresses)
+        except (GraphQLClientError, GraphQLResponseError) as exc:
+            raise UpdateFailed(str(exc)) from exc
+
+    async def fetch_v2_devices() -> list[dict[str, Any]]:
+        try:
+            return await fetch_with_addresses(query_v2, query_v2_no_addresses)
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLResponseError as exc:
+            if is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
+                return await fetch_base_devices()
+            raise UpdateFailed(str(exc)) from exc
+
+    async def fetch_v3_no_part_devices() -> list[dict[str, Any]]:
+        try:
+            return await fetch_with_addresses(
+                query_v3_no_part, query_v3_no_part_no_addresses
+            )
+        except GraphQLClientError as exc:
+            raise UpdateFailed(str(exc)) from exc
+        except GraphQLResponseError as exc:
+            if is_missing_field_error(
+                exc.errors, ["display_name", "product_family", "product_model"]
+            ):
+                return await fetch_v2_devices()
+            if is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
+                return await fetch_base_devices()
+            raise UpdateFailed(str(exc)) from exc
+
+    try:
+        return await fetch_with_addresses(query_v3, query_v3_no_addresses)
+    except GraphQLResponseError as exc:
+        if is_missing_field_error(exc.errors, ["part_number"]):
+            return await fetch_v3_no_part_devices()
+        if is_missing_field_error(
+            exc.errors, ["display_name", "product_family", "product_model"]
+        ):
+            return await fetch_v2_devices()
+        if is_missing_field_error(exc.errors, ["serial_number", "mac_address"]):
+            return await fetch_base_devices()
+        raise UpdateFailed(str(exc)) from exc
+    except GraphQLClientError as exc:
+        raise UpdateFailed(str(exc)) from exc

--- a/custom_components/helianthus/coordinator_merge.py
+++ b/custom_components/helianthus/coordinator_merge.py
@@ -1,0 +1,171 @@
+"""Private normalization and merge phases for Helianthus coordinators."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+
+def parse_optional_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_optional_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_radio_device(raw: dict[str, Any]) -> dict[str, Any] | None:
+    group = parse_optional_int(raw.get("group"))
+    instance = parse_optional_int(raw.get("instance"))
+    if group is None or instance is None:
+        return None
+    if group < 0 or group > 0xFF or instance < 0 or instance > 0xFF:
+        return None
+
+    normalized: dict[str, Any] = {
+        "group": group,
+        "instance": instance,
+        "slot_mode": str(raw.get("slot_mode") or "").strip() or "active",
+    }
+
+    connected = raw.get("device_connected")
+    if isinstance(connected, bool):
+        normalized["device_connected"] = connected
+    class_address = parse_optional_int(raw.get("device_class_address"))
+    if class_address is not None and 0 <= class_address <= 0xFF:
+        normalized["device_class_address"] = class_address
+
+    device_model = str(raw.get("device_model") or "").strip()
+    if device_model:
+        normalized["device_model"] = device_model
+    firmware = str(raw.get("firmware_version") or "").strip()
+    if firmware:
+        normalized["firmware_version"] = firmware
+
+    hardware_identifier = parse_optional_int(raw.get("hardware_identifier"))
+    if hardware_identifier is not None and hardware_identifier >= 0:
+        normalized["hardware_identifier"] = hardware_identifier
+    remote_control_address = parse_optional_int(raw.get("remote_control_address"))
+    if remote_control_address is not None and remote_control_address >= 0:
+        normalized["remote_control_address"] = remote_control_address
+    paired = raw.get("device_paired")
+    if isinstance(paired, bool):
+        normalized["device_paired"] = paired
+    reception_strength = parse_optional_int(raw.get("reception_strength"))
+    if reception_strength is not None:
+        normalized["reception_strength"] = reception_strength
+    zone_assignment = parse_optional_int(raw.get("zone_assignment"))
+    if zone_assignment is not None and zone_assignment >= 0:
+        normalized["zone_assignment"] = zone_assignment
+    room_temperature = parse_optional_float(raw.get("room_temperature_c"))
+    if room_temperature is not None:
+        normalized["room_temperature_c"] = room_temperature
+    room_humidity = parse_optional_float(raw.get("room_humidity_pct"))
+    if room_humidity is not None:
+        normalized["room_humidity_pct"] = room_humidity
+    return normalized
+
+
+def has_radio_identity_evidence(device: dict[str, Any]) -> bool:
+    class_address = parse_optional_int(device.get("device_class_address"))
+    if class_address == 0x26:
+        return True
+    if str(device.get("device_model") or "").strip():
+        return True
+    if str(device.get("firmware_version") or "").strip():
+        return True
+    hardware_identifier = parse_optional_int(device.get("hardware_identifier"))
+    if hardware_identifier is not None and hardware_identifier > 0:
+        return True
+    return False
+
+
+def is_active_radio_device(
+    device: dict[str, Any], *, zone_groups: tuple[int, int] = (0x09, 0x0A)
+) -> bool:
+    group = parse_optional_int(device.get("group"))
+    if group is None:
+        return False
+    connected = device.get("device_connected") is True
+    if group in zone_groups:
+        return connected
+    if group == 0x0C:
+        return has_radio_identity_evidence(device)
+    return connected or has_radio_identity_evidence(device)
+
+
+def radio_bus_key(group: int, instance: int) -> str:
+    return f"g{group:02x}-i{instance:02d}"
+
+
+def build_radio_zone_candidates(
+    active_by_slot: dict[tuple[int, int], dict[str, Any]],
+    *,
+    zone_groups: tuple[int, int] = (0x09, 0x0A),
+) -> dict[int, list[dict[str, Any]]]:
+    candidates: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for (_, _), device in active_by_slot.items():
+        group = parse_optional_int(device.get("group"))
+        instance = parse_optional_int(device.get("instance"))
+        if group not in zone_groups:
+            continue
+        if instance is None:
+            continue
+        if device.get("device_connected") is not True:
+            continue
+        zone_assignment = parse_optional_int(device.get("zone_assignment"))
+        if zone_assignment is None or zone_assignment <= 0:
+            continue
+        zone_instance = zone_assignment - 1
+        candidates[zone_instance].append(
+            {
+                "group": group,
+                "instance": instance,
+                "remote_control_address": parse_optional_int(
+                    device.get("remote_control_address")
+                ),
+                "radio_bus_key": radio_bus_key(group, instance),
+            }
+        )
+    out: dict[int, list[dict[str, Any]]] = {}
+    for zone_instance, entries in candidates.items():
+        entries.sort(
+            key=lambda item: (
+                int(item.get("group") or 0),
+                int(item["remote_control_address"])
+                if isinstance(item.get("remote_control_address"), int)
+                else 255,
+                int(item.get("instance") or 0),
+            )
+        )
+        out[zone_instance] = entries
+    return out
+
+
+def normalize_energy_totals_payload(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    totals = payload.get("energy_totals")
+    if not isinstance(totals, dict):
+        return None
+    for channel_name in ("gas", "electric", "solar"):
+        channel = totals.get(channel_name)
+        if not isinstance(channel, dict):
+            return None
+        for usage in ("dhw", "climate"):
+            series = channel.get(usage)
+            if not isinstance(series, dict):
+                return None
+            if "today" not in series or "yearly" not in series:
+                return None
+    return totals

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,7 +31,9 @@ homeassistant_module = types.ModuleType("homeassistant")
 homeassistant_module.helpers = helpers_module
 sys.modules.setdefault("homeassistant", homeassistant_module)
 sys.modules.setdefault("homeassistant.helpers", helpers_module)
-sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_coordinator_module)
+sys.modules.setdefault(
+    "homeassistant.helpers.update_coordinator", update_coordinator_module
+)
 
 import custom_components.helianthus.coordinator as coordinator_module
 
@@ -57,9 +59,10 @@ from custom_components.helianthus.coordinator import (
     QUERY_STATUS,
     QUERY_STATUS_NO_INITIATOR,
     QUERY_STATUS_MINIMAL,
-    QUERY_STATUS_LEGACY,
     QUERY_SYSTEM,
     QUERY_SYSTEM_GATEWAY_METADATA,
+    QUERY_SYSTEM_INSTALLER,
+    QUERY_SYSTEM_SENSITIVE,
     UpdateFailed,
     HelianthusBoilerCoordinator,
     HelianthusCircuitCoordinator,
@@ -74,7 +77,10 @@ from custom_components.helianthus.coordinator import (
     HelianthusStatusCoordinator,
     QUERY_SCHEDULES,
 )
-from custom_components.helianthus.graphql import GraphQLClientError, GraphQLResponseError
+from custom_components.helianthus.graphql import (
+    GraphQLClientError,
+    GraphQLResponseError,
+)
 
 
 class _ScriptedClient:
@@ -104,7 +110,9 @@ def _build_status_coordinator(client: _ScriptedClient) -> HelianthusStatusCoordi
     return coordinator
 
 
-def _build_adapter_info_coordinator(client: _ScriptedClient) -> HelianthusAdapterInfoCoordinator:
+def _build_adapter_info_coordinator(
+    client: _ScriptedClient,
+) -> HelianthusAdapterInfoCoordinator:
     coordinator = object.__new__(HelianthusAdapterInfoCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     coordinator._hardware_info_supported = None  # type: ignore[attr-defined]
@@ -144,13 +152,17 @@ def _build_energy_coordinator(client: _ScriptedClient) -> HelianthusEnergyCoordi
     return coordinator
 
 
-def _build_radio_coordinator(client: _ScriptedClient) -> HelianthusRadioDeviceCoordinator:
+def _build_radio_coordinator(
+    client: _ScriptedClient,
+) -> HelianthusRadioDeviceCoordinator:
     coordinator = object.__new__(HelianthusRadioDeviceCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     coordinator._last_by_slot = {}  # type: ignore[attr-defined]
     coordinator._stale_cycles = {}  # type: ignore[attr-defined]
     coordinator.data = {}  # type: ignore[attr-defined]
-    coordinator.async_set_updated_data = lambda payload: setattr(coordinator, "data", payload)  # type: ignore[attr-defined]
+    coordinator.async_set_updated_data = lambda payload: setattr(
+        coordinator, "data", payload
+    )  # type: ignore[attr-defined]
     return coordinator
 
 
@@ -280,7 +292,11 @@ def test_v2_fallback_drops_addresses_when_missing() -> None:
 
     assert len(data) == 1
     assert data[0]["address"] == 21
-    assert client.calls == [QUERY_EXTENDED_V3, QUERY_EXTENDED_V2, QUERY_EXTENDED_V2_NO_ADDRESSES]
+    assert client.calls == [
+        QUERY_EXTENDED_V3,
+        QUERY_EXTENDED_V2,
+        QUERY_EXTENDED_V2_NO_ADDRESSES,
+    ]
 
 
 def test_status_query_uses_initiator_field_when_available() -> None:
@@ -331,7 +347,11 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "initiator_address" on type "ServiceStatus".'}]
+                [
+                    {
+                        "message": 'Cannot query field "initiator_address" on type "ServiceStatus".'
+                    }
+                ]
             ),
             {
                 "daemon_status": {
@@ -358,11 +378,17 @@ def test_status_query_falls_back_when_initiator_field_missing() -> None:
     assert client.calls == [QUERY_STATUS, QUERY_STATUS_NO_INITIATOR]
 
 
-def test_status_query_legacy_gateway_falls_back_after_no_initiator_query_error() -> None:
+def test_status_query_legacy_gateway_falls_back_after_no_initiator_query_error() -> (
+    None
+):
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "initiator_address" on type "ServiceStatus".'}]
+                [
+                    {
+                        "message": 'Cannot query field "initiator_address" on type "ServiceStatus".'
+                    }
+                ]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "busSummary" on type "Query".'}]
@@ -388,14 +414,22 @@ def test_status_query_legacy_gateway_falls_back_after_no_initiator_query_error()
     assert data["daemon"]["status"] == "running"
     assert data["admission"]["trusted"] is False
     assert data["admission"]["repair_code"] == "schema_incompatible"
-    assert client.calls == [QUERY_STATUS, QUERY_STATUS_NO_INITIATOR, QUERY_STATUS_MINIMAL]
+    assert client.calls == [
+        QUERY_STATUS,
+        QUERY_STATUS_NO_INITIATOR,
+        QUERY_STATUS_MINIMAL,
+    ]
 
 
 def test_status_query_partial_source_selection_schema_fails_closed() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "failed_source" on type "BusAdmissionSourceSelection".'}]
+                [
+                    {
+                        "message": 'Cannot query field "failed_source" on type "BusAdmissionSourceSelection".'
+                    }
+                ]
             ),
             {
                 "daemon_status": {
@@ -483,10 +517,18 @@ def test_adapter_info_query_missing_root_field_reprobes_after_backoff(
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "adapter_hardware_info" on type "Query".'}]
+                [
+                    {
+                        "message": 'Cannot query field "adapter_hardware_info" on type "Query".'
+                    }
+                ]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "adapter_hardware_info" on type "Query".'}]
+                [
+                    {
+                        "message": 'Cannot query field "adapter_hardware_info" on type "Query".'
+                    }
+                ]
             ),
         ]
     )
@@ -553,7 +595,11 @@ def test_adapter_info_query_subfield_incompatibility_sticks_to_minimal_mode() ->
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "bootloader_version" on type "AdapterHardwareInfo".'}]
+                [
+                    {
+                        "message": 'Cannot query field "bootloader_version" on type "AdapterHardwareInfo".'
+                    }
+                ]
             ),
             {
                 "adapter_hardware_info": {
@@ -636,7 +682,11 @@ def test_boiler_query_missing_nested_field_falls_back_to_none() -> None:
     client = _ScriptedClient(
         [
             GraphQLResponseError(
-                [{"message": 'Cannot query field "central_heating_pump_active" on type "BoilerState".'}]
+                [
+                    {
+                        "message": 'Cannot query field "central_heating_pump_active" on type "BoilerState".'
+                    }
+                ]
             )
         ]
     )
@@ -768,7 +818,9 @@ def test_radio_query_builds_candidates_and_inventory_slot() -> None:
 
     data = asyncio.run(coordinator._async_update_data())
 
-    slots = {(int(item["group"]), int(item["instance"])) for item in data["radio_devices"]}
+    slots = {
+        (int(item["group"]), int(item["instance"])) for item in data["radio_devices"]
+    }
     assert slots == {(0x09, 1), (0x0C, 1)}
     assert 1 in data["radio_zone_candidates"]
     assert data["radio_zone_candidates"][1][0]["group"] == 0x09
@@ -796,15 +848,36 @@ def test_radio_query_uses_stale_grace_cycles_for_disconnected_slot() -> None:
     first = asyncio.run(coordinator._async_update_data())
     assert len(first["radio_devices"]) == 1
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
+        [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "device_connected": False,
+                "device_class_address": 0x15,
+            }
+        ]
     )
     assert coordinator.data["radio_devices"][0]["stale_cycles"] == 1  # type: ignore[index]
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
+        [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "device_connected": False,
+                "device_class_address": 0x15,
+            }
+        ]
     )
     assert coordinator.data["radio_devices"][0]["stale_cycles"] == 2  # type: ignore[index]
     coordinator.apply_radio_update(
-        [{"group": 0x09, "instance": 1, "device_connected": False, "device_class_address": 0x15}]
+        [
+            {
+                "group": 0x09,
+                "instance": 1,
+                "device_connected": False,
+                "device_class_address": 0x15,
+            }
+        ]
     )
     assert coordinator.data["radio_devices"][0]["stale_cycles"] == 3  # type: ignore[index]
 
@@ -902,7 +975,9 @@ def test_energy_query_falls_back_to_legacy_when_monthly_unsupported() -> None:
     assert coordinator._monthly_supported is False
 
 
-def _build_schedule_coordinator(client: _ScriptedClient) -> HelianthusScheduleCoordinator:
+def _build_schedule_coordinator(
+    client: _ScriptedClient,
+) -> HelianthusScheduleCoordinator:
     coordinator = object.__new__(HelianthusScheduleCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     coordinator.schedule_supported = True  # type: ignore[attr-defined]
@@ -918,7 +993,10 @@ def test_schedule_coordinator_returns_programs() -> None:
                     "hc": "heating",
                     "config": {"max_slots": 12, "has_temperature": True},
                     "days": [
-                        {"weekday": "monday", "slots": [{"start_hour": 6, "end_hour": 22}]}
+                        {
+                            "weekday": "monday",
+                            "slots": [{"start_hour": 6, "end_hour": 22}],
+                        }
                     ],
                 }
             ]
@@ -936,11 +1014,13 @@ def test_schedule_coordinator_returns_programs() -> None:
 
 
 def test_schedule_coordinator_returns_empty_on_missing_field() -> None:
-    client = _ScriptedClient([
-        GraphQLResponseError(
-            [{"message": 'Cannot query field "schedules" on type "Query".'}]
-        ),
-    ])
+    client = _ScriptedClient(
+        [
+            GraphQLResponseError(
+                [{"message": 'Cannot query field "schedules" on type "Query".'}]
+            ),
+        ]
+    )
     coordinator = _build_schedule_coordinator(client)
 
     result = asyncio.run(coordinator._async_update_data())
@@ -961,7 +1041,9 @@ def test_schedule_coordinator_returns_empty_on_null_schedules() -> None:
 # --- Semantic coordinator quick veto fallback tests ---
 
 
-def _build_semantic_coordinator(client: _ScriptedClient) -> HelianthusSemanticCoordinator:
+def _build_semantic_coordinator(
+    client: _ScriptedClient,
+) -> HelianthusSemanticCoordinator:
     coordinator = object.__new__(HelianthusSemanticCoordinator)
     coordinator._client = client  # type: ignore[attr-defined]
     return coordinator
@@ -1012,7 +1094,11 @@ def test_semantic_falls_back_to_no_holiday() -> None:
                 [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
+                [
+                    {
+                        "message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'
+                    }
+                ]
             ),
             _semantic_payload(),
         ]
@@ -1022,7 +1108,11 @@ def test_semantic_falls_back_to_no_holiday() -> None:
     result = asyncio.run(coordinator._async_update_data())
 
     assert len(result["zones"]) == 1
-    assert client.calls == [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC, QUERY_SEMANTIC_NO_HOLIDAY]
+    assert client.calls == [
+        QUERY_SEMANTIC_PROMOTED,
+        QUERY_SEMANTIC,
+        QUERY_SEMANTIC_NO_HOLIDAY,
+    ]
 
 
 def test_semantic_falls_back_to_no_qv() -> None:
@@ -1032,7 +1122,11 @@ def test_semantic_falls_back_to_no_qv() -> None:
                 [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
+                [
+                    {
+                        "message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'
+                    }
+                ]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
@@ -1060,7 +1154,11 @@ def test_semantic_falls_back_to_legacy() -> None:
                 [{"message": 'Cannot query field "source_label" on type "ZoneConfig".'}]
             ),
             GraphQLResponseError(
-                [{"message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'}]
+                [
+                    {
+                        "message": 'Cannot query field "holiday_start_date" on type "ZoneConfig".'
+                    }
+                ]
             ),
             GraphQLResponseError(
                 [{"message": 'Cannot query field "quick_veto" on type "ZoneConfig".'}]
@@ -1104,9 +1202,14 @@ def test_semantic_returns_empty_on_zones_missing() -> None:
     assert result == {"zones": [], "dhw": None}
 
 
-def test_semantic_missing_promoted_fields_preserves_existing_zone_and_dhw_payload() -> None:
+def test_semantic_missing_promoted_fields_preserves_existing_zone_and_dhw_payload() -> (
+    None
+):
     payload = _semantic_payload()
-    payload["dhw"] = {"state": {"current_temp_c": 0.0}, "config": {"target_temp_c": 0.0}}
+    payload["dhw"] = {
+        "state": {"current_temp_c": 0.0},
+        "config": {"target_temp_c": 0.0},
+    }
     client = _ScriptedClient(
         [
             GraphQLResponseError(
@@ -1123,7 +1226,9 @@ def test_semantic_missing_promoted_fields_preserves_existing_zone_and_dhw_payloa
     assert client.calls == [QUERY_SEMANTIC_PROMOTED, QUERY_SEMANTIC]
 
 
-def test_promoted_semantic_queries_cover_all_public_leaves_without_protocol_leaks() -> None:
+def test_promoted_semantic_queries_cover_all_public_leaves_without_protocol_leaks() -> (
+    None
+):
     """Keep the 18-leaf MSP-09C contract at existing public query roots only."""
     semantic_paths = {
         "/dhw/operating_mode": "operating_mode",
@@ -1147,7 +1252,9 @@ def test_promoted_semantic_queries_cover_all_public_leaves_without_protocol_leak
     }
 
     assert len(semantic_paths) == 18
-    public_queries = "\n".join([QUERY_SEMANTIC_PROMOTED, QUERY_SYSTEM, QUERY_SYSTEM_GATEWAY_METADATA])
+    public_queries = "\n".join(
+        [QUERY_SEMANTIC_PROMOTED, QUERY_SYSTEM, QUERY_SYSTEM_GATEWAY_METADATA]
+    )
     assert all(field in public_queries for field in semantic_paths.values())
     assert all(
         forbidden not in public_queries
@@ -1165,7 +1272,9 @@ def test_promoted_semantic_queries_cover_all_public_leaves_without_protocol_leak
     )
 
 
-def test_system_gateway_metadata_is_optional_and_preserves_existing_system_payload() -> None:
+def test_system_gateway_metadata_is_optional_and_preserves_existing_system_payload() -> (
+    None
+):
     payload = {
         "system": {
             "state": {"outdoor_temperature": 0.0},
@@ -1192,3 +1301,48 @@ def test_system_gateway_metadata_is_optional_and_preserves_existing_system_paylo
     assert result["properties"] == {"system_scheme": 0}
     assert result["metadata"] == {}
     assert client.calls[:2] == [QUERY_SYSTEM, QUERY_SYSTEM_GATEWAY_METADATA]
+
+
+def test_system_optional_query_schema_failure_preserves_base_payload_and_other_availability() -> (
+    None
+):
+    """Characterize independent optional-schema availability after a partial fetch."""
+
+    client = _ScriptedClient(
+        [
+            {
+                "system": {
+                    "state": {"outdoor_temperature": 4.5},
+                    "config": {"max_room_humidity": 60},
+                    "properties": {"system_scheme": 3},
+                }
+            },
+            {},
+            GraphQLResponseError(
+                [
+                    {
+                        "message": 'Cannot query field "installer_name" on type "SystemConfig".'
+                    }
+                ]
+            ),
+            {"system": {"config": {"installer_menu_code": "1234"}}},
+        ]
+    )
+    coordinator = _build_system_coordinator(client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result == {
+        "state": {"outdoor_temperature": 4.5},
+        "config": {"max_room_humidity": 60, "installer_menu_code": "1234"},
+        "properties": {"system_scheme": 3},
+        "metadata": {},
+    }
+    assert coordinator.system_installer_available is False
+    assert coordinator.system_sensitive_available is True
+    assert client.calls == [
+        QUERY_SYSTEM,
+        QUERY_SYSTEM_GATEWAY_METADATA,
+        QUERY_SYSTEM_INSTALLER,
+        QUERY_SYSTEM_SENSITIVE,
+    ]


### PR DESCRIPTION
Closes #245

## Scope
Mechanically extracts private device-fetch, normalization/merge, and optional-query availability phases from `coordinator.py`. Public coordinator classes, query constants, cadence, exception mapping, data shapes, and entity behavior remain unchanged.

## Validation
- `./scripts/ci_local.sh` (527 passed; parity PASS; adoption 51 passed; private IPv4 gate passed)
- `ruff check custom_components/helianthus/coordinator.py custom_components/helianthus/coordinator_fetch.py custom_components/helianthus/coordinator_merge.py custom_components/helianthus/coordinator_availability.py`

## Docs gate
N/A: private mechanical relocation with no public behavior change.

## Residual risk
The refactor is covered by existing fallback, merge, last-known-data, and optional-schema behavior tests plus one explicit partial-availability characterization.